### PR TITLE
Remove the need to always inject the parent command

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/AbstractApiCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/AbstractApiCmd.java
@@ -54,7 +54,9 @@ public abstract class AbstractApiCmd extends AbstractCmd {
         return String.format("[%s / %s]", orgName, workspaceName);
     }
 
-    public abstract Tower app();
+    private Tower app() {
+        return (Tower) getSpec().root().userObject();
+    }
 
     protected DefaultApi api() {
 

--- a/src/main/java/io/seqera/tower/cli/commands/AbstractRootCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/AbstractRootCmd.java
@@ -1,21 +1,11 @@
 package io.seqera.tower.cli.commands;
 
-import io.seqera.tower.cli.Tower;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.ParentCommand;
 
 @Command
 public abstract class AbstractRootCmd extends AbstractApiCmd {
 
-    @ParentCommand
-    protected Tower app;
-
     public AbstractRootCmd() {
-    }
-
-    @Override
-    public Tower app() {
-        return app;
     }
 
 }

--- a/src/main/java/io/seqera/tower/cli/commands/actions/AbstractActionsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/actions/AbstractActionsCmd.java
@@ -16,14 +16,6 @@ import java.util.stream.Collectors;
 @CommandLine.Command
 public abstract class AbstractActionsCmd extends AbstractApiCmd {
 
-    @CommandLine.ParentCommand
-    protected ActionsCmd parent;
-
-    @Override
-    public Tower app() {
-        return parent.app();
-    }
-
     protected ListActionsResponseActionInfo actionByName(String actionName) throws ApiException {
         ListActionsResponse listActionResponse = api().listActions(workspaceId());
 

--- a/src/main/java/io/seqera/tower/cli/commands/actions/create/AbstractCreateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/actions/create/AbstractCreateCmd.java
@@ -1,9 +1,7 @@
 package io.seqera.tower.cli.commands.actions.create;
 
 import io.seqera.tower.ApiException;
-import io.seqera.tower.cli.Tower;
 import io.seqera.tower.cli.commands.AbstractApiCmd;
-import io.seqera.tower.cli.commands.actions.CreateCmd;
 import io.seqera.tower.cli.commands.pipelines.LaunchOptions;
 import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.responses.Response;
@@ -28,14 +26,6 @@ public abstract class AbstractCreateCmd extends AbstractApiCmd {
 
     @CommandLine.Mixin
     public LaunchOptions opts;
-
-    @CommandLine.ParentCommand
-    protected CreateCmd parent;
-
-    @Override
-    public Tower app() {
-        return parent.app();
-    }
 
     @Override
     protected Response exec() throws ApiException, IOException {

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/AbstractComputeEnvCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/AbstractComputeEnvCmd.java
@@ -1,25 +1,13 @@
 package io.seqera.tower.cli.commands.computeenvs;
 
-import io.seqera.tower.cli.Tower;
 import io.seqera.tower.cli.commands.AbstractApiCmd;
-import io.seqera.tower.cli.commands.ComputeEnvsCmd;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.ParentCommand;
 
 @Command
 public abstract class AbstractComputeEnvCmd extends AbstractApiCmd {
 
-    @ParentCommand
-    protected ComputeEnvsCmd parent;
-
     public AbstractComputeEnvCmd() {
     }
-
-    @Override
-    public Tower app() {
-        return parent.app();
-    }
-
 }
 
 

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/create/AbstractCreateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/create/AbstractCreateCmd.java
@@ -1,9 +1,7 @@
 package io.seqera.tower.cli.commands.computeenvs.create;
 
 import io.seqera.tower.ApiException;
-import io.seqera.tower.cli.Tower;
 import io.seqera.tower.cli.commands.AbstractApiCmd;
-import io.seqera.tower.cli.commands.computeenvs.CreateCmd;
 import io.seqera.tower.cli.commands.computeenvs.platforms.Platform;
 import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.responses.ComputeEnvCreated;
@@ -14,7 +12,6 @@ import io.seqera.tower.model.CreateComputeEnvRequest;
 import io.seqera.tower.model.Credentials;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.ParentCommand;
 
 import java.io.IOException;
 import java.util.List;
@@ -26,13 +23,6 @@ public abstract class AbstractCreateCmd extends AbstractApiCmd {
     public String name;
     @Option(names = {"-c", "--credentials-id"}, description = "Credentials identifier (defaults to use the workspace credentials)")
     public String credentialsId;
-    @ParentCommand
-    protected CreateCmd parent;
-
-    @Override
-    public Tower app() {
-        return parent.app();
-    }
 
     @Override
     protected Response exec() throws ApiException, IOException {

--- a/src/main/java/io/seqera/tower/cli/commands/credentials/AbstractCredentialsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/credentials/AbstractCredentialsCmd.java
@@ -1,23 +1,12 @@
 package io.seqera.tower.cli.commands.credentials;
 
-import io.seqera.tower.cli.Tower;
 import io.seqera.tower.cli.commands.AbstractApiCmd;
-import io.seqera.tower.cli.commands.CredentialsCmd;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.ParentCommand;
 
 @Command
 public abstract class AbstractCredentialsCmd extends AbstractApiCmd {
 
-    @ParentCommand
-    protected CredentialsCmd parent;
-
     public AbstractCredentialsCmd() {
-    }
-
-    @Override
-    public Tower app() {
-        return parent.app();
     }
 
 }

--- a/src/main/java/io/seqera/tower/cli/commands/credentials/create/AbstractCreateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/credentials/create/AbstractCreateCmd.java
@@ -1,9 +1,7 @@
 package io.seqera.tower.cli.commands.credentials.create;
 
 import io.seqera.tower.ApiException;
-import io.seqera.tower.cli.Tower;
 import io.seqera.tower.cli.commands.AbstractApiCmd;
-import io.seqera.tower.cli.commands.credentials.CreateCmd;
 import io.seqera.tower.cli.commands.credentials.providers.CredentialsProvider;
 import io.seqera.tower.cli.responses.CredentialsCreated;
 import io.seqera.tower.cli.responses.Response;
@@ -13,7 +11,6 @@ import io.seqera.tower.model.CredentialsSpec;
 import io.seqera.tower.model.SecurityKeys;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.ParentCommand;
 
 import java.io.IOException;
 
@@ -22,13 +19,6 @@ public abstract class AbstractCreateCmd<T extends SecurityKeys> extends Abstract
 
     @Option(names = {"-n", "--name"}, description = "Credentials name", required = true)
     public String name;
-    @ParentCommand
-    protected CreateCmd parent;
-
-    @Override
-    public Tower app() {
-        return parent.app();
-    }
 
     @Override
     protected Response exec() throws ApiException, IOException {

--- a/src/main/java/io/seqera/tower/cli/commands/credentials/update/AbstractUpdateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/credentials/update/AbstractUpdateCmd.java
@@ -1,9 +1,7 @@
 package io.seqera.tower.cli.commands.credentials.update;
 
 import io.seqera.tower.ApiException;
-import io.seqera.tower.cli.Tower;
 import io.seqera.tower.cli.commands.AbstractApiCmd;
-import io.seqera.tower.cli.commands.credentials.UpdateCmd;
 import io.seqera.tower.cli.commands.credentials.providers.CredentialsProvider;
 import io.seqera.tower.cli.exceptions.CredentialsNotFoundException;
 import io.seqera.tower.cli.responses.CredentialsUpdated;
@@ -14,7 +12,6 @@ import io.seqera.tower.model.DescribeCredentialsResponse;
 import io.seqera.tower.model.UpdateCredentialsRequest;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.ParentCommand;
 
 import java.io.IOException;
 
@@ -23,15 +20,8 @@ public abstract class AbstractUpdateCmd extends AbstractApiCmd {
 
     @CommandLine.Option(names = {"-i", "--id"}, required = true)
     public String id;
-    @ParentCommand
-    protected UpdateCmd parent;
 
     public AbstractUpdateCmd() {
-    }
-
-    @Override
-    public Tower app() {
-        return parent.app();
     }
 
     @Override

--- a/src/main/java/io/seqera/tower/cli/commands/members/AbstractMembersClass.java
+++ b/src/main/java/io/seqera/tower/cli/commands/members/AbstractMembersClass.java
@@ -13,15 +13,7 @@ import picocli.CommandLine;
 @CommandLine.Command
 abstract public class AbstractMembersClass extends AbstractApiCmd {
 
-    @CommandLine.ParentCommand
-    protected MembersCmd parent;
-
     public AbstractMembersClass() {
-    }
-
-    @Override
-    public Tower app() {
-        return parent.app();
     }
 
     protected MemberDbDto findMemberByUser(Long orgId, String user) throws ApiException {

--- a/src/main/java/io/seqera/tower/cli/commands/organizations/AbstractOrganizationsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/organizations/AbstractOrganizationsCmd.java
@@ -1,9 +1,7 @@
 package io.seqera.tower.cli.commands.organizations;
 
 import io.seqera.tower.ApiException;
-import io.seqera.tower.cli.Tower;
 import io.seqera.tower.cli.commands.AbstractApiCmd;
-import io.seqera.tower.cli.commands.OrganizationsCmd;
 import io.seqera.tower.cli.exceptions.OrganizationNotFoundException;
 import io.seqera.tower.cli.exceptions.UserOrganizationsNotFoundException;
 import io.seqera.tower.model.ListWorkspacesAndOrgResponse;
@@ -16,15 +14,8 @@ import java.util.stream.Collectors;
 
 @CommandLine.Command
 public class AbstractOrganizationsCmd extends AbstractApiCmd {
-    @CommandLine.ParentCommand
-    protected OrganizationsCmd parent;
 
     public AbstractOrganizationsCmd() {
-    }
-
-    @Override
-    public Tower app() {
-        return parent.app();
     }
 
     protected List<OrgAndWorkspaceDbDto> organizationsByUser() throws ApiException {

--- a/src/main/java/io/seqera/tower/cli/commands/participants/AbstractParticipantsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/participants/AbstractParticipantsCmd.java
@@ -1,9 +1,7 @@
 package io.seqera.tower.cli.commands.participants;
 
 import io.seqera.tower.ApiException;
-import io.seqera.tower.cli.Tower;
 import io.seqera.tower.cli.commands.AbstractApiCmd;
-import io.seqera.tower.cli.commands.ParticipantsCmd;
 import io.seqera.tower.cli.exceptions.MemberNotFoundException;
 import io.seqera.tower.cli.exceptions.OrganizationNotFoundException;
 import io.seqera.tower.cli.exceptions.ParticipantNotFoundException;
@@ -27,15 +25,7 @@ import java.util.stream.Collectors;
 @CommandLine.Command
 public class AbstractParticipantsCmd extends AbstractApiCmd {
 
-    @CommandLine.ParentCommand
-    protected ParticipantsCmd parent;
-
     public AbstractParticipantsCmd() {
-    }
-
-    @Override
-    public Tower app() {
-        return parent.app();
     }
 
     protected OrgAndWorkspaceDbDto findOrgAndWorkspaceByName(String organizationName, String workspaceName) throws ApiException {

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/AbstractPipelinesCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/AbstractPipelinesCmd.java
@@ -1,28 +1,17 @@
 package io.seqera.tower.cli.commands.pipelines;
 
 import io.seqera.tower.ApiException;
-import io.seqera.tower.cli.Tower;
 import io.seqera.tower.cli.commands.AbstractApiCmd;
-import io.seqera.tower.cli.commands.PipelinesCmd;
 import io.seqera.tower.cli.exceptions.MultiplePipelinesFoundException;
 import io.seqera.tower.cli.exceptions.PipelineNotFoundException;
 import io.seqera.tower.model.ListPipelinesResponse;
 import io.seqera.tower.model.PipelineDbDto;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.ParentCommand;
 
 @Command
 public abstract class AbstractPipelinesCmd extends AbstractApiCmd {
 
-    @ParentCommand
-    protected PipelinesCmd parent;
-
     public AbstractPipelinesCmd() {
-    }
-
-    @Override
-    public Tower app() {
-        return parent.app();
     }
 
     protected PipelineDbDto pipelineByName(String name) throws ApiException {

--- a/src/main/java/io/seqera/tower/cli/commands/runs/AbstractRunsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/AbstractRunsCmd.java
@@ -1,9 +1,7 @@
 package io.seqera.tower.cli.commands.runs;
 
 import io.seqera.tower.ApiException;
-import io.seqera.tower.cli.Tower;
 import io.seqera.tower.cli.commands.AbstractApiCmd;
-import io.seqera.tower.cli.commands.RunsCmd;
 import io.seqera.tower.cli.exceptions.LaunchNotFoundException;
 import io.seqera.tower.cli.exceptions.RunNotFoundException;
 import io.seqera.tower.cli.exceptions.WorkflowProgressNotFoundException;
@@ -14,20 +12,11 @@ import io.seqera.tower.model.Launch;
 import io.seqera.tower.model.Workflow;
 import io.seqera.tower.model.WorkflowLoad;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.ParentCommand;
 
 @Command
 abstract public class AbstractRunsCmd extends AbstractApiCmd {
 
-    @ParentCommand
-    protected RunsCmd parent;
-
     public AbstractRunsCmd() {
-    }
-
-    @Override
-    public Tower app() {
-        return parent.app();
     }
 
     protected Workflow workflowById(String id) throws ApiException {

--- a/src/main/java/io/seqera/tower/cli/commands/teams/AbstractTeamsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/teams/AbstractTeamsCmd.java
@@ -1,9 +1,7 @@
 package io.seqera.tower.cli.commands.teams;
 
 import io.seqera.tower.ApiException;
-import io.seqera.tower.cli.Tower;
 import io.seqera.tower.cli.commands.AbstractApiCmd;
-import io.seqera.tower.cli.commands.TeamsCmd;
 import io.seqera.tower.cli.exceptions.MemberNotFoundException;
 import io.seqera.tower.cli.exceptions.OrganizationNotFoundException;
 import io.seqera.tower.cli.exceptions.TeamNotFoundException;
@@ -14,7 +12,6 @@ import io.seqera.tower.model.MemberDbDto;
 import io.seqera.tower.model.OrgAndWorkspaceDbDto;
 import io.seqera.tower.model.TeamDbDto;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.ParentCommand;
 
 import java.util.List;
 import java.util.Objects;
@@ -23,15 +20,7 @@ import java.util.stream.Collectors;
 @Command
 public abstract class AbstractTeamsCmd extends AbstractApiCmd {
 
-    @ParentCommand
-    protected TeamsCmd parent;
-
     public AbstractTeamsCmd() {
-    }
-
-    @Override
-    public Tower app() {
-        return parent.app();
     }
 
     public OrgAndWorkspaceDbDto findOrganizationByName(String organizationName) throws ApiException {

--- a/src/main/java/io/seqera/tower/cli/commands/teams/members/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/teams/members/AddCmd.java
@@ -1,7 +1,6 @@
 package io.seqera.tower.cli.commands.teams.members;
 
 import io.seqera.tower.ApiException;
-import io.seqera.tower.cli.Tower;
 import io.seqera.tower.cli.commands.AbstractApiCmd;
 import io.seqera.tower.cli.commands.teams.MembersCmd;
 import io.seqera.tower.cli.responses.Response;
@@ -25,10 +24,6 @@ public class AddCmd extends AbstractApiCmd {
 
     @CommandLine.ParentCommand
     public MembersCmd parent;
-
-    public Tower app() {
-        return parent.app();
-    }
 
     @Override
     protected Response exec() throws ApiException, IOException {

--- a/src/main/java/io/seqera/tower/cli/commands/teams/members/DeleteCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/teams/members/DeleteCmd.java
@@ -1,7 +1,6 @@
 package io.seqera.tower.cli.commands.teams.members;
 
 import io.seqera.tower.ApiException;
-import io.seqera.tower.cli.Tower;
 import io.seqera.tower.cli.commands.AbstractApiCmd;
 import io.seqera.tower.cli.commands.teams.MembersCmd;
 import io.seqera.tower.cli.responses.Response;
@@ -24,10 +23,6 @@ public class DeleteCmd extends AbstractApiCmd {
 
     @CommandLine.ParentCommand
     public MembersCmd parent;
-
-    public Tower app() {
-        return parent.app();
-    }
 
     @Override
     protected Response exec() throws ApiException, IOException {

--- a/src/main/java/io/seqera/tower/cli/commands/workspaces/AbstractWorkspaceCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/workspaces/AbstractWorkspaceCmd.java
@@ -1,15 +1,12 @@
 package io.seqera.tower.cli.commands.workspaces;
 
 import io.seqera.tower.ApiException;
-import io.seqera.tower.cli.Tower;
 import io.seqera.tower.cli.commands.AbstractApiCmd;
-import io.seqera.tower.cli.commands.WorkspacesCmd;
 import io.seqera.tower.cli.exceptions.OrganizationNotFoundException;
 import io.seqera.tower.cli.exceptions.WorkspaceNotFoundException;
 import io.seqera.tower.model.ListWorkspacesAndOrgResponse;
 import io.seqera.tower.model.OrgAndWorkspaceDbDto;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.ParentCommand;
 
 import java.util.List;
 import java.util.Objects;
@@ -19,17 +16,9 @@ import java.util.stream.Collectors;
 @Command
 public abstract class AbstractWorkspaceCmd extends AbstractApiCmd {
 
-    @ParentCommand
-    protected WorkspacesCmd parent;
-
     public AbstractWorkspaceCmd() {
     }
-
-    @Override
-    public Tower app() {
-        return parent.app();
-    }
-
+    
     protected OrgAndWorkspaceDbDto orgAndWorkspaceByName(String workspaceName, String organizationName) throws ApiException {
         return findOrgAndWorkspaceByName(organizationName, workspaceName).orElse(null);
     }


### PR DESCRIPTION
## Description

Current implementation all the command must inject the parent command just to implement the `Tower app()`. This can be directly get from the command specs, so we don't need to force all the class hierarchy to implement it.