### PR TITLE
Unify help message format across commands

### DIFF
--- a/src/main/java/io/seqera/tower/cli/Tower.java
+++ b/src/main/java/io/seqera/tower/cli/Tower.java
@@ -74,7 +74,7 @@ public class Tower extends AbstractCmd {
     @Option(names = {"-o", "--output"}, description = "Show output in defined format (only the 'json' option is available at the moment)")
     public OutputType output;
 
-    @Option(names = {"-v", "--verbose"}, description = "Shows HTTP request/response logs at stderr")
+    @Option(names = {"-v", "--verbose"}, description = "Show HTTP request/response logs at stderr")
     public boolean verbose;
 
     public Tower() {

--- a/src/main/java/io/seqera/tower/cli/Tower.java
+++ b/src/main/java/io/seqera/tower/cli/Tower.java
@@ -68,7 +68,7 @@ public class Tower extends AbstractCmd {
     @Option(names = {"-t", "--access-token"}, description = "Tower personal access token (TOWER_ACCESS_TOKEN)", defaultValue = "${TOWER_ACCESS_TOKEN}", required = true)
     public String token;
 
-    @Option(names = {"-u", "--url"}, description = "Tower server API endpoint URL. Defaults to tower.nf (TOWER_API_ENDPOINT)", defaultValue = "${TOWER_API_ENDPOINT:-https://api.tower.nf}", required = true)
+    @Option(names = {"-u", "--url"}, description = "Tower server API endpoint URL (TOWER_API_ENDPOINT) [default: 'tower.nf']", defaultValue = "${TOWER_API_ENDPOINT:-https://api.tower.nf}", required = true)
     public String url;
 
     @Option(names = {"-o", "--output"}, description = "Show output in defined format (only the 'json' option is available at the moment)")

--- a/src/main/java/io/seqera/tower/cli/commands/CollaboratorsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/CollaboratorsCmd.java
@@ -16,7 +16,7 @@ import picocli.CommandLine;
 
 @CommandLine.Command(
         name = "collaborators",
-        description = "Manage organization's collaborators",
+        description = "Manage organization collaborators",
         subcommands = {
                 ListCmd.class,
         }

--- a/src/main/java/io/seqera/tower/cli/commands/HealthCheckCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/HealthCheckCmd.java
@@ -25,7 +25,7 @@ import java.util.Properties;
 
 @CommandLine.Command(
         name = "health",
-        description = "Checks system health status"
+        description = "Check system health status"
 )
 public class HealthCheckCmd extends AbstractRootCmd {
     @Override

--- a/src/main/java/io/seqera/tower/cli/commands/LaunchesCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/LaunchesCmd.java
@@ -51,7 +51,7 @@ public class LaunchesCmd extends AbstractRootCmd {
     @Option(names = {"--params"}, description = "Parameters file")
     Path params;
 
-    @Option(names = {"-c", "--compute-env"}, description = "Compute environment name (defaults to workspace primary)")
+    @Option(names = {"-c", "--compute-env"}, description = "Compute environment name [default: primary workspace]")
     String computeEnv;
 
     @Option(names = {"--work-dir"}, description = "Working directory")

--- a/src/main/java/io/seqera/tower/cli/commands/LaunchesCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/LaunchesCmd.java
@@ -38,7 +38,7 @@ import static io.seqera.tower.cli.utils.ModelHelper.createLaunchRequest;
 
 @Command(
         name = "launch",
-        description = "Run a Nextflow pipeline"
+        description = "Launch a Nextflow pipeline"
 )
 public class LaunchesCmd extends AbstractRootCmd {
 

--- a/src/main/java/io/seqera/tower/cli/commands/LaunchesCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/LaunchesCmd.java
@@ -152,7 +152,7 @@ public class LaunchesCmd extends AbstractRootCmd {
 
     public static class AdvancedOptions {
 
-        @Option(names = {"--config"}, description = "Additional Nextflow config settings can be provided in the above field. These settings will be included in the nextflow.config file for this execution")
+        @Option(names = {"--config"}, description = "Additional Nextflow config settings can be provided in the above field. These settings will be included in the `nextflow.config` file for this execution")
         public Path config;
 
         @Option(names = {"--pre-run"}, description = "Pre-run script")
@@ -161,7 +161,7 @@ public class LaunchesCmd extends AbstractRootCmd {
         @Option(names = {"--post-run"}, description = "Post-run script")
         public Path postRunScript;
 
-        @Option(names = {"--pull-latest"}, description = "Enabling this option Nextflow pulls the latest version from the Git repository before run the pipeline")
+        @Option(names = {"--pull-latest"}, description = "Enable Nextflow to pull the latest repository version before running the pipeline")
         public Boolean pullLatest;
 
         @Option(names = {"--stub-run"}, description = "Execute the workflow replacing process scripts with command stubs")

--- a/src/main/java/io/seqera/tower/cli/commands/MembersCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/MembersCmd.java
@@ -20,7 +20,7 @@ import picocli.CommandLine;
 
 @CommandLine.Command(
         name = "members",
-        description = "Manage organization's members",
+        description = "Manage organization members",
         subcommands = {
                 ListCmd.class,
                 CreateCmd.class,

--- a/src/main/java/io/seqera/tower/cli/commands/PipelinesCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/PipelinesCmd.java
@@ -23,7 +23,7 @@ import picocli.CommandLine.Command;
 
 @Command(
         name = "pipelines",
-        description = "Manage workspace pipelines launchpad",
+        description = "Manage workspace pipeline launchpad",
         subcommands = {
                 ListCmd.class,
                 CreateCmd.class,

--- a/src/main/java/io/seqera/tower/cli/commands/RunsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/RunsCmd.java
@@ -20,7 +20,7 @@ import picocli.CommandLine;
 
 @CommandLine.Command(
         name = "runs",
-        description = "Manage workspace pipeline's runs",
+        description = "Manage workspace pipeline runs",
         subcommands = {
                 ViewCmd.class,
                 ListCmd.class,

--- a/src/main/java/io/seqera/tower/cli/commands/TeamsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/TeamsCmd.java
@@ -20,7 +20,7 @@ import picocli.CommandLine;
 
 @CommandLine.Command(
         name = "teams",
-        description = "Manage organization's teams",
+        description = "Manage organization teams",
         subcommands = {
                 ListCmd.class,
                 CreateCmd.class,

--- a/src/main/java/io/seqera/tower/cli/commands/collaborators/ListCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/collaborators/ListCmd.java
@@ -26,10 +26,10 @@ import picocli.CommandLine;
 )
 public class ListCmd extends AbstractCollaboratorsCmd {
 
-    @CommandLine.Option(names = {"-o", "--organization"}, description = "Organization's identifier", required = true)
+    @CommandLine.Option(names = {"-o", "--organization"}, description = "Organization identifier", required = true)
     public Long organizationId;
 
-    @CommandLine.Option(names = {"-f", "--filter"}, description = "Show only members with usernames that starts with the given word")
+    @CommandLine.Option(names = {"-f", "--filter"}, description = "Only show members with usernames that start with the given word")
     public String startsWith;
 
     @CommandLine.Mixin

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/create/AbstractCreateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/create/AbstractCreateCmd.java
@@ -38,7 +38,7 @@ public abstract class AbstractCreateCmd extends AbstractApiCmd {
     @CommandLine.Mixin
     public WorkspaceOptions workspace;
 
-    @Option(names = {"-i", "--id"}, description = "Credentials identifier (defaults to use the workspace credentials)")
+    @Option(names = {"-i", "--id"}, description = "Credentials identifier [default: workspace credentials]")
     public String credentialsId;
 
     @Override

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AltairPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AltairPlatform.java
@@ -36,7 +36,7 @@ public class AltairPlatform extends AbstractPlatform<AltairPbsComputeConfig> {
     @Option(names = {"--compute-queue"}, description = "The name of queue on the cluster to which pipeline jobs are submitted. This queue can be overridden by the pipeline configuration.")
     public String computeQueue;
 
-    @Option(names = {"--launch-dir"}, description = "The directory where Nextflow runs. It must be an absolute directory and the user should have read-write access permissions to it. If omitted defaults to the pipeline work directory")
+    @Option(names = {"--launch-dir"}, description = "The directory where Nextflow runs. It must be an absolute directory and the user should have read-write access permissions to it [default: pipeline work directory]")
     public String launchDir;
 
     @ArgGroup(heading = "%nAdvanced options:%n", validate = false)
@@ -79,7 +79,7 @@ public class AltairPlatform extends AbstractPlatform<AltairPbsComputeConfig> {
     }
 
     public static class AdvancedOptions {
-        @Option(names = {"--max-queue-size"}, description = "This option limits the number of jobs Nextflow can submit to the Slurm queue at the same time (default: 100)")
+        @Option(names = {"--max-queue-size"}, description = "This option limits the number of jobs Nextflow can submit to the Slurm queue at the same time [default: 100]")
         public Integer maxQueueSize;
 
         @Option(names = {"--head-job-options"}, description = "Slurm submit options for the Nextflow head job. These options are added to the 'sbatch' command run by Tower to launch the pipeline execution.")

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AwsBatchForgePlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AwsBatchForgePlatform.java
@@ -141,10 +141,10 @@ public class AwsBatchForgePlatform extends AbstractPlatform<AwsBatchConfig> {
         @Option(names = {"--create-efs"}, description = "A OneZone EFS without backup will be created. EC2 instances can run on a different zone and inter-region transfer fees will be billed. If you want to remove transfer costs, restrict to only one subnet at advanced options")
         public boolean createEfs;
 
-        @Option(names = {"--efs-id"}, description = "Enter the EFS file system id (ex: fs-0123456789)")
+        @Option(names = {"--efs-id"}, description = "Enter the EFS file system id e.g. fs-0123456789")
         public String efsId;
 
-        @Option(names = {"--efs-mount"}, description = "Enter the EFS mount path (defaults to the pipeline work directory root path if omitted)")
+        @Option(names = {"--efs-mount"}, description = "Enter the EFS mount path [default: pipeline work directory]")
         public String efsMount;
 
     }
@@ -154,10 +154,10 @@ public class AwsBatchForgePlatform extends AbstractPlatform<AwsBatchConfig> {
         @Option(names = {"--fsx-size"}, description = "Enter the FSx storage capacity in GB (minimum 1,200 GB or increments of 2,400 GB)")
         public Integer fsxSize;
 
-        @Option(names = {"--fsx-dns"}, description = "Enter the FSx file system DNS name (ex: fs-0123456789.fsx.eu-west-1.amazonaws.com)")
+        @Option(names = {"--fsx-dns"}, description = "Enter the FSx file system DNS name e.g. 'fs-0123456789.fsx.eu-west-1.amazonaws.com'")
         public String fsxDns;
 
-        @Option(names = {"--fsx-mount"}, description = "Enter the FSx mount path (defaults to the pipeline work directory root path if omitted)")
+        @Option(names = {"--fsx-mount"}, description = "Enter the FSx mount path [default: pipeline work directory]")
         public String fsxMount;
 
     }
@@ -178,7 +178,7 @@ public class AwsBatchForgePlatform extends AbstractPlatform<AwsBatchConfig> {
         @Option(names = {"--security-groups"}, split = ",", paramLabel = "<group>", description = "One or more security groups (separated by comma) that defines a set of firewall rules to control the traffic for your EC2 compute nodes.")
         public List<String> securityGroups;
 
-        @Option(names = {"--ami-id"}, description = "Ths option allows you to use your own AMI. Note however it must be an AWS Linux-2 ECS-optimised image and meet the compute resource AMI specification. By default Tower uses the latest approved version of the Amazon ECS-optimized AMI for compute resources.")
+        @Option(names = {"--ami-id"}, description = "Ths option allows you to use your own AMI. Note however it must be an AWS Linux-2 ECS-optimised image and meet the compute resource AMI specification [default: latest approved version of the Amazon ECS-optimized AMI]")
         public String amiId;
 
         @Option(names = {"--key-pair"}, description = "The EC2 key pair to be installed in the compute nodes to access via SSH.")
@@ -199,10 +199,10 @@ public class AwsBatchForgePlatform extends AbstractPlatform<AwsBatchConfig> {
         @Option(names = {"--compute-job-role"}, description = "IAM role to fine-grained control permissions for jobs submitted by Nextflow")
         public String computeJobRole;
 
-        @Option(names = {"--ebs-blocksize"}, description = "This field controls the initial size of the EBS auto-expandable volume (default: 50 GB). New blocks of the same size are added as necessary when the volume is running out of free space.")
+        @Option(names = {"--ebs-blocksize"}, description = "This field controls the initial size of the EBS auto-expandable volume. New blocks of the same size are added as necessary when the volume is running out of free space [default: 50 GB]")
         public Integer ebsBlockSize;
 
-        @Option(names = {"--bid-percentage"}, description = "The maximum percentage that a Spot Instance price can be when compared with the On-Demand price for that instance type before instances are launched. For example, if your maximum percentage is 20%%, then the Spot price must be less than 20%% of the current On-Demand price for that Amazon EC2 instance. You always pay the lowest (market) price and never more than your maximum percentage. If you leave this field empty, the default value is 100%% of the On-Demand price.")
+        @Option(names = {"--bid-percentage"}, description = "The maximum percentage that a Spot Instance price can be when compared with the On-Demand price for that instance type before instances are launched. For example, if your maximum percentage is 20%%, then the Spot price must be less than 20%% of the current On-Demand price for that Amazon EC2 instance. You always pay the lowest (market) price and never more than your maximum percentage [default: 100%% of the On-Demand price]")
         public Integer bidPercentage;
 
         @Option(names = {"--cli-path"}, description = "Nextflow requires the AWS CLI installed in the Ec2 instances. Use this field to specify the path")

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AwsBatchForgePlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AwsBatchForgePlatform.java
@@ -43,7 +43,7 @@ public class AwsBatchForgePlatform extends AbstractPlatform<AwsBatchConfig> {
     @Option(names = {"--gpu"}, description = "Deploys GPU enabled Ec2 instances")
     public boolean gpu;
 
-    @Option(names = {"--allow-buckets"}, split = ",", paramLabel = "<bucket>", description = "List separated by comma any S3 bucket or path, other than pipeline work directory, to which it should be granted read-write permission from this environment.")
+    @Option(names = {"--allow-buckets"}, split = ",", paramLabel = "<bucket>", description = "Comma-separated list of S3 buckets or paths other than pipeline work directory that should be granted read-write permission from this environment")
     public List<String> allowBuckets;
 
     @Option(names = "--preserve-resources", description = "Enable this if you want to preserve the Batch compute resources created by Tower independently from the lifecycle of this compute environment")
@@ -172,10 +172,10 @@ public class AwsBatchForgePlatform extends AbstractPlatform<AwsBatchConfig> {
         @Option(names = {"--vpc-id"}, description = "VPC identifier")
         public String vpcId;
 
-        @Option(names = {"--subnets"}, split = ",", paramLabel = "<subnet>", description = "One or more subnets (separated by comma) in your VPC that can be used to isolate the EC2 resources from each other or from the Internet.")
+        @Option(names = {"--subnets"}, split = ",", paramLabel = "<subnet>", description = "Comma-separated list of one or more subnets in your VPC that can be used to isolate the EC2 resources from each other or from the Internet.")
         public List<String> subnets;
 
-        @Option(names = {"--security-groups"}, split = ",", paramLabel = "<group>", description = "One or more security groups (separated by comma) that defines a set of firewall rules to control the traffic for your EC2 compute nodes.")
+        @Option(names = {"--security-groups"}, split = ",", paramLabel = "<group>", description = "Comma-separated list of one or more security groups that defines a set of firewall rules to control the traffic for your EC2 compute nodes.")
         public List<String> securityGroups;
 
         @Option(names = {"--ami-id"}, description = "Ths option allows you to use your own AMI. Note however it must be an AWS Linux-2 ECS-optimised image and meet the compute resource AMI specification [default: latest approved version of the Amazon ECS-optimized AMI]")

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchForgePlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchForgePlatform.java
@@ -26,7 +26,7 @@ public class AzBatchForgePlatform extends AbstractPlatform<AzBatchConfig> {
     @Option(names = {"-l", "--location"}, description = "The Azure location where the workload will be deployed", required = true)
     public String location;
 
-    @Option(names = {"--vm-type"}, description = "Specify the virtual machine type used by this pool. It must be a valid Azure Batch VM type (default: Standard_D4_v3)")
+    @Option(names = {"--vm-type"}, description = "Specify the virtual machine type used by this pool. It must be a valid Azure Batch VM type [default: Standard_D4_v3]")
     public String vmType;
 
     @Option(names = {"--vm-count"}, description = "The number of virtual machines in this pool. When autoscaling feature is enabled, this option represents the maximum number of virtual machines to which the pool can grow and automatically scales to zero when unused")
@@ -79,7 +79,7 @@ public class AzBatchForgePlatform extends AbstractPlatform<AzBatchConfig> {
         @Option(names = {"--jobs-cleanup"}, description = "Enable the automatic deletion of Batch jobs created by the pipeline execution (ON_SUCESS, ALWAYS, NEVER)")
         public JobCleanupPolicy jobsCleanup;
 
-        @Option(names = {"--token-duration"}, description = "The duration of the shared access signature token created by Nextflow when the 'sasToken' option is not specified (default: 12h)")
+        @Option(names = {"--token-duration"}, description = "The duration of the shared access signature token created by Nextflow when the 'sasToken' option is not specified [default: 12h]")
         public String tokenDuration;
 
     }

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchManualPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchManualPlatform.java
@@ -61,7 +61,7 @@ public class AzBatchManualPlatform extends AbstractPlatform<AzBatchConfig> {
         @Option(names = {"--jobs-cleanup"}, description = "Enable the automatic deletion of Batch jobs created by the pipeline execution (ON_SUCESS, ALWAYS, NEVER)")
         public JobCleanupPolicy jobsCleanup;
 
-        @Option(names = {"--token-duration"}, description = "The duration of the shared access signature token created by Nextflow when the 'sasToken' option is not specified (default: 12h)")
+        @Option(names = {"--token-duration"}, description = "The duration of the shared access signature token created by Nextflow when the 'sasToken' option is not specified [default: 12h]")
         public String tokenDuration;
 
     }

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/GoogleLifeSciencesPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/GoogleLifeSciencesPlatform.java
@@ -28,7 +28,7 @@ public class GoogleLifeSciencesPlatform extends AbstractPlatform<GoogleLifeScien
     @Option(names = {"--zones"}, split = ",", description = "One or more zones where the workload will be executed. If specified, it has priority over the region setting.")
     public List<String> zones;
 
-    @Option(names = {"--location"}, description = "The location where the job executions are deployed to Cloud Life Sciences API (default: the same as the region or the zones specified)")
+    @Option(names = {"--location"}, description = "The location where the job executions are deployed to Cloud Life Sciences API [default: same as the specified region/zone]")
     public String location;
 
     @Option(names = {"--preemptible"}, description = "Use preemptible virtual machines")
@@ -83,7 +83,7 @@ public class GoogleLifeSciencesPlatform extends AbstractPlatform<GoogleLifeScien
         @Option(names = {"--nfs-target"}, description = "The Filestore instance IP address and share file name e.g. 1.2.3.4:/my_share_name")
         public String nfsTarget;
 
-        @Option(names = {"--nfs-mount"}, description = "Specify the NFS mount path. It should be the same as the pipeline work directory or a parent path of it (defaults to the pipeline work directory root path if omitted).")
+        @Option(names = {"--nfs-mount"}, description = "Specify the NFS mount path. It should be the same as the pipeline work directory or a parent path of it [default: pipeline work directory]")
         public String nfsMount;
 
     }

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/LsfPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/LsfPlatform.java
@@ -36,7 +36,7 @@ public class LsfPlatform extends AbstractPlatform<LsfComputeConfig> {
     @Option(names = {"--compute-queue"}, description = "The name of queue on the cluster to which pipeline jobs are submitted. This queue can be overridden by the pipeline configuration.")
     public String computeQueue;
 
-    @Option(names = {"--launch-dir"}, description = "The directory where Nextflow runs. It must be an absolute directory and the user should have read-write access permissions to it. If omitted defaults to the pipeline work directory")
+    @Option(names = {"--launch-dir"}, description = "The directory where Nextflow runs. It must be an absolute directory and the user should have read-write access permissions to it [default: pipeline work directory]")
     public String launchDir;
 
     @ArgGroup(heading = "%nAdvanced options:%n", validate = false)
@@ -84,7 +84,7 @@ public class LsfPlatform extends AbstractPlatform<LsfComputeConfig> {
     }
 
     public static class AdvancedOptions {
-        @Option(names = {"--max-queue-size"}, description = "This option limits the number of jobs Nextflow can submit to the Slurm queue at the same time (default: 100)")
+        @Option(names = {"--max-queue-size"}, description = "This option limits the number of jobs Nextflow can submit to the Slurm queue at the same time [default: 100]")
         public Integer maxQueueSize;
 
         @Option(names = {"--head-job-options"}, description = "Slurm submit options for the Nextflow head job. These options are added to the 'sbatch' command run by Tower to launch the pipeline execution.")

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/SlurmPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/SlurmPlatform.java
@@ -36,7 +36,7 @@ public class SlurmPlatform extends AbstractPlatform<SlurmComputeConfig> {
     @Option(names = {"--compute-queue"}, description = "The name of queue on the cluster to which pipeline jobs are submitted. This queue can be overridden by the pipeline configuration.")
     public String computeQueue;
 
-    @Option(names = {"--launch-dir"}, description = "The directory where Nextflow runs. It must be an absolute directory and the user should have read-write access permissions to it. If omitted defaults to the pipeline work directory")
+    @Option(names = {"--launch-dir"}, description = "The directory where Nextflow runs. It must be an absolute directory and the user should have read-write access permissions to it [default: pipeline work directory]")
     public String launchDir;
 
     @ArgGroup(heading = "%nAdvanced options:%n", validate = false)
@@ -79,7 +79,7 @@ public class SlurmPlatform extends AbstractPlatform<SlurmComputeConfig> {
     }
 
     public static class AdvancedOptions {
-        @Option(names = {"--max-queue-size"}, description = "This option limits the number of jobs Nextflow can submit to the Slurm queue at the same time (default: 100)")
+        @Option(names = {"--max-queue-size"}, description = "This option limits the number of jobs Nextflow can submit to the Slurm queue at the same time [default: 100]")
         public Integer maxQueueSize;
 
         @Option(names = {"--head-job-options"}, description = "Slurm submit options for the Nextflow head job. These options are added to the 'sbatch' command run by Tower to launch the pipeline execution.")

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/UnivaPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/UnivaPlatform.java
@@ -36,7 +36,7 @@ public class UnivaPlatform extends AbstractPlatform<UnivaComputeConfig> {
     @Option(names = {"--compute-queue"}, description = "The name of queue on the cluster to which pipeline jobs are submitted. This queue can be overridden by the pipeline configuration.")
     public String computeQueue;
 
-    @Option(names = {"--launch-dir"}, description = "The directory where Nextflow runs. It must be an absolute directory and the user should have read-write access permissions to it. If omitted defaults to the pipeline work directory")
+    @Option(names = {"--launch-dir"}, description = "The directory where Nextflow runs. It must be an absolute directory and the user should have read-write access permissions to it [default: pipeline work directory]")
     public String launchDir;
 
     @ArgGroup(heading = "%nAdvanced options:%n", validate = false)
@@ -79,7 +79,7 @@ public class UnivaPlatform extends AbstractPlatform<UnivaComputeConfig> {
     }
 
     public static class AdvancedOptions {
-        @Option(names = {"--max-queue-size"}, description = "This option limits the number of jobs Nextflow can submit to the Slurm queue at the same time (default: 100)")
+        @Option(names = {"--max-queue-size"}, description = "This option limits the number of jobs Nextflow can submit to the Slurm queue at the same time [default: 100]")
         public Integer maxQueueSize;
 
         @Option(names = {"--head-job-options"}, description = "Slurm submit options for the Nextflow head job. These options are added to the 'sbatch' command run by Tower to launch the pipeline execution.")

--- a/src/main/java/io/seqera/tower/cli/commands/global/PaginationOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/global/PaginationOptions.java
@@ -27,10 +27,10 @@ public class PaginationOptions {
     public Sizeable sizeable;
 
     public static class Pageable {
-        @CommandLine.Option(names = {"--page"}, description = "Page to display to display [default: 1]")
+        @CommandLine.Option(names = {"--page"}, description = "Pages to display [default: 1]")
         public Integer page;
 
-        @CommandLine.Option(names = {"--offset"}, description = "Rows record's offset [default: 0]")
+        @CommandLine.Option(names = {"--offset"}, description = "Rows record offset [default: 0]")
         public Integer offset;
     }
 

--- a/src/main/java/io/seqera/tower/cli/commands/global/PaginationOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/global/PaginationOptions.java
@@ -27,15 +27,15 @@ public class PaginationOptions {
     public Sizeable sizeable;
 
     public static class Pageable {
-        @CommandLine.Option(names = {"--page"}, description = "Page to display to display (default is 1)")
+        @CommandLine.Option(names = {"--page"}, description = "Page to display to display [default: 1]")
         public Integer page;
 
-        @CommandLine.Option(names = {"--offset"}, description = "Rows record's offset (default is 0)")
+        @CommandLine.Option(names = {"--offset"}, description = "Rows record's offset [default: 0]")
         public Integer offset;
     }
 
     public static class Sizeable {
-        @CommandLine.Option(names = {"--max"}, description = "Maximum number of records to display (default is " + MAX + ")")
+        @CommandLine.Option(names = {"--max"}, description = "Maximum number of records to display [default: " + MAX + "]")
         public Integer max;
 
         @CommandLine.Option(names = {"--no-max"}, description = "Show all records")

--- a/src/main/java/io/seqera/tower/cli/commands/members/CreateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/members/CreateCmd.java
@@ -27,10 +27,10 @@ import picocli.CommandLine;
 )
 public class CreateCmd extends AbstractMembersClass {
 
-    @CommandLine.Option(names = {"-u", "--user"}, description = "User email to add as organization's member", required = true)
+    @CommandLine.Option(names = {"-u", "--user"}, description = "User email to add as organization member", required = true)
     public String user;
 
-    @CommandLine.Option(names = {"-o", "--organization"}, description = "Organization's name identifier", required = true)
+    @CommandLine.Option(names = {"-o", "--organization"}, description = "Organization name identifier", required = true)
     public String organizationName;
 
     @Override

--- a/src/main/java/io/seqera/tower/cli/commands/members/DeleteCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/members/DeleteCmd.java
@@ -26,10 +26,10 @@ import picocli.CommandLine;
 )
 public class DeleteCmd extends AbstractMembersClass{
 
-    @CommandLine.Option(names = {"-u", "--user"}, description = "Username or email of user to delete from organization's members", required = true)
+    @CommandLine.Option(names = {"-u", "--user"}, description = "Username or email to delete from organization members", required = true)
     public String user;
 
-    @CommandLine.Option(names = {"-o", "--organization"}, description = "Organization's name identifier", required = true)
+    @CommandLine.Option(names = {"-o", "--organization"}, description = "Organization name identifier", required = true)
     public String organizationName;
 
     @Override

--- a/src/main/java/io/seqera/tower/cli/commands/members/LeaveCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/members/LeaveCmd.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 )
 public class LeaveCmd extends AbstractMembersClass {
 
-    @CommandLine.Option(names = {"-o", "--organization"}, description = "Organization's name identifier", required = true)
+    @CommandLine.Option(names = {"-o", "--organization"}, description = "Organization name identifier", required = true)
     public String organizationName;
 
     @Override

--- a/src/main/java/io/seqera/tower/cli/commands/members/ListCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/members/ListCmd.java
@@ -23,14 +23,14 @@ import picocli.CommandLine;
 
 @CommandLine.Command(
         name = "list",
-        description = "List all the teams of a given organization"
+        description = "List all the teams in a given organization"
 )
 public class ListCmd extends AbstractMembersClass {
 
-    @CommandLine.Option(names = {"-o", "--organization"}, description = "Organization's name identifier", required = true)
+    @CommandLine.Option(names = {"-o", "--organization"}, description = "Organization name identifier", required = true)
     public String organizationName;
 
-    @CommandLine.Option(names = {"-f", "--filter"}, description = "Show only members with usernames that starts with the given word")
+    @CommandLine.Option(names = {"-f", "--filter"}, description = "Only show members with usernames that start with the given word")
     public String startsWith;
 
     @CommandLine.Mixin

--- a/src/main/java/io/seqera/tower/cli/commands/members/UpdateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/members/UpdateCmd.java
@@ -28,13 +28,13 @@ import picocli.CommandLine;
 )
 public class UpdateCmd extends AbstractMembersClass {
 
-    @CommandLine.Option(names = {"-u", "--user"}, description = "Username or email of user to update from organization's members", required = true)
+    @CommandLine.Option(names = {"-u", "--user"}, description = "Username or email to update from organization members", required = true)
     public String user;
 
-    @CommandLine.Option(names = {"-r", "--role"}, description = "Member's organization role (OWNER, MEMBER or COLLABORATOR)", required = true)
+    @CommandLine.Option(names = {"-r", "--role"}, description = "Member organization role (OWNER, MEMBER or COLLABORATOR)", required = true)
     public OrgRole role;
 
-    @CommandLine.Option(names = {"-o", "--organization"}, description = "Organization's name identifier", required = true)
+    @CommandLine.Option(names = {"-o", "--organization"}, description = "Organization name identifier", required = true)
     public String organizationName;
 
     @Override

--- a/src/main/java/io/seqera/tower/cli/commands/participants/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/participants/AddCmd.java
@@ -30,10 +30,10 @@ import java.util.Objects;
 )
 public class AddCmd extends AbstractParticipantsCmd {
 
-    @CommandLine.Option(names = {"-n", "--name"}, description = "Team name or username of existing organization team or member", required = true)
+    @CommandLine.Option(names = {"-n", "--name"}, description = "Team name or username for existing organization member", required = true)
     public String name;
 
-    @CommandLine.Option(names = {"-t", "--type"}, description = "Type or participant (MEMBER, COLLABORATOR or TEAM)", required = true)
+    @CommandLine.Option(names = {"-t", "--type"}, description = "Type of participant (MEMBER, COLLABORATOR or TEAM)", required = true)
     public ParticipantType type;
 
     @CommandLine.Mixin

--- a/src/main/java/io/seqera/tower/cli/commands/participants/ChangeCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/participants/ChangeCmd.java
@@ -30,10 +30,10 @@ import java.io.IOException;
 )
 public class ChangeCmd extends AbstractParticipantsCmd {
 
-    @CommandLine.Option(names = {"-n", "--name"}, description = "Team name, username or email of existing organization team or member", required = true)
+    @CommandLine.Option(names = {"-n", "--name"}, description = "Team name, username or email for existing organization member", required = true)
     public String name;
 
-    @CommandLine.Option(names = {"-t", "--type"}, description = "Type or participant (MEMBER, COLLABORATOR or TEAM)", required = true)
+    @CommandLine.Option(names = {"-t", "--type"}, description = "Type of participant (MEMBER, COLLABORATOR or TEAM)", required = true)
     public ParticipantType type;
 
     @CommandLine.Option(names = {"-r", "--role"}, description = "Workspace participant role (OWNER, ADMIN, MAINTAIN, LAUNCH or VIEW)", required = true)

--- a/src/main/java/io/seqera/tower/cli/commands/participants/DeleteCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/participants/DeleteCmd.java
@@ -27,10 +27,10 @@ import java.io.IOException;
 )
 public class DeleteCmd extends AbstractParticipantsCmd {
 
-    @CommandLine.Option(names = {"-n", "--name"}, description = "Team name, username or email of existing organization team or member", required = true)
+    @CommandLine.Option(names = {"-n", "--name"}, description = "Team name, username or email for existing organization member", required = true)
     public String name;
 
-    @CommandLine.Option(names = {"-t", "--type"}, description = "Type or participant (MEMBER, COLLABORATOR or TEAM)", required = true)
+    @CommandLine.Option(names = {"-t", "--type"}, description = "Type of participant (MEMBER, COLLABORATOR or TEAM)", required = true)
     public ParticipantType type;
 
     @CommandLine.Mixin

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/ImportCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/ImportCmd.java
@@ -38,7 +38,7 @@ public class ImportCmd extends AbstractPipelinesCmd {
     @CommandLine.Mixin
     public WorkspaceOptions workspace;
 
-    @CommandLine.Option(names = {"-c", "--compute-env"}, description = "Compute environment name (defaults to json file defined environment)")
+    @CommandLine.Option(names = {"-c", "--compute-env"}, description = "Compute environment name [default: as defined in json environment file]")
     public String computeEnv;
 
     @CommandLine.Parameters(index = "0", paramLabel = "FILENAME", description = "File name to import", arity = "1")

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/LaunchOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/LaunchOptions.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 public class LaunchOptions {
 
-    @Option(names = {"-c", "--compute-env"}, description = "Compute environment name (defaults to primary compute environment)")
+    @Option(names = {"-c", "--compute-env"}, description = "Compute environment name [default: primary compute environment]")
     public String computeEnv;
 
     @Option(names = {"--work-dir"}, description = "Path where the pipeline scratch data is stored")

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/LaunchOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/LaunchOptions.java
@@ -36,10 +36,10 @@ public class LaunchOptions {
     @Option(names = {"--config"}, description = "Additional Nextflow config settings file")
     public Path config;
 
-    @Option(names = {"--pre-run"}, description = "Bash script that's executed in the same environment where Nextflow runs just before the pipeline is launched")
+    @Option(names = {"--pre-run"}, description = "Bash script that is executed in the same environment where Nextflow runs just before the pipeline is launched")
     public Path preRunScript;
 
-    @Option(names = {"--post-run"}, description = "Bash script that's executed in the same environment where Nextflow runs immediately after the pipeline completion")
+    @Option(names = {"--post-run"}, description = "Bash script that is executed in the same environment where Nextflow runs immediately after the pipeline completion")
     public Path postRunScript;
 
     @Option(names = {"--pull-latest"}, description = "Enabling this option Nextflow pulls the latest version from the Git repository before run the pipeline")

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/LaunchOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/LaunchOptions.java
@@ -24,10 +24,10 @@ public class LaunchOptions {
     @Option(names = {"--work-dir"}, description = "Path where the pipeline scratch data is stored")
     public String workDir;
 
-    @Option(names = {"-p", "--profiles"}, split = ",", description = "One or more (separated by comma) configuration profile names you want to use for this pipeline execution")
+    @Option(names = {"-p", "--profiles"}, split = ",", description = "Comma-separated list of one or more configuration profile names you want to use for this pipeline execution")
     public List<String> profiles;
 
-    @Option(names = {"--params"}, description = "Pipeline parameters using either JSON or YML file")
+    @Option(names = {"--params"}, description = "Pipeline parameters in either JSON or YML format")
     public Path params;
 
     @Option(names = {"--revision"}, description = "A valid repository commit Id, tag or branch name")
@@ -42,7 +42,7 @@ public class LaunchOptions {
     @Option(names = {"--post-run"}, description = "Bash script that is executed in the same environment where Nextflow runs immediately after the pipeline completion")
     public Path postRunScript;
 
-    @Option(names = {"--pull-latest"}, description = "Enabling this option Nextflow pulls the latest version from the Git repository before run the pipeline")
+    @Option(names = {"--pull-latest"}, description = "Enable Nextflow to pull the latest repository version before running the pipeline")
     public Boolean pullLatest;
 
     @Option(names = {"--stub-run"}, description = "Execute the workflow replacing process scripts with command stubs")

--- a/src/main/java/io/seqera/tower/cli/commands/runs/CancelCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/CancelCmd.java
@@ -22,11 +22,11 @@ import java.io.IOException;
 
 @CommandLine.Command(
         name = "cancel",
-        description = "Cancel a pipeline's execution"
+        description = "Cancel a pipeline execution"
 )
 public class CancelCmd extends AbstractRunsCmd {
 
-    @CommandLine.Option(names = {"-i", "--id"}, description = "Pipeline's run identifier", required = true)
+    @CommandLine.Option(names = {"-i", "--id"}, description = "Pipeline run identifier", required = true)
     public String id;
 
     @CommandLine.Mixin

--- a/src/main/java/io/seqera/tower/cli/commands/runs/DeleteCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/DeleteCmd.java
@@ -22,11 +22,11 @@ import java.io.IOException;
 
 @CommandLine.Command(
         name = "delete",
-        description = "Delete a pipeline's execution"
+        description = "Delete a pipeline execution"
 )
 public class DeleteCmd extends AbstractRunsCmd {
 
-    @CommandLine.Option(names = {"-i", "-id"}, description = "Pipeline's run identifier", required = true)
+    @CommandLine.Option(names = {"-i", "-id"}, description = "Pipeline run identifier", required = true)
     public String id;
 
     @CommandLine.Mixin

--- a/src/main/java/io/seqera/tower/cli/commands/runs/ListCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/ListCmd.java
@@ -23,14 +23,14 @@ import java.io.IOException;
 
 @CommandLine.Command(
         name = "list",
-        description = "List all pipeline's runs"
+        description = "List all pipeline runs"
 )
 public class ListCmd extends AbstractRunsCmd {
 
     @CommandLine.Mixin
     public WorkspaceOptions workspace;
 
-    @CommandLine.Option(names = {"-f", "--filter"}, description = "Show only pipeline's runs that it's name starts with the given word")
+    @CommandLine.Option(names = {"-f", "--filter"}, description = "Show only pipeline runs with names that start with the given word")
     public String startsWith;
 
     @CommandLine.Mixin

--- a/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
@@ -46,7 +46,7 @@ public class RelaunchCmd extends AbstractRunsCmd {
     @Option(names = {"--pipeline"}, description = "Pipeline to launch")
     public String pipeline;
 
-    @Option(names = {"--no-resume"}, description = "Not to resume the pipeline's run (true as default)")
+    @Option(names = {"--no-resume"}, description = "Not to resume the pipeline's run [default: true]")
     public boolean resume = true;
 
     @Mixin

--- a/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
@@ -33,11 +33,11 @@ import java.time.OffsetDateTime;
 
 @Command(
         name = "relaunch",
-        description = "Create a pipeline's run"
+        description = "Create a pipeline run"
 )
 public class RelaunchCmd extends AbstractRunsCmd {
 
-    @Option(names = {"-i", "--id"}, description = "Pipeline's run id to relaunch", required = true)
+    @Option(names = {"-i", "--id"}, description = "Pipeline run id to relaunch", required = true)
     public String id;
 
     @CommandLine.Mixin
@@ -46,7 +46,7 @@ public class RelaunchCmd extends AbstractRunsCmd {
     @Option(names = {"--pipeline"}, description = "Pipeline to launch")
     public String pipeline;
 
-    @Option(names = {"--no-resume"}, description = "Not to resume the pipeline's run [default: true]")
+    @Option(names = {"--no-resume"}, description = "Do not resume the pipeline run [default: true]")
     public boolean resume = true;
 
     @Mixin

--- a/src/main/java/io/seqera/tower/cli/commands/runs/RunViewOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/RunViewOptions.java
@@ -15,39 +15,39 @@ import picocli.CommandLine;
 
 public class RunViewOptions {
 
-    @CommandLine.Option(names = {"--config"}, description = "Display pipeline's run configuration")
+    @CommandLine.Option(names = {"--config"}, description = "Display pipeline run configuration")
     public boolean config;
 
-    @CommandLine.Option(names = {"--params"}, description = "Display pipeline's run parameters")
+    @CommandLine.Option(names = {"--params"}, description = "Display pipeline run parameters")
     public boolean params;
 
-    @CommandLine.Option(names = {"--command"}, description = "Display pipeline's run command")
+    @CommandLine.Option(names = {"--command"}, description = "Display pipeline run command")
     public boolean command = false;
 
-    @CommandLine.Option(names = {"--status"}, description = "Display pipeline's run status")
+    @CommandLine.Option(names = {"--status"}, description = "Display pipeline run status")
     public boolean status = false;
 
-    @CommandLine.Option(names = {"--processes"}, description = "Display pipeline's run processed")
+    @CommandLine.Option(names = {"--processes"}, description = "Display pipeline run processes")
     public boolean processes = false;
 
-    @CommandLine.Option(names = {"--stats"}, description = "Display pipeline's run stats")
+    @CommandLine.Option(names = {"--stats"}, description = "Display pipeline run stats")
     public boolean stats = false;
 
-    @CommandLine.Option(names = {"--load"}, description = "Display pipeline's run load")
+    @CommandLine.Option(names = {"--load"}, description = "Display pipeline run load")
     public boolean load = false;
 
-    @CommandLine.Option(names = {"--utilization"}, description = "Display pipeline's run utilization")
+    @CommandLine.Option(names = {"--utilization"}, description = "Display pipeline run utilization")
     public boolean utilization = false;
 
-    @CommandLine.Option(names = {"--metrics-memory"}, description = "Display pipeline's run processes memory metrics")
+    @CommandLine.Option(names = {"--metrics-memory"}, description = "Display pipeline run memory metrics")
     public boolean metricsMemory = false;
 
-    @CommandLine.Option(names = {"--metrics-cpu"}, description = "Display pipeline's run processes CPU metrics")
+    @CommandLine.Option(names = {"--metrics-cpu"}, description = "Display pipeline run CPU metrics")
     public boolean metricsCpu = false;
 
-    @CommandLine.Option(names = {"--metrics-time"}, description = "Display pipeline's run processes job time metrics")
+    @CommandLine.Option(names = {"--metrics-time"}, description = "Display pipeline run job time metrics")
     public boolean metricsTime = false;
 
-    @CommandLine.Option(names = {"--metrics-io"}, description = "Display pipeline's run processes I/O metrics")
+    @CommandLine.Option(names = {"--metrics-io"}, description = "Display pipeline run I/O metrics")
     public boolean metricsIo = false;
 }

--- a/src/main/java/io/seqera/tower/cli/commands/runs/ViewCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/ViewCmd.java
@@ -32,11 +32,11 @@ import java.util.concurrent.TimeUnit;
 
 @CommandLine.Command(
         name = "view",
-        description = "View pipeline's runs"
+        description = "View pipeline runs"
 )
 public class ViewCmd extends AbstractRunsCmd {
 
-    @CommandLine.Option(names = {"-i", "--id"}, description = "Pipeline's run identifier", required = true)
+    @CommandLine.Option(names = {"-i", "--id"}, description = "Pipeline run identifier", required = true)
     public String id;
 
     @CommandLine.Mixin

--- a/src/main/java/io/seqera/tower/cli/commands/teams/CreateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/teams/CreateCmd.java
@@ -28,13 +28,13 @@ import java.io.IOException;
 )
 public class CreateCmd extends AbstractTeamsCmd {
 
-    @CommandLine.Option(names = {"-n", "--name"}, description = "Team's name", required = true)
+    @CommandLine.Option(names = {"-n", "--name"}, description = "Team name", required = true)
     public String teamName;
 
-    @CommandLine.Option(names = {"-o", "--organization"}, description = "Organization's name identifier", required = true)
+    @CommandLine.Option(names = {"-o", "--organization"}, description = "Organization name identifier", required = true)
     public String organizationName;
 
-    @CommandLine.Option(names = {"-d", "--description"}, description = "Team's description")
+    @CommandLine.Option(names = {"-d", "--description"}, description = "Team description")
     public String teamDescription;
 
     @Override

--- a/src/main/java/io/seqera/tower/cli/commands/teams/DeleteCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/teams/DeleteCmd.java
@@ -25,10 +25,10 @@ import java.io.IOException;
 )
 public class DeleteCmd extends AbstractTeamsCmd {
 
-    @CommandLine.Option(names = {"-i", "--id"}, description = "Team's identifier", required = true)
+    @CommandLine.Option(names = {"-i", "--id"}, description = "Team identifier", required = true)
     public Long teamId;
 
-    @CommandLine.Option(names = {"-o", "--organization"}, description = "Organization's name identifier", required = true)
+    @CommandLine.Option(names = {"-o", "--organization"}, description = "Organization name identifier", required = true)
     public String organizationName;
 
     @Override

--- a/src/main/java/io/seqera/tower/cli/commands/teams/ListCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/teams/ListCmd.java
@@ -23,11 +23,11 @@ import java.io.IOException;
 
 @CommandLine.Command(
         name = "list",
-        description = "List all the teams of a given organization"
+        description = "List all the teams in a given organization"
 )
 public class ListCmd extends AbstractTeamsCmd {
 
-    @CommandLine.Option(names = {"-o", "--organization"}, description = "Organization's name identifier", required = true)
+    @CommandLine.Option(names = {"-o", "--organization"}, description = "Organization name identifier", required = true)
     public String organizationName;
 
     @CommandLine.Mixin

--- a/src/main/java/io/seqera/tower/cli/commands/teams/MembersCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/teams/MembersCmd.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 @CommandLine.Command(
         name = "members",
-        description = "Operates over team's members",
+        description = "Add or remove team members",
         subcommands = {
                 AddCmd.class,
                 DeleteCmd.class,
@@ -34,10 +34,10 @@ import java.io.IOException;
 )
 public class MembersCmd extends AbstractTeamsCmd {
 
-    @CommandLine.Option(names = {"-t", "--team"}, description = "Team's name", required = true)
+    @CommandLine.Option(names = {"-t", "--team"}, description = "Team name", required = true)
     public String teamName;
 
-    @CommandLine.Option(names = {"-o", "--organization"}, description = "Organization's name identifier", required = true)
+    @CommandLine.Option(names = {"-o", "--organization"}, description = "Organization name identifier", required = true)
     public String organizationName;
 
     @Override

--- a/src/main/java/io/seqera/tower/cli/commands/teams/members/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/teams/members/AddCmd.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 @CommandLine.Command(
         name = "add",
-        description = "Adds a team's members"
+        description = "Add a team member"
 )
 public class AddCmd extends AbstractApiCmd {
 

--- a/src/main/java/io/seqera/tower/cli/commands/teams/members/DeleteCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/teams/members/DeleteCmd.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 
 @CommandLine.Command(
         name = "delete",
-        description = "Delete a team's members"
+        description = "Delete a team member"
 )
 public class DeleteCmd extends AbstractApiCmd {
 

--- a/src/main/java/io/seqera/tower/cli/commands/workspaces/CreateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/workspaces/CreateCmd.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 
 @Command(
         name = "create",
-        description = "Create a new organization's workspace"
+        description = "Create a new organization workspace"
 )
 public class CreateCmd extends AbstractWorkspaceCmd {
     @Mixin

--- a/src/main/java/io/seqera/tower/cli/commands/workspaces/DeleteCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/workspaces/DeleteCmd.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 
 @Command(
         name = "delete",
-        description = "Delete an organization's workspace"
+        description = "Delete an organization workspace"
 )
 public class DeleteCmd extends AbstractWorkspaceCmd {
 

--- a/src/main/java/io/seqera/tower/cli/commands/workspaces/UpdateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/workspaces/UpdateCmd.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 @Command(
         name = "update",
-        description = "Update an existing organization's workspace"
+        description = "Update an existing organization workspace"
 )
 public class UpdateCmd extends AbstractWorkspaceCmd {
 

--- a/src/main/java/io/seqera/tower/cli/commands/workspaces/ViewCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/workspaces/ViewCmd.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 
 @Command(
         name = "view",
-        description = "Describe an existing organization's workspace"
+        description = "Describe an existing organization workspace"
 )
 public class ViewCmd extends AbstractWorkspaceCmd {
 

--- a/src/main/java/io/seqera/tower/cli/default.code-search
+++ b/src/main/java/io/seqera/tower/cli/default.code-search
@@ -1,0 +1,296 @@
+# Query: default
+# ContextLines: 1
+
+68 results - 40 files
+
+build.gradle:
+  72      mainClassName = 'io.seqera.tower.cli.Tower'
+  73:     applicationDefaultJvmArgs = ["-agentlib:native-image-agent=config-merge-dir=conf/"]
+  74  }
+
+gradlew:
+   45  
+   46: # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+   47: DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+   48  
+
+  182  # Collect all arguments for the java command, following the shell quoting and substitution rules
+  183: eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS "\"-Dorg.gradle.appname=$APP_BASE_NAME\"" -classpath "\"$CLASSPATH\"" org.gradle.wrapper.GradleWrapperMain "$APP_ARGS"
+  184  
+
+gradlew.bat:
+  34  
+  35: @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+  36: set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
+  37  
+
+  88  @rem Execute Gradle
+  89: "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+  90  
+
+README.md:
+  39  1. `TOWER_ACCESS_TOKEN`: (mandatory) the user access token
+  40: 2. `TOWER_WORKSPACE_ID`: (optional) the workspace id. Defaults to user workspace.
+  41: 3. `TOWER_API_ENDPOINT`: (optional) the Tower API URL. Defaults to `api.tower.nf` API.
+  42  
+
+conf/reflect-config.json:
+  3148  {
+  3149:   "name":"sun.security.ssl.SSLContextImpl$DefaultSSLContext",
+  3150    "methods":[{"name":"<init>","parameterTypes":[] }]
+
+src/main/java/io/seqera/tower/cli/Tower.java:
+  67  
+  68:     @Option(names = {"-t", "--access-token"}, description = "Tower personal access token (TOWER_ACCESS_TOKEN)", defaultValue = "${TOWER_ACCESS_TOKEN}", required = true)
+  69      public String token;
+  70  
+  71:     @Option(names = {"-u", "--url"}, description = "Tower server API endpoint URL (TOWER_API_ENDPOINT) [default: 'tower.nf']", defaultValue = "${TOWER_API_ENDPOINT:-https://api.tower.nf}", required = true)
+  72      public String url;
+
+src/main/java/io/seqera/tower/cli/commands/AbstractApiCmd.java:
+  15  import io.seqera.tower.ApiException;
+  16: import io.seqera.tower.api.DefaultApi;
+  17  import io.seqera.tower.cli.Tower;
+
+  49  
+  50:     private DefaultApi api;
+  51  
+
+  73  
+  74:     protected DefaultApi api() {
+  75  
+
+  80              client.setBearerToken(app().token);
+  81:             api = new DefaultApi(client);
+  82          }
+
+  91                  if (app().verbose) {
+  92:                     clientConfig.register(new LoggingFeature(Logger.getLogger(LoggingFeature.DEFAULT_LOGGER_NAME), java.util.logging.Level.INFO, LoggingFeature.Verbosity.PAYLOAD_ANY, 1024 * 50 /* Log payloads up to 50K */));
+  93                      clientConfig.property(LoggingFeature.LOGGING_FEATURE_VERBOSITY, LoggingFeature.Verbosity.PAYLOAD_ANY);
+
+src/main/java/io/seqera/tower/cli/commands/LaunchesCmd.java:
+  53  
+  54:     @Option(names = {"-c", "--compute-env"}, description = "Compute environment name [default: primary workspace]")
+  55      String computeEnv;
+
+src/main/java/io/seqera/tower/cli/commands/actions/UpdateCmd.java:
+  57  
+  58:         // Use compute env values by default
+  59          String workDirValue = opts.workDir != null ? opts.workDir : action.getLaunch().getWorkDir();
+
+src/main/java/io/seqera/tower/cli/commands/actions/create/AbstractCreateCmd.java:
+  49  
+  50:         // Use compute env values by default
+  51          String workDirValue = opts.workDir != null ? opts.workDir : ce.getConfig() != null ? ce.getConfig().getWorkDir() : null;
+
+src/main/java/io/seqera/tower/cli/commands/computeenvs/ExportCmd.java:
+  66          try {
+  67:             configOutput = new JSON().getContext(ComputeConfig.class).writerWithDefaultPrettyPrinter().writeValueAsString(computeEnv.getConfig());
+  68          } catch (JsonProcessingException e) {
+
+src/main/java/io/seqera/tower/cli/commands/computeenvs/create/AbstractCreateCmd.java:
+  40  
+  41:     @Option(names = {"-i", "--id"}, description = "Credentials identifier [default: workspace credentials]")
+  42      public String credentialsId;
+
+src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AltairPlatform.java:
+  38  
+  39:     @Option(names = {"--launch-dir"}, description = "The directory where Nextflow runs. It must be an absolute directory and the user should have read-write access permissions to it. [default: pipeline work directory]")
+  40      public String launchDir;
+
+  81      public static class AdvancedOptions {
+  82:         @Option(names = {"--max-queue-size"}, description = "This option limits the number of jobs Nextflow can submit to the Slurm queue at the same time [default: 100]")
+  83          public Integer maxQueueSize;
+
+src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AwsBatchForgePlatform.java:
+   33  
+   34:     @Option(names = {"--provisioning-model"}, description = "VMs provisioning model. 'EC2' deploys uninterruptible Ec2 instances. 'SPOT' uses interruptible Ec2 instances", required = true, defaultValue = "SPOT")
+   35      public TypeEnum provisioningModel;
+
+  146  
+  147:         @Option(names = {"--efs-mount"}, description = "Enter the EFS mount path [default: pipeline work directory]")
+  148          public String efsMount;
+
+  159  
+  160:         @Option(names = {"--fsx-mount"}, description = "Enter the FSx mount path [default: pipeline work directory]")
+  161          public String fsxMount;
+
+  180  
+  181:         @Option(names = {"--ami-id"}, description = "Ths option allows you to use your own AMI. Note however it must be an AWS Linux-2 ECS-optimised image and meet the compute resource AMI specification [default: latest approved version of the Amazon ECS-optimized AMI]")
+  182          public String amiId;
+
+  201  
+  202:         @Option(names = {"--ebs-blocksize"}, description = "This field controls the initial size of the EBS auto-expandable volume. New blocks of the same size are added as necessary when the volume is running out of free space [default: 50 GB]")
+  203          public Integer ebsBlockSize;
+  204  
+  205:         @Option(names = {"--bid-percentage"}, description = "The maximum percentage that a Spot Instance price can be when compared with the On-Demand price for that instance type before instances are launched. For example, if your maximum percentage is 20%%, then the Spot price must be less than 20%% of the current On-Demand price for that Amazon EC2 instance. You always pay the lowest (market) price and never more than your maximum percentage [default: 100% of the On-Demand price]")
+  206          public Integer bidPercentage;
+
+src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AwsBatchManualPlatform.java:
+  28  
+  29:     @Option(names = {"--compute-queue"}, description = "The default Batch queue to which Nextflow will submit jobs. This can be overwritten via Nextflow config", required = true)
+  30      public String computeQueue;
+
+src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchForgePlatform.java:
+  28  
+  29:     @Option(names = {"--vm-type"}, description = "Specify the virtual machine type used by this pool. It must be a valid Azure Batch VM type [default: Standard_D4_v3]")
+  30      public String vmType;
+
+  81  
+  82:         @Option(names = {"--token-duration"}, description = "The duration of the shared access signature token created by Nextflow when the 'sasToken' option is not specified [default: 12h]")
+  83          public String tokenDuration;
+
+src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchManualPlatform.java:
+  63  
+  64:         @Option(names = {"--token-duration"}, description = "The duration of the shared access signature token created by Nextflow when the 'sasToken' option is not specified (default: 12h)")
+  65          public String tokenDuration;
+
+src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/GoogleLifeSciencesPlatform.java:
+  30  
+  31:     @Option(names = {"--location"}, description = "The location where the job executions are deployed to Cloud Life Sciences API [default: same as the specified region/zone]")
+  32      public String location;
+
+  85  
+  86:         @Option(names = {"--nfs-mount"}, description = "Specify the NFS mount path. It should be the same as the pipeline work directory or a parent path of it [default: pipeline work directory]")
+  87          public String nfsMount;
+
+src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/LsfPlatform.java:
+  38  
+  39:     @Option(names = {"--launch-dir"}, description = "The directory where Nextflow runs. It must be an absolute directory and the user should have read-write access permissions to it [default: pipeline work directory]")
+  40      public String launchDir;
+
+  86      public static class AdvancedOptions {
+  87:         @Option(names = {"--max-queue-size"}, description = "This option limits the number of jobs Nextflow can submit to the Slurm queue at the same time [default: 100]")
+  88          public Integer maxQueueSize;
+
+src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/SlurmPlatform.java:
+  38  
+  39:     @Option(names = {"--launch-dir"}, description = "The directory where Nextflow runs. It must be an absolute directory and the user should have read-write access permissions to it [default: pipeline work directory]")
+  40      public String launchDir;
+
+  81      public static class AdvancedOptions {
+  82:         @Option(names = {"--max-queue-size"}, description = "This option limits the number of jobs Nextflow can submit to the Slurm queue at the same time [default: 100]")
+  83          public Integer maxQueueSize;
+
+src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/UnivaPlatform.java:
+  38  
+  39:     @Option(names = {"--launch-dir"}, description = "The directory where Nextflow runs. It must be an absolute directory and the user should have read-write access permissions to it [default: pipeline work directory]")
+  40      public String launchDir;
+
+  81      public static class AdvancedOptions {
+  82:         @Option(names = {"--max-queue-size"}, description = "This option limits the number of jobs Nextflow can submit to the Slurm queue at the same time [default: 100]")
+  83          public Integer maxQueueSize;
+
+src/main/java/io/seqera/tower/cli/commands/global/OrgAndWorkspace.java:
+  17  
+  18:     @CommandLine.Option(names = {"--workspace-name"}, description = "Workspace name (case insensitive)", defaultValue = "${TOWER_WORKSPACE_NAME}")
+  19      public String workspace;
+  20  
+  21:     @CommandLine.Option(names = {"--organization-name"}, description = "Organization name (case insensitive)", defaultValue = "${TOWER_ORG_NAME}")
+  22      public String organization;
+
+src/main/java/io/seqera/tower/cli/commands/global/OrganizationOption.java:
+  17      
+  18:     @CommandLine.Option(names = {"-o", "--organization-id"}, description = "Organization numeric identifier (TOWER_ORGANIZATION_ID)", defaultValue = "${TOWER_ORGANIZATION_ID}")
+  19      public Long organizationId = null;
+
+src/main/java/io/seqera/tower/cli/commands/global/PaginationOptions.java:
+  29      public static class Pageable {
+  30:         @CommandLine.Option(names = {"--page"}, description = "Page to display to display (default is 1)")
+  31          public Integer page;
+  32  
+  33:         @CommandLine.Option(names = {"--offset"}, description = "Rows record's offset (default is 0)")
+  34          public Integer offset;
+
+  37      public static class Sizeable {
+  38:         @CommandLine.Option(names = {"--max"}, description = "Maximum number of records to display (default is " + MAX + ")")
+  39          public Integer max;
+
+src/main/java/io/seqera/tower/cli/commands/global/WorkspaceOptions.java:
+  17  
+  18:     @CommandLine.Option(names = {"-w", "--workspace"}, description = "Workspace numeric identifier (TOWER_WORKSPACE_ID)", defaultValue = "${TOWER_WORKSPACE_ID}")
+  19      public Long workspaceId = null;
+
+src/main/java/io/seqera/tower/cli/commands/pipelines/CreateCmd.java:
+  58  
+  59:         // Use compute env values by default
+  60          String workDirValue = opts.workDir == null ? ce.getConfig().getWorkDir() : opts.workDir;
+
+src/main/java/io/seqera/tower/cli/commands/pipelines/ExportCmd.java:
+  57          try {
+  58:             configOutput = new JSON().getContext(CreatePipelineRequest.class).writerWithDefaultPrettyPrinter().writeValueAsString(createPipelineRequest);
+  59          } catch (JsonProcessingException e) {
+
+src/main/java/io/seqera/tower/cli/commands/pipelines/ImportCmd.java:
+  40  
+  41:     @CommandLine.Option(names = {"-c", "--compute-env"}, description = "Compute environment name [default: as defined in json environment file]")
+  42      public String computeEnv;
+
+src/main/java/io/seqera/tower/cli/commands/pipelines/LaunchOptions.java:
+  20  
+  21:     @Option(names = {"-c", "--compute-env"}, description = "Compute environment name [default: primary compute environment]")
+  22      public String computeEnv;
+
+src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java:
+  48  
+  49:     @Option(names = {"--no-resume"}, description = "Not to resume the pipeline's run (true as default)")
+  50      public boolean resume = true;
+
+src/main/java/io/seqera/tower/cli/responses/ComputeEnvView.java:
+  57          try {
+  58:             configJson = new JSON().getContext(ComputeConfig.class).writerWithDefaultPrettyPrinter().writeValueAsString(config);
+  59          } catch (JsonProcessingException e) {
+
+src/main/java/io/seqera/tower/cli/responses/actions/ActionsView.java:
+  36              WorkflowLaunchRequest request = ModelHelper.createLaunchRequest(action.getLaunch());
+  37:             configJson = new JSON().getContext(WorkflowLaunchRequest.class).writerWithDefaultPrettyPrinter().writeValueAsString(request);
+  38          } catch (JsonProcessingException e) {
+
+src/main/java/io/seqera/tower/cli/responses/pipelines/PipelinesView.java:
+  41              WorkflowLaunchRequest request = ModelHelper.createLaunchRequest(launch);
+  42:             configJson = new JSON().getContext(WorkflowLaunchRequest.class).writerWithDefaultPrettyPrinter().writeValueAsString(request);
+  43          } catch (JsonProcessingException e) {
+
+src/main/java/io/seqera/tower/cli/utils/ErrorReporting.java:
+  70  
+  71:                 default:
+  72                      print(err, decodeMessage(ex));
+
+src/main/java/io/seqera/tower/cli/utils/JsonHelper.java:
+  22      public static String prettyJson(Object obj) throws JsonProcessingException {
+  23:         return new JSON().getContext(obj.getClass()).writerWithDefaultPrettyPrinter().writeValueAsString(obj);
+  24      }
+
+src/main/java/io/seqera/tower/cli/utils/ModelHelper.java:
+  42  
+  43:     public static <T> T coalesce(T value, T defaultValue) {
+  44          if (value == null) {
+  45:             return defaultValue;
+  46          }
+
+src/main/resources/logback.xml:
+  15          <!-- encoders are assigned the type
+  16:              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+  17          <encoder>
+
+src/test/java/io/seqera/tower/cli/computeenvs/ComputeEnvsCmdTest.java:
+  336  
+  337:         String configOutput = new JSON().getContext(ComputeConfig.class).writerWithDefaultPrettyPrinter().writeValueAsString(computeConfig);
+  338  
+
+src/test/java/io/seqera/tower/cli/Pipelines/PipelinesCmdTest.java:
+  538  
+  539:         String configOutput = new JSON().getContext(CreatePipelineRequest.class).writerWithDefaultPrettyPrinter().writeValueAsString(createPipelineRequest);
+  540  
+
+src/test/resources/runcmd/runs/runs_view.json:
+   35        "skip_markduplicates": false,
+   36:       "ribo_database_manifest": "/.nextflow/assets/nf-core/rnaseq/assets/rrna-db-defaults.txt",
+   37        "monochrome_logs": false,
+
+  839      },
+  840: ⟪ 998 characters skipped ⟫.txt'\n   save_bbsplit_reads = false\n   skip_bbsplit = false\n   remove_ribo_rna = false\n   save_non_ribo_reads = false\n   ribo_database_manifest = '/.nextflow/assets/nf-core/rnaseq/assets/rrna-db-defaults.txt'\n   aligner = 'star_salmon'\n   pseudo_aligner = 'salmon'\n   seq_center = null\n   bam_csi_index = false\n   star_ignore_sjdbgtf = false\n   salmon_quant_libtype = null\n   hisat2_build_memory = '200.GB'\n   stringtie_ignore_gtf = false\n   min_mapped_reads = 5\n   save_merged_fastq = false\n   save_unaligned = false\n   save_align_intermeds = false\n   skip_markduplicates = false\n   skip_alignment = false\n   skip_qc = false\n   skip_bigwig = false\n   skip_stringtie = false\n   skip_fastqc = false\n   skip_preseq = false\n   skip_dupradar = false\n   skip_qualimap = false\n   skip_rseqc = false\n   skip_biotype_qc = false\n   skip_deseq2_qc = false\n   skip_multiqc = false\n   deseq2_vst = false\n   rseqc_modules = 'bam_stat,inner_distance,infer_experiment,junction_annotation,junction_saturation,read_distribution,read_duplication'\n   outdir = './results'\n   publish_dir_mode = 'copy'\n   multiqc_config = null\n   multiqc_title = null\n   email = null\n   email_on_fai
+  841      "manifest": {
+  842        "nextflowVersion": "!>=21.04.0",
+  843:       "defaultBranch": "master",
+  844        "version": "3.4",

--- a/src/main/java/io/seqera/tower/cli/exceptions/MembersMultiplicityException.java
+++ b/src/main/java/io/seqera/tower/cli/exceptions/MembersMultiplicityException.java
@@ -14,6 +14,6 @@ package io.seqera.tower.cli.exceptions;
 public class MembersMultiplicityException extends TowerException {
 
     public MembersMultiplicityException(String user, Long orgId) {
-        super(String.format("Multiple Members were found for the '%s' keyword %d organization", user, orgId));
+        super(String.format("Multiple members were found for the '%s' keyword %d organization", user, orgId));
     }
 }

--- a/src/main/java/io/seqera/tower/cli/exceptions/RunNotFoundException.java
+++ b/src/main/java/io/seqera/tower/cli/exceptions/RunNotFoundException.java
@@ -13,6 +13,6 @@ package io.seqera.tower.cli.exceptions;
 
 public class RunNotFoundException extends TowerException {
     public RunNotFoundException(String name, String workspaceRef) {
-        super(String.format("Pipeline's run '%s' not found at %s workspace", name, workspaceRef));
+        super(String.format("Pipeline run '%s' not found at %s workspace", name, workspaceRef));
     }
 }

--- a/src/main/java/io/seqera/tower/cli/responses/RunCanceled.java
+++ b/src/main/java/io/seqera/tower/cli/responses/RunCanceled.java
@@ -23,7 +23,7 @@ public class RunCanceled extends Response{
 
     @Override
     public String toString() {
-        return ansi(String.format("%n  @|yellow Pipeline's run '%s' canceled at %s workspace|@%n", id, workspaceRef));
+        return ansi(String.format("%n  @|yellow Pipeline run '%s' canceled at %s workspace|@%n", id, workspaceRef));
     }
 
 }

--- a/src/main/java/io/seqera/tower/cli/responses/RunDeleted.java
+++ b/src/main/java/io/seqera/tower/cli/responses/RunDeleted.java
@@ -23,6 +23,6 @@ public class RunDeleted extends Response {
 
     @Override
     public String toString() {
-        return ansi(String.format("%n  @|yellow Pipeline's run '%s' deleted at %s workspace|@%n", id, workspaceRef));
+        return ansi(String.format("%n  @|yellow Pipeline run '%s' deleted at %s workspace|@%n", id, workspaceRef));
     }
 }

--- a/src/main/java/io/seqera/tower/cli/responses/RunList.java
+++ b/src/main/java/io/seqera/tower/cli/responses/RunList.java
@@ -29,10 +29,10 @@ public class RunList extends Response {
 
     @Override
     public void toString(PrintWriter out) {
-        out.println(ansi(String.format("%n  @|bold Pipeline's runs at %s workspace:|@%n", workspaceRef)));
+        out.println(ansi(String.format("%n  @|bold Pipeline runs at %s workspace:|@%n", workspaceRef)));
 
         if (workflows.isEmpty()) {
-            out.println(ansi("    @|yellow No pipeline's runs found|@"));
+            out.println(ansi("    @|yellow No pipeline runs found|@"));
             return;
         }
 


### PR DESCRIPTION
* Changed to using `[default: 100]` syntax everywhere as specified in [docopt](http://docopt.org/)
* Changed plurals for `Team's`, `Member's`, `Workspace's` etc to singular values for tidyness
* Reworded help descriptions and fix a few tyops

It appears like we aren't consistently using full-stops at the end of option descriptions. Not sure how fussed we are about it but in-built options like `--help` and `--version` do have a full-stop.