### PR TITLE
Platform dependent pipeline import parameters

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/ImportCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/ImportCmd.java
@@ -14,6 +14,7 @@ package io.seqera.tower.cli.commands.pipelines;
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
 import io.seqera.tower.cli.exceptions.ComputeEnvNotFoundException;
+import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.pipelines.PipelinesAdded;
 import io.seqera.tower.cli.utils.FilesHelper;
@@ -57,8 +58,12 @@ public class ImportCmd extends AbstractPipelinesCmd {
             ComputeEnv ce = computeEnvByRef(wspId, computeEnv);
             request.getLaunch().setComputeEnvId(ce.getId());
         } else {
+            String ceId = request.getLaunch().getComputeEnvId();
+            if (ceId == null) {
+                throw new TowerException("Missing compute environment ID. Provide it using '--compute-env' option or field 'launch.computeEnvId'.");
+            }
             try {
-                api().describeComputeEnv(request.getLaunch().getComputeEnvId(), wspId);
+                api().describeComputeEnv(ceId, wspId);
             } catch (ApiException apiException) {
                 throw new ComputeEnvNotFoundException(request.getLaunch().getId(), wspId);
             }

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/ImportCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/ImportCmd.java
@@ -20,12 +20,14 @@ import io.seqera.tower.cli.responses.pipelines.PipelinesAdded;
 import io.seqera.tower.cli.utils.FilesHelper;
 import io.seqera.tower.model.ComputeEnv;
 import io.seqera.tower.model.CreatePipelineRequest;
+import io.seqera.tower.model.WorkflowLaunchRequest;
 import picocli.CommandLine;
 
 import java.io.IOException;
 import java.nio.file.Path;
 
 import static io.seqera.tower.cli.utils.JsonHelper.parseJson;
+import static io.seqera.tower.cli.utils.ModelHelper.coalesce;
 
 @CommandLine.Command(
         name = "import",
@@ -54,20 +56,23 @@ public class ImportCmd extends AbstractPipelinesCmd {
         request = parseJson(FilesHelper.readString(fileName), CreatePipelineRequest.class);
         request.setName(name);
 
-        if (computeEnv != null) {
-            ComputeEnv ce = computeEnvByRef(wspId, computeEnv);
-            request.getLaunch().setComputeEnvId(ce.getId());
-        } else {
-            String ceId = request.getLaunch().getComputeEnvId();
-            if (ceId == null) {
-                throw new TowerException("Missing compute environment ID. Provide it using '--compute-env' option or field 'launch.computeEnvId'.");
-            }
-            try {
-                api().describeComputeEnv(ceId, wspId);
-            } catch (ApiException apiException) {
-                throw new ComputeEnvNotFoundException(request.getLaunch().getId(), wspId);
-            }
+        WorkflowLaunchRequest launch = request.getLaunch();
+        String ceRef = computeEnv != null ? computeEnv : launch.getComputeEnvId();
+        if (ceRef == null) {
+            throw new TowerException("Missing compute environment ID. Provide it using '--compute-env' option or field 'launch.computeEnvId'.");
         }
+
+        ComputeEnv ce = computeEnvByRef(wspId, ceRef);
+
+        // Use compute env values by default
+        String workDirValue = coalesce(launch.getWorkDir(), ce.getConfig().getWorkDir());
+        String preRunScriptValue = coalesce(launch.getPreRunScript(), ce.getConfig().getPreRunScript());
+        String postRunScriptValue = coalesce(launch.getPostRunScript(), ce.getConfig().getPostRunScript());
+
+        launch.setComputeEnvId(ce.getId());
+        launch.setWorkDir(workDirValue);
+        launch.setPreRunScript(preRunScriptValue);
+        launch.setPostRunScript(postRunScriptValue);
 
         api().createPipeline(request, wspId);
 

--- a/src/test/java/io/seqera/tower/cli/pipelines/PipelinesCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/pipelines/PipelinesCmdTest.java
@@ -529,48 +529,6 @@ class PipelinesCmdTest extends BaseCmdTest {
 
     @Test
     void testImport(MockServerClient mock) throws IOException {
-        mock.when(
-                request().withMethod("POST").withPath("/pipelines")
-                        .withBody("{\"name\":\"pipelineNew\",\"launch\":{\"computeEnvId\":\"3xkkzYH2nbD3nZjrzKm0oR\",\"pipeline\":\"https://github.com/grananda/nextflow-hello\",\"workDir\":\"s3://nextflow-ci/julio\",\"revision\":\"main\",\"resume\":false,\"pullLatest\":false,\"stubRun\":false}}")
-                        .withContentType(MediaType.APPLICATION_JSON), exactly(1)
-        ).respond(
-                response()
-                        .withStatusCode(200)
-                        .withBody(loadResource("pipelines_add_response"))
-                        .withContentType(MediaType.APPLICATION_JSON)
-        );
-
-        mock.when(
-                request().withMethod("GET").withPath("/compute-envs"), exactly(1)
-        ).respond(
-                response().withStatusCode(200).withBody("{\"computeEnvs\":[{\"id\":\"3xkkzYH2nbD3nZjrzKm0oR\",\"name\":\"demo\",\"platform\":\"aws-batch\",\"status\":\"AVAILABLE\",\"message\":null,\"lastUsed\":null,\"primary\":null,\"workspaceName\":null,\"visibility\":null}]}").withContentType(MediaType.APPLICATION_JSON)
-        );
-
-        mock.when(
-                request().withMethod("GET").withPath("/compute-envs/3xkkzYH2nbD3nZjrzKm0oR"), exactly(1)
-        ).respond(
-                response().withStatusCode(200).withBody(loadResource("compute_env_view")).withContentType(MediaType.APPLICATION_JSON)
-        );
-
-        ExecOut out = exec(mock, "pipelines", "import", tempFile(new String(loadResource("pipelines_add"), StandardCharsets.UTF_8), "data", ".json"), "-n", "pipelineNew");
-
-        assertEquals("", out.stdErr);
-        assertEquals(new PipelinesAdded(USER_WORKSPACE_NAME, "pipelineNew").toString(), out.stdOut);
-        assertEquals(0, out.exitCode);
-    }
-
-    @Test
-    void testImportWithComputeEnv(MockServerClient mock) throws IOException {
-        mock.when(
-                request().withMethod("POST").withPath("/pipelines")
-                        .withBody("{\"name\":\"pipelineNew\",\"launch\":{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\",\"pipeline\":\"https://github.com/grananda/nextflow-hello\",\"workDir\":\"s3://nextflow-ci/julio\",\"revision\":\"main\",\"resume\":false,\"pullLatest\":false,\"stubRun\":false}}")
-                        .withContentType(MediaType.APPLICATION_JSON), exactly(1)
-        ).respond(
-                response()
-                        .withStatusCode(200)
-                        .withBody(loadResource("pipelines_add_response"))
-                        .withContentType(MediaType.APPLICATION_JSON)
-        );
 
         mock.when(
                 request().withMethod("GET").withPath("/compute-envs"), exactly(1)
@@ -584,7 +542,84 @@ class PipelinesCmdTest extends BaseCmdTest {
                 response().withStatusCode(200).withBody(loadResource("compute_env_view")).withContentType(MediaType.APPLICATION_JSON)
         );
 
+        mock.when(
+                request().withMethod("POST").withPath("/pipelines")
+                        .withBody("{\"name\":\"pipelineNew\",\"launch\":{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\",\"pipeline\":\"https://github.com/grananda/nextflow-hello\",\"workDir\":\"s3://nextflow-ci/julio\",\"revision\":\"main\",\"resume\":false,\"pullLatest\":false,\"stubRun\":false}}")
+                        .withContentType(MediaType.APPLICATION_JSON), exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withBody(loadResource("pipelines_add_response"))
+                        .withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(mock, "-v", "pipelines", "import", tempFile(new String(loadResource("pipelines_add"), StandardCharsets.UTF_8), "data", ".json"), "-n", "pipelineNew");
+
+        assertEquals("", out.stdErr);
+        assertEquals(new PipelinesAdded(USER_WORKSPACE_NAME, "pipelineNew").toString(), out.stdOut);
+        assertEquals(0, out.exitCode);
+    }
+
+    @Test
+    void testImportWithComputeEnv(MockServerClient mock) throws IOException {
+
+        mock.when(
+                request().withMethod("GET").withPath("/compute-envs"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"computeEnvs\":[{\"id\":\"isnEDBLvHDAIteOEF44ow\",\"name\":\"demo\",\"platform\":\"aws-batch\",\"status\":\"AVAILABLE\",\"message\":null,\"lastUsed\":null,\"primary\":null,\"workspaceName\":null,\"visibility\":null}]}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/compute-envs/isnEDBLvHDAIteOEF44ow"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("compute_env_view")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("POST").withPath("/pipelines")
+                        .withBody("{\"name\":\"pipelineNew\",\"launch\":{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\",\"pipeline\":\"https://github.com/grananda/nextflow-hello\",\"workDir\":\"s3://nextflow-ci/julio\",\"revision\":\"main\",\"resume\":false,\"pullLatest\":false,\"stubRun\":false}}")
+                        .withContentType(MediaType.APPLICATION_JSON), exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withBody(loadResource("pipelines_add_response"))
+                        .withContentType(MediaType.APPLICATION_JSON)
+        );
+
         ExecOut out = exec(mock, "pipelines", "import", tempFile(new String(loadResource("pipelines_add"), StandardCharsets.UTF_8), "data", ".json"), "-n", "pipelineNew", "-c", "demo");
+
+        assertEquals("", out.stdErr);
+        assertEquals(new PipelinesAdded(USER_WORKSPACE_NAME, "pipelineNew").toString(), out.stdOut);
+        assertEquals(0, out.exitCode);
+    }
+
+    @Test
+    void testImportWithoutWorkdir(MockServerClient mock) throws IOException {
+
+        mock.when(
+                request().withMethod("GET").withPath("/compute-envs"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"computeEnvs\":[{\"id\":\"isnEDBLvHDAIteOEF44ow\",\"name\":\"demo\",\"platform\":\"aws-batch\",\"status\":\"AVAILABLE\",\"message\":null,\"lastUsed\":null,\"primary\":null,\"workspaceName\":null,\"visibility\":null}]}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/compute-envs/isnEDBLvHDAIteOEF44ow"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("compute_env_view")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("POST").withPath("/pipelines")
+                        .withBody("{\"name\":\"pipelineNew\",\"launch\":{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\",\"pipeline\":\"https://github.com/grananda/nextflow-hello\",\"workDir\":\"s3://nextflow-ci/jordeu\",\"revision\":\"main\",\"resume\":false,\"pullLatest\":false,\"stubRun\":false}}")
+                        .withContentType(MediaType.APPLICATION_JSON), exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withBody(loadResource("pipelines_add_response"))
+                        .withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(mock, "pipelines", "import", tempFile(new String(loadResource("pipelines_add_no_workdir"), StandardCharsets.UTF_8), "data", ".json"), "-n", "pipelineNew", "-c", "demo");
 
         assertEquals("", out.stdErr);
         assertEquals(new PipelinesAdded(USER_WORKSPACE_NAME, "pipelineNew").toString(), out.stdOut);

--- a/src/test/java/io/seqera/tower/cli/pipelines/PipelinesCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/pipelines/PipelinesCmdTest.java
@@ -553,7 +553,7 @@ class PipelinesCmdTest extends BaseCmdTest {
                         .withContentType(MediaType.APPLICATION_JSON)
         );
 
-        ExecOut out = exec(mock, "-v", "pipelines", "import", tempFile(new String(loadResource("pipelines_add"), StandardCharsets.UTF_8), "data", ".json"), "-n", "pipelineNew");
+        ExecOut out = exec(mock, "pipelines", "import", tempFile(new String(loadResource("pipelines_add"), StandardCharsets.UTF_8), "data", ".json"), "-n", "pipelineNew");
 
         assertEquals("", out.stdErr);
         assertEquals(new PipelinesAdded(USER_WORKSPACE_NAME, "pipelineNew").toString(), out.stdOut);

--- a/src/test/resources/runcmd/pipelines_add_no_workdir.json
+++ b/src/test/resources/runcmd/pipelines_add_no_workdir.json
@@ -1,9 +1,7 @@
 {
   "name": "pipelineNew",
   "launch": {
-    "computeEnvId": "isnEDBLvHDAIteOEF44ow",
     "pipeline": "https://github.com/grananda/nextflow-hello",
-    "workDir": "s3://nextflow-ci/julio",
     "revision": "main",
     "resume": false,
     "pullLatest": false,


### PR DESCRIPTION
Following same `pipelines add` behaviour, at `pipelines import` parameters that can be platform dependent (`workDir`, `preRunScript`, `postRunScript`) are inherited from the compute environment when they are not provided.