### PR TITLE
Consistently name comand line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,12 @@ Comprehensive details about Tower Forge are availible in the [user documentation
 Add a pre-configured pipeline that can be re-used later:
 
 ```bash
-tw pipelines add --name=my_sleepy_pipeline --params=<(echo 'timeout: 60') https://github.com/pditommaso/nf-sleep
+tw pipelines add --name=my_sleepy_pipeline --params-file=<(echo 'timeout: 60') https://github.com/pditommaso/nf-sleep
 ```
 
 Pipelines consist of a pipeline repository, launch parameters, and a Compute Environment. When a Compute Environment is not specified the primary one is used.
 
-> The `params` option should be a YAML or JSON file. Here we use a Bash pipe to convert a command into a YAML file automatically.
+> The `params-file` option should be a YAML or JSON file. Here we use a Bash pipe to convert a command into a YAML file automatically.
 
 ### 9. Launch it!
 
@@ -149,7 +149,7 @@ tw launch my_sleepy_pipeline
 Launch the pipeline with different parameters:
 
 ```bash
-tw launch my_sleepy_pipeline --params=<(echo 'timeout: 30')
+tw launch my_sleepy_pipeline --params-file=<(echo 'timeout: 30')
 ```
 
 ### 11. Update a pipeline
@@ -157,7 +157,7 @@ tw launch my_sleepy_pipeline --params=<(echo 'timeout: 30')
 The default launch parameters can be changed using the `update` command:
 
 ```bash
-tw pipelines update --name=my_sleepy_pipeline --params=<(echo 'timeout: 30')
+tw pipelines update --name=my_sleepy_pipeline --params-file=<(echo 'timeout: 30')
 ```
 
 ### 12. Launch a pipeline directly
@@ -183,7 +183,7 @@ The `tw launch` command provides a similar user experience to `nextflow run` wit
 1. Run a Pipeline pre-defined in a Tower Workspace with a custom parameters file:
 
     ```bash
-    tw launch my_sleepy_pipeline --params=./my_params.yaml
+    tw launch my_sleepy_pipeline --params-file=./my_params.yaml
     ```
 
 2. Run any Nextflow pipeline using the primary Compute Environment:
@@ -201,7 +201,7 @@ The `tw launch` command provides a similar user experience to `nextflow run` wit
 4. Run any Nextflow pipeline and adjust the default profile and parameters:
 
     ```bash
-    tw launch nf-core/rnaseq --profile=test,docker --params=./my_params.yaml --compute-env=my_aws_ce
+    tw launch nf-core/rnaseq --profile=test,docker --params-file=./my_params.yaml --compute-env=my_aws_ce
     ```
 
 ## Activate autocompletion

--- a/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
@@ -48,16 +48,16 @@ public class LaunchCmd extends AbstractRootCmd {
     @CommandLine.Mixin
     public WorkspaceOptionalOptions workspace;
 
-    @Option(names = {"--params"}, description = "Parameters file.")
+    @Option(names = {"--params"}, description = "Pipeline parameters in either JSON or YML format.")
     Path params;
 
-    @Option(names = {"-c", "--compute-env"}, description = "Compute environment name [default: primary workspace].")
+    @Option(names = {"-c", "--compute-env"}, description = "Compute environment name [default: primary compute environment].")
     String computeEnv;
 
-    @Option(names = {"--work-dir"}, description = "Working directory.")
+    @Option(names = {"--work-dir"}, description = "Path where the pipeline scratch data is stored.")
     String workDir;
 
-    @Option(names = {"-p", "--profile"}, split = ",", description = "Configuration profiles.")
+    @Option(names = {"-p", "--profile"}, split = ",", description = "Comma-separated list of one or more configuration profile names you want to use for this pipeline execution.")
     List<String> profile;
 
     @Option(names = {"-r", "--revision"}, description = "A valid repository commit Id, tag or branch name.")
@@ -144,13 +144,13 @@ public class LaunchCmd extends AbstractRootCmd {
 
     public static class AdvancedOptions {
 
-        @Option(names = {"--config"}, description = "Additional Nextflow config settings can be provided in the above field. These settings will be included in the `nextflow.config` file for this execution.")
+        @Option(names = {"--config"}, description = "Additional Nextflow config settings file.")
         public Path config;
 
-        @Option(names = {"--pre-run"}, description = "Pre-run script.")
+        @Option(names = {"--pre-run"}, description = "Bash script that is executed in the same environment where Nextflow runs just before the pipeline is launched.")
         public Path preRunScript;
 
-        @Option(names = {"--post-run"}, description = "Post-run script.")
+        @Option(names = {"--post-run"}, description = "Bash script that is executed in the same environment where Nextflow runs immediately after the pipeline completion.")
         public Path postRunScript;
 
         @Option(names = {"--pull-latest"}, description = "Enable Nextflow to pull the latest repository version before running the pipeline.")
@@ -159,13 +159,13 @@ public class LaunchCmd extends AbstractRootCmd {
         @Option(names = {"--stub-run"}, description = "Execute the workflow replacing process scripts with command stubs.")
         public Boolean stubRun;
 
-        @Option(names = {"--main-script"}, description = "Specify the pipeline main script file if different from `main.nf`.")
+        @Option(names = {"--main-script"}, description = "Pipeline main script file if different from `main.nf`.")
         public String mainScript;
 
-        @Option(names = {"--entry-name"}, description = "Specify the main workflow name to be executed when using DLS2 syntax.")
+        @Option(names = {"--entry-name"}, description = "Main workflow name to be executed when using DLS2 syntax.")
         public String entryName;
 
-        @Option(names = {"--schema-name"}, description = "Enter schema name.")
+        @Option(names = {"--schema-name"}, description = "Schema name.")
         public String schemaName;
 
     }

--- a/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
@@ -48,8 +48,8 @@ public class LaunchCmd extends AbstractRootCmd {
     @CommandLine.Mixin
     public WorkspaceOptionalOptions workspace;
 
-    @Option(names = {"--params"}, description = "Pipeline parameters in either JSON or YML format.")
-    Path params;
+    @Option(names = {"--params-file"}, description = "Pipeline parameters in either JSON or YML format.")
+    Path paramsFile;
 
     @Option(names = {"-c", "--compute-env"}, description = "Compute environment name [default: primary compute environment].")
     String computeEnv;
@@ -100,7 +100,7 @@ public class LaunchCmd extends AbstractRootCmd {
                 .pipeline(base.getPipeline())
                 .computeEnvId(base.getComputeEnvId())
                 .workDir(coalesce(workDir, base.getWorkDir()))
-                .paramsText(coalesce(readString(params), base.getParamsText()))
+                .paramsText(coalesce(readString(paramsFile), base.getParamsText()))
                 .configProfiles(coalesce(profile, base.getConfigProfiles()))
                 .revision(coalesce(revision, base.getRevision()))
                 .configText(coalesce(readString(adv().config), base.getConfigText()))

--- a/src/main/java/io/seqera/tower/cli/commands/actions/UpdateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/actions/UpdateCmd.java
@@ -66,7 +66,7 @@ public class UpdateCmd extends AbstractActionsCmd {
                 .pipeline(action.getLaunch().getPipeline())
                 .revision(opts.revision)
                 .workDir(workDirValue)
-                .configProfiles(opts.profiles)
+                .configProfiles(opts.profile)
                 .paramsText(FilesHelper.readString(opts.params))
 
                 // Advanced options

--- a/src/main/java/io/seqera/tower/cli/commands/actions/UpdateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/actions/UpdateCmd.java
@@ -67,7 +67,7 @@ public class UpdateCmd extends AbstractActionsCmd {
                 .revision(opts.revision)
                 .workDir(workDirValue)
                 .configProfiles(opts.profile)
-                .paramsText(FilesHelper.readString(opts.params))
+                .paramsText(FilesHelper.readString(opts.paramsFile))
 
                 // Advanced options
                 .configText(FilesHelper.readString(opts.config))

--- a/src/main/java/io/seqera/tower/cli/commands/actions/add/AbstractAddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/actions/add/AbstractAddCmd.java
@@ -60,7 +60,7 @@ public abstract class AbstractAddCmd extends AbstractApiCmd {
                 .pipeline(pipeline)
                 .revision(opts.revision)
                 .workDir(workDirValue)
-                .configProfiles(opts.profiles)
+                .configProfiles(opts.profile)
                 .paramsText(FilesHelper.readString(opts.params))
 
                 // Advanced options

--- a/src/main/java/io/seqera/tower/cli/commands/actions/add/AbstractAddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/actions/add/AbstractAddCmd.java
@@ -61,7 +61,7 @@ public abstract class AbstractAddCmd extends AbstractApiCmd {
                 .revision(opts.revision)
                 .workDir(workDirValue)
                 .configProfiles(opts.profile)
-                .paramsText(FilesHelper.readString(opts.params))
+                .paramsText(FilesHelper.readString(opts.paramsFile))
 
                 // Advanced options
                 .configText(FilesHelper.readString(opts.config))

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/AddCmd.java
@@ -71,7 +71,7 @@ public class AddCmd extends AbstractPipelinesCmd {
                                 .revision(opts.revision)
                                 .workDir(workDirValue)
                                 .configProfiles(opts.profile)
-                                .paramsText(FilesHelper.readString(opts.params))
+                                .paramsText(FilesHelper.readString(opts.paramsFile))
 
                                 // Advanced options
                                 .configText(FilesHelper.readString(opts.config))

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/AddCmd.java
@@ -70,7 +70,7 @@ public class AddCmd extends AbstractPipelinesCmd {
                                 .pipeline(pipeline)
                                 .revision(opts.revision)
                                 .workDir(workDirValue)
-                                .configProfiles(opts.profiles)
+                                .configProfiles(opts.profile)
                                 .paramsText(FilesHelper.readString(opts.params))
 
                                 // Advanced options

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/LaunchOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/LaunchOptions.java
@@ -27,8 +27,8 @@ public class LaunchOptions {
     @Option(names = {"-p", "--profile"}, split = ",", description = "Comma-separated list of one or more configuration profile names you want to use for this pipeline execution.")
     public List<String> profile;
 
-    @Option(names = {"--params"}, description = "Pipeline parameters in either JSON or YML format.")
-    public Path params;
+    @Option(names = {"--params-file"}, description = "Pipeline parameters in either JSON or YML format.")
+    public Path paramsFile;
 
     @Option(names = {"--revision"}, description = "A valid repository commit Id, tag or branch name.")
     public String revision;

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/LaunchOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/LaunchOptions.java
@@ -24,8 +24,8 @@ public class LaunchOptions {
     @Option(names = {"--work-dir"}, description = "Path where the pipeline scratch data is stored.")
     public String workDir;
 
-    @Option(names = {"-p", "--profiles"}, split = ",", description = "Comma-separated list of one or more configuration profile names you want to use for this pipeline execution.")
-    public List<String> profiles;
+    @Option(names = {"-p", "--profile"}, split = ",", description = "Comma-separated list of one or more configuration profile names you want to use for this pipeline execution.")
+    public List<String> profile;
 
     @Option(names = {"--params"}, description = "Pipeline parameters in either JSON or YML format.")
     public Path params;

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/UpdateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/UpdateCmd.java
@@ -81,7 +81,7 @@ public class UpdateCmd extends AbstractPipelinesCmd {
                                 .revision(coalesce(opts.revision, launch.getRevision()))
                                 .workDir(coalesce(opts.workDir, launch.getWorkDir()))
                                 .configProfiles(coalesce(opts.profile, launch.getConfigProfiles()))
-                                .paramsText(coalesce(FilesHelper.readString(opts.params), launch.getParamsText()))
+                                .paramsText(coalesce(FilesHelper.readString(opts.paramsFile), launch.getParamsText()))
 
                                 // Advanced options
                                 .configText(coalesce(FilesHelper.readString(opts.config), launch.getConfigText()))

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/UpdateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/UpdateCmd.java
@@ -17,8 +17,6 @@ import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.pipelines.PipelinesUpdated;
 import io.seqera.tower.cli.utils.FilesHelper;
 import io.seqera.tower.model.ComputeEnv;
-import io.seqera.tower.model.DescribeLaunchResponse;
-import io.seqera.tower.model.DescribePipelineResponse;
 import io.seqera.tower.model.Launch;
 import io.seqera.tower.model.PipelineDbDto;
 import io.seqera.tower.model.UpdatePipelineRequest;
@@ -82,7 +80,7 @@ public class UpdateCmd extends AbstractPipelinesCmd {
                                 .pipeline(coalesce(pipeline, launch.getPipeline()))
                                 .revision(coalesce(opts.revision, launch.getRevision()))
                                 .workDir(coalesce(opts.workDir, launch.getWorkDir()))
-                                .configProfiles(coalesce(opts.profiles, launch.getConfigProfiles()))
+                                .configProfiles(coalesce(opts.profile, launch.getConfigProfiles()))
                                 .paramsText(coalesce(FilesHelper.readString(opts.params), launch.getParamsText()))
 
                                 // Advanced options

--- a/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
@@ -76,7 +76,7 @@ public class RelaunchCmd extends AbstractRunsCmd {
                 .pipeline(pipeline != null ? pipeline : launch.getPipeline())
                 .workDir(opts.workDir != null ? opts.workDir : workflow.getWorkDir())
                 .revision(opts.revision != null ? opts.revision : workflow.getRevision())
-                .configProfiles(opts.profiles != null ? opts.profiles : launch.getConfigProfiles())
+                .configProfiles(opts.profile != null ? opts.profile : launch.getConfigProfiles())
                 .configText(opts.config != null ? FilesHelper.readString(opts.config) : workflow.getConfigText())
                 .paramsText(opts.params != null ? FilesHelper.readString(opts.params) : launch.getParamsText())
                 .preRunScript(opts.preRunScript != null ? FilesHelper.readString(opts.preRunScript) : launch.getPreRunScript())

--- a/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
@@ -78,7 +78,7 @@ public class RelaunchCmd extends AbstractRunsCmd {
                 .revision(opts.revision != null ? opts.revision : workflow.getRevision())
                 .configProfiles(opts.profile != null ? opts.profile : launch.getConfigProfiles())
                 .configText(opts.config != null ? FilesHelper.readString(opts.config) : workflow.getConfigText())
-                .paramsText(opts.params != null ? FilesHelper.readString(opts.params) : launch.getParamsText())
+                .paramsText(opts.paramsFile != null ? FilesHelper.readString(opts.paramsFile) : launch.getParamsText())
                 .preRunScript(opts.preRunScript != null ? FilesHelper.readString(opts.preRunScript) : launch.getPreRunScript())
                 .postRunScript(opts.postRunScript != null ? FilesHelper.readString(opts.postRunScript) : launch.getPostRunScript())
                 .mainScript(opts.mainScript != null ? opts.mainScript : launch.getPostRunScript())

--- a/src/test/java/io/seqera/tower/cli/pipelines/PipelinesCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/pipelines/PipelinesCmdTest.java
@@ -147,7 +147,7 @@ class PipelinesCmdTest extends BaseCmdTest {
                 response().withStatusCode(200).withBody("{\"pipeline\":{\"pipelineId\":18388134856008,\"name\":\"sleep_one_minute\",\"description\":null,\"icon\":null,\"repository\":\"https://github.com/pditommaso/nf-sleep\",\"userId\":4,\"userName\":\"jordi\",\"userFirstName\":null,\"userLastName\":null,\"orgId\":null,\"orgName\":null,\"workspaceId\":null,\"workspaceName\":null,\"visibility\":null}}").withContentType(MediaType.APPLICATION_JSON)
         );
 
-        ExecOut out = exec(mock, "pipelines", "add", "-n", "sleep_one_minute", "--params", tempFile("timeout: 60\n", "params", ".yml"), "https://github.com/pditommaso/nf-sleep");
+        ExecOut out = exec(mock, "pipelines", "add", "-n", "sleep_one_minute", "--params-file", tempFile("timeout: 60\n", "params", ".yml"), "https://github.com/pditommaso/nf-sleep");
 
         assertEquals("", out.stdErr);
         assertEquals(new PipelinesAdded(USER_WORKSPACE_NAME, "sleep_one_minute").toString(), out.stdOut);


### PR DESCRIPTION
### Description

In general, when it is possible, we tend to use same options that `nextflow run` is using.

- Use always `--profile` instead of `--profiles`. Resolves #160 
- Use `--params-file` instead of only `--params`. This is what Nextflow is using and also when we've single parameters (see #89) will make more sense to distinguish the parameters that you pass from a file and the ones that you pass as a command option.