### PR TITLE
Check that dataset path file exists

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/datasets/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datasets/AddCmd.java
@@ -13,12 +13,14 @@ package io.seqera.tower.cli.commands.datasets;
 
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.global.WorkspaceRequiredOptions;
+import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.datasets.DatasetCreate;
 import io.seqera.tower.model.CreateDatasetRequest;
 import io.seqera.tower.model.CreateDatasetResponse;
 import picocli.CommandLine;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
@@ -26,7 +28,7 @@ import java.nio.file.Path;
         name = "add",
         description = "Create a workspace dataset."
 )
-public class AddCmd extends AbstractDatasetsCmd{
+public class AddCmd extends AbstractDatasetsCmd {
 
     @CommandLine.Option(names = {"-n", "--name"}, description = "Dataset name.", required = true)
     public String name;
@@ -45,6 +47,15 @@ public class AddCmd extends AbstractDatasetsCmd{
 
     @Override
     protected Response exec() throws ApiException, IOException {
+        File dataset = fileName.toFile();
+        if (!dataset.exists()) {
+            throw new TowerException(String.format("File path '%s' do not exists.", fileName));
+        }
+
+        if (dataset.isDirectory()) {
+            throw new TowerException(String.format("File path '%s' must be a file, not a directory.", fileName));
+        }
+
         Long wspId = workspaceId(workspace.workspace);
         CreateDatasetRequest request = new CreateDatasetRequest();
         request.setName(name);

--- a/src/test/java/io/seqera/tower/cli/datasets/DatasetsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/datasets/DatasetsCmdTest.java
@@ -33,6 +33,7 @@ import org.mockserver.model.MediaType;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.Arrays;
 
 import static io.seqera.tower.cli.utils.JsonHelper.parseJson;
@@ -308,7 +309,7 @@ public class DatasetsCmdTest extends BaseCmdTest {
 
         ExecOut out = exec(format, mock, "datasets", "add", "-w", "249664655368293", "-n", "name", "path/that/do/not/exist/file.tsv");
 
-        assertEquals(errorMessage(out.app, new TowerException(String.format("File path '%s' do not exists.", "path/that/do/not/exist/file.tsv"))), out.stdErr);
+        assertEquals(errorMessage(out.app, new TowerException(String.format("File path '%s' do not exists.", Path.of("path/that/do/not/exist/file.tsv")))), out.stdErr);
         assertEquals("", out.stdOut);
         assertEquals(1, out.exitCode);
     }

--- a/src/test/java/io/seqera/tower/cli/datasets/DatasetsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/datasets/DatasetsCmdTest.java
@@ -14,6 +14,7 @@ package io.seqera.tower.cli.datasets;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.seqera.tower.cli.BaseCmdTest;
 import io.seqera.tower.cli.commands.enums.OutputType;
+import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.responses.datasets.DatasetCreate;
 import io.seqera.tower.cli.responses.datasets.DatasetDelete;
 import io.seqera.tower.cli.responses.datasets.DatasetDownload;
@@ -299,5 +300,16 @@ public class DatasetsCmdTest extends BaseCmdTest {
         assertOutput(format, out, new DatasetUpdate("dataset1", "249664655368293", "4D9TP0w2pM0qmwqVHgrgBK"));
         assertEquals("", out.stdErr);
         assertEquals(0, out.exitCode);
+    }
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testFileNotExistsError(OutputType format, MockServerClient mock) throws IOException {
+
+        ExecOut out = exec(format, mock, "datasets", "add", "-w", "249664655368293", "-n", "name", "path/that/do/not/exist/file.tsv");
+
+        assertEquals(errorMessage(out.app, new TowerException(String.format("File path '%s' do not exists.", "path/that/do/not/exist/file.tsv"))), out.stdErr);
+        assertEquals("", out.stdOut);
+        assertEquals(1, out.exitCode);
     }
 }


### PR DESCRIPTION
## Description

Adds a validation check at command `tw datasets add ... <dataset_file_path>` to verify that the file exists before creating the dataset request. Fixes #187 
