### PR TITLE
Improve error message for invalid workspace ids

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/AbstractApiCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/AbstractApiCmd.java
@@ -16,6 +16,7 @@ import io.seqera.tower.ApiException;
 import io.seqera.tower.api.DefaultApi;
 import io.seqera.tower.cli.Tower;
 import io.seqera.tower.cli.exceptions.ComputeEnvNotFoundException;
+import io.seqera.tower.cli.exceptions.InvalidWorkspaceParameterException;
 import io.seqera.tower.cli.exceptions.NoComputeEnvironmentException;
 import io.seqera.tower.cli.exceptions.OrganizationNotFoundException;
 import io.seqera.tower.cli.exceptions.ShowUsageException;
@@ -28,7 +29,6 @@ import io.seqera.tower.model.ListComputeEnvsResponseEntry;
 import io.seqera.tower.model.ListWorkspacesAndOrgResponse;
 import io.seqera.tower.model.OrgAndWorkspaceDbDto;
 import io.seqera.tower.model.User;
-import io.swagger.annotations.Api;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.logging.LoggingFeature;
 import org.glassfish.jersey.media.multipart.BodyPart;
@@ -187,7 +187,10 @@ public abstract class AbstractApiCmd extends AbstractCmd {
             if (workspaceId == null) {
                 if (workspaceRef.contains("/")) {
                     String[] wspRefs = workspaceRef.split(WORKSPACE_REF_SEPARATOR);
-                    OrgAndWorkspaceDbDto orgAndWorkspaceDbDto = this.findOrgAndWorkspaceByName(wspRefs[0], wspRefs[1]);
+                    if (wspRefs.length != 2) {
+                        throw new InvalidWorkspaceParameterException(workspaceRef);
+                    }
+                    OrgAndWorkspaceDbDto orgAndWorkspaceDbDto = this.findOrgAndWorkspaceByName(wspRefs[0].strip(), wspRefs[1].strip());
                     if (orgAndWorkspaceDbDto != null) {
                         workspaceName = orgAndWorkspaceDbDto.getWorkspaceName();
                         workspaceId = orgAndWorkspaceDbDto.getWorkspaceId();
@@ -195,7 +198,11 @@ public abstract class AbstractApiCmd extends AbstractCmd {
                         orgId = orgAndWorkspaceDbDto.getOrgId();
                     }
                 } else {
-                    workspaceId = Long.valueOf(workspaceRef);
+                    try {
+                        workspaceId = Long.valueOf(workspaceRef);
+                    } catch (NumberFormatException e) {
+                        throw new InvalidWorkspaceParameterException(workspaceRef);
+                    }
                 }
             }
         }

--- a/src/main/java/io/seqera/tower/cli/exceptions/InvalidWorkspaceParameterException.java
+++ b/src/main/java/io/seqera/tower/cli/exceptions/InvalidWorkspaceParameterException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2021, Seqera Labs.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This Source Code Form is "Incompatible With Secondary Licenses", as
+ * defined by the Mozilla Public License, v. 2.0.
+ */
+
+package io.seqera.tower.cli.exceptions;
+
+public class InvalidWorkspaceParameterException extends TowerException {
+    public InvalidWorkspaceParameterException(String workspaceRef) {
+        super(String.format("Invalid workspace parameter '%s'. Expected format '<organization_name>/<workspace_name>' or '<workspace_numeric_identifier>'.", workspaceRef));
+    }
+}


### PR DESCRIPTION
Bad usage examples that now give a better error message:

```
tw compute-envs list --workspace "my_org /"
```

```
tw compute-envs list --workspace missing_org
```

And now it's trimming blank spaces so:
```
tw compute-envs list --workspace " my_org / my_wsp "
```
is valid like the equivalent:
```
tw compute-envs list --workspace my_org/my_wsp
```

Fixes #182