### PR TITLE
Customize HTTP agent header

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
         env:
           GITHUB_USERNAME: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GH_SEQERA_TOKEN }}
+          PLATFORM: linux-x86_64
 
       - name: Upload linux native image artifact
         uses: actions/upload-artifact@v2
@@ -109,6 +110,7 @@ jobs:
         env:
           GITHUB_USERNAME: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GH_SEQERA_TOKEN }}
+          PLATFORM: osx-x86_64
 
       - name: Upload Mac native image artifact
         uses: actions/upload-artifact@v2
@@ -169,6 +171,7 @@ jobs:
         env:
           GITHUB_USERNAME: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GH_SEQERA_TOKEN }}
+          PLATFORM: windows-x86_64
 
       - name: Upload Windows native image artifact
         uses: actions/upload-artifact@v2

--- a/build.gradle
+++ b/build.gradle
@@ -51,10 +51,12 @@ task buildInfo {
         def version = rootProject.file('VERSION').text.trim()
         def versionApi = rootProject.file('VERSION-API').text.trim()
         def commitId = System.env.getOrDefault("GITHUB_SHA", "unknown").substring(0,7)
+        def platform = System.env.getOrDefault("PLATFORM", "java")
         def info = """\
                     version=${version}
                     versionApi=${versionApi}
                     commitId=${commitId}
+                    platform=${platform}
                 """.stripIndent().toString()
         def f = file("src/main/resources/META-INF/build-info.properties")
         f.parentFile.mkdirs()

--- a/src/main/java/io/seqera/tower/cli/commands/AbstractApiCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/AbstractApiCmd.java
@@ -43,6 +43,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -91,10 +92,25 @@ public abstract class AbstractApiCmd extends AbstractCmd {
             client.setServerIndex(null);
             client.setBasePath(app().url);
             client.setBearerToken(app().token);
+
+            // Set HTTP Agent header
+            Properties props = getCliProperties();
+            client.setUserAgent(String.format("tw/%s (%s)", props.get("version"), props.get("platform")));
+
             api = new DefaultApi(client);
         }
 
         return api;
+    }
+
+    protected Properties getCliProperties() throws ApiException {
+        Properties properties = new Properties();
+        try {
+            properties.load(this.getClass().getResourceAsStream("/META-INF/build-info.properties"));
+        } catch (IOException e) {
+            throw new ApiException("loading build-info.properties");
+        }
+        return properties;
     }
 
     private ApiClient buildApiClient() {

--- a/src/main/java/io/seqera/tower/cli/commands/InfoCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/InfoCmd.java
@@ -81,10 +81,4 @@ public class InfoCmd extends AbstractRootCmd {
 
         return new InfoResponse(connectionCheck, versionCheck, credentialsCheck, opts);
     }
-
-    private Properties getCliProperties() throws IOException {
-        Properties properties = new Properties();
-        properties.load(this.getClass().getResourceAsStream("/META-INF/build-info.properties"));
-        return properties;
-    }
 }


### PR DESCRIPTION
## Description

Define the HTTP agent header as:
```
User-Agent: tw/<cli version> (<platform>)
```
For platform I mean the same suffix that we add at the release assets: `linux-x86_64`, `osx-x86_64` and `windows-x86_64`.

Example:
```
User-Agent: tw/0.5.1 (linux-x86_64)
```

Fixes #192 

## Test guidelines.

Check the different platform binaries with this command:
```
tw -v info
```

It should show the new `User-Agent` header at the HTTP request logs.