### PR TITLE
Add custom run name

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
@@ -54,6 +54,9 @@ public class LaunchCmd extends AbstractRootCmd {
     @Option(names = {"-c", "--compute-env"}, description = "Compute environment name [default: primary compute environment].")
     String computeEnv;
 
+    @Option(names = {"-n", "--name"}, description = "Custom workflow run name")
+    String name;
+
     @Option(names = {"--work-dir"}, description = "Path where the pipeline scratch data is stored.")
     String workDir;
 
@@ -99,6 +102,7 @@ public class LaunchCmd extends AbstractRootCmd {
                 .id(base.getId())
                 .pipeline(base.getPipeline())
                 .computeEnvId(base.getComputeEnvId())
+                .runName(coalesce(name, base.getRunName()))
                 .workDir(coalesce(workDir, base.getWorkDir()))
                 .paramsText(coalesce(readString(paramsFile), base.getParamsText()))
                 .configProfiles(coalesce(profile, base.getConfigProfiles()))

--- a/src/test/java/io/seqera/tower/cli/LaunchCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/LaunchCmdTest.java
@@ -231,7 +231,7 @@ class LaunchCmdTest extends BaseCmdTest {
         );
 
         // Run the command
-        ExecOut out = exec(format, mock, "-v", "launch", "sarek", "-n", "custom_run_name");
+        ExecOut out = exec(format, mock, "launch", "sarek", "-n", "custom_run_name");
 
         // Assert results
         assertOutput(format, out, new RunSubmited("35aLiS0bIM5efd", baseUserUrl(mock, "jordi"), USER_WORKSPACE_NAME));


### PR DESCRIPTION
## Description

Allow to set the run name at `tw launch --name <custom_name> ... `

Fixes #200 and #150

## Test guidelines

Launch a pipeline using the flag `-n / --name`.