### PR TITLE
Allow to wait for a given status after creating a compute environment and launching a workflow.

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/AbstractApiCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/AbstractApiCmd.java
@@ -15,6 +15,7 @@ import io.seqera.tower.ApiClient;
 import io.seqera.tower.ApiException;
 import io.seqera.tower.api.DefaultApi;
 import io.seqera.tower.cli.Tower;
+import io.seqera.tower.cli.commands.enums.OutputType;
 import io.seqera.tower.cli.exceptions.ComputeEnvNotFoundException;
 import io.seqera.tower.cli.exceptions.NoComputeEnvironmentException;
 import io.seqera.tower.cli.exceptions.OrganizationNotFoundException;
@@ -23,7 +24,6 @@ import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.exceptions.WorkspaceNotFoundException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.model.ComputeEnv;
-import io.seqera.tower.model.ListComputeEnvsResponse;
 import io.seqera.tower.model.ListComputeEnvsResponseEntry;
 import io.seqera.tower.model.ListWorkspacesAndOrgResponse;
 import io.seqera.tower.model.OrgAndWorkspaceDbDto;
@@ -38,6 +38,7 @@ import picocli.CommandLine;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.net.URLConnection;
 import java.util.HashMap;
 import java.util.List;
@@ -75,7 +76,7 @@ public abstract class AbstractApiCmd extends AbstractCmd {
         return String.format("[%s / %s]", orgName, workspaceName);
     }
 
-    private Tower app() {
+    protected Tower app() {
         return (Tower) getSpec().root().userObject();
     }
 
@@ -267,24 +268,6 @@ public abstract class AbstractApiCmd extends AbstractCmd {
         return orgAndWorkspaceDbDtoList.stream().findFirst().orElse(null);
     }
 
-    protected OrgAndWorkspaceDbDto findOrganizationByName(String organizationName) throws ApiException {
-        ListWorkspacesAndOrgResponse workspacesAndOrgResponse = api().listWorkspacesUser(userId());
-
-        if (workspacesAndOrgResponse.getOrgsAndWorkspaces() == null) {
-            throw new OrganizationNotFoundException(organizationName);
-        }
-
-        List<OrgAndWorkspaceDbDto> orgAndWorkspaceDbDtoList = workspacesAndOrgResponse
-                .getOrgsAndWorkspaces()
-                .stream()
-                .filter(
-                        item -> Objects.equals(item.getWorkspaceName(), null) && Objects.equals(item.getOrgName(), organizationName)
-                )
-                .collect(Collectors.toList());
-
-        return orgAndWorkspaceDbDtoList.stream().findFirst().orElseThrow(() -> new OrganizationNotFoundException(organizationName));
-    }
-
     protected OrgAndWorkspaceDbDto findOrganizationByRef(String organizationRef) throws ApiException {
         ListWorkspacesAndOrgResponse workspacesAndOrgResponse = api().listWorkspacesUser(userId());
 
@@ -301,19 +284,6 @@ public abstract class AbstractApiCmd extends AbstractCmd {
                 .collect(Collectors.toList());
 
         return orgAndWorkspaceDbDtoList.stream().findFirst().orElseThrow(() -> new OrganizationNotFoundException(organizationRef));
-    }
-
-    protected ComputeEnv findComputeEnvironmentByName(Long workspaceId, String name) throws ApiException {
-        ListComputeEnvsResponse listComputeEnvsResponse = api().listComputeEnvs(null, workspaceId);
-
-        ListComputeEnvsResponseEntry listComputeEnvsResponseEntry = listComputeEnvsResponse
-                .getComputeEnvs()
-                .stream()
-                .filter(it -> Objects.equals(it.getName(), name))
-                .findFirst()
-                .orElseThrow(() -> new ComputeEnvNotFoundException(name, workspaceId));
-
-        return api().describeComputeEnv(listComputeEnvsResponseEntry.getId(), workspaceId).getComputeEnv();
     }
 
     private void loadUser() throws ApiException {
@@ -377,12 +347,17 @@ public abstract class AbstractApiCmd extends AbstractCmd {
     @Override
     public Integer call() {
         try {
-            return outputFormat(app().getOut(), exec(), app().output);
+            Response response = exec();
+            int exitCode = outputFormat(app().getOut(), response, app().output);
+            return onBeforeExit(exitCode, response);
         } catch (Exception e) {
             errorMessage(app(), e);
         }
-
         return CommandLine.ExitCode.SOFTWARE;
+    }
+
+    protected Integer onBeforeExit(int exitCode, Response response) throws ApiException {
+        return exitCode;
     }
 
     protected Response exec() throws ApiException, IOException {

--- a/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
@@ -12,6 +12,7 @@
 package io.seqera.tower.cli.commands;
 
 import io.seqera.tower.ApiException;
+import io.seqera.tower.cli.commands.enums.OutputType;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
 import io.seqera.tower.cli.exceptions.InvalidResponseException;
 import io.seqera.tower.cli.responses.Response;
@@ -22,6 +23,7 @@ import io.seqera.tower.model.ListPipelinesResponse;
 import io.seqera.tower.model.SubmitWorkflowLaunchRequest;
 import io.seqera.tower.model.SubmitWorkflowLaunchResponse;
 import io.seqera.tower.model.WorkflowLaunchRequest;
+import io.seqera.tower.model.WorkflowStatus;
 import picocli.CommandLine;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
@@ -35,6 +37,7 @@ import java.util.List;
 import static io.seqera.tower.cli.utils.FilesHelper.readString;
 import static io.seqera.tower.cli.utils.ModelHelper.coalesce;
 import static io.seqera.tower.cli.utils.ModelHelper.createLaunchRequest;
+import static io.seqera.tower.cli.utils.ResponseHelper.waitStatus;
 
 @Command(
         name = "launch",
@@ -62,6 +65,9 @@ public class LaunchCmd extends AbstractRootCmd {
 
     @Option(names = {"-r", "--revision"}, description = "A valid repository commit Id, tag or branch name.")
     String revision;
+
+    @Option(names = {"--wait"}, description = "Wait until given status or fail. Valid options: ${COMPLETION-CANDIDATES}.")
+    public WorkflowStatus wait;
 
     @ArgGroup(heading = "%nAdvanced options:%n", validate = false)
     AdvancedOptions adv;
@@ -132,8 +138,40 @@ public class LaunchCmd extends AbstractRootCmd {
     protected Response submitWorkflow(WorkflowLaunchRequest launch, Long wspId) throws ApiException {
         SubmitWorkflowLaunchResponse response = api().createWorkflowLaunch(new SubmitWorkflowLaunchRequest().launch(launch), wspId, null);
         String workflowId = response.getWorkflowId();
-        return new RunSubmited(workflowId, baseWorkspaceUrl(wspId), workspaceRef(wspId));
+        return new RunSubmited(workflowId, wspId, baseWorkspaceUrl(wspId), workspaceRef(wspId));
     }
+
+    @Override
+    protected Integer onBeforeExit(int exitCode, Response response) {
+
+        if (exitCode != 0 || wait == null || response == null) {
+            return exitCode;
+        }
+
+        RunSubmited submitted = (RunSubmited) response;
+        boolean showProgress = app().output != OutputType.json;
+
+        try {
+            return waitStatus(
+                    app().getOut(),
+                    showProgress,
+                    wait,
+                    WorkflowStatus.values(),
+                    () -> checkWorkflowStatus(submitted.workflowId, submitted.workspaceId)
+            );
+        } catch (InterruptedException e) {
+            return exitCode;
+        }
+    }
+
+    private WorkflowStatus checkWorkflowStatus(String workflowId, Long workspaceId) {
+        try {
+            return api().describeWorkflow(workflowId, workspaceId).getWorkflow().getStatus();
+        } catch (ApiException | NullPointerException e) {
+            return null;
+        }
+    }
+
 
     private AdvancedOptions adv() {
         if (adv == null) {

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/add/AbstractAddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/add/AbstractAddCmd.java
@@ -14,21 +14,28 @@ package io.seqera.tower.cli.commands.computeenvs.add;
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.AbstractApiCmd;
 import io.seqera.tower.cli.commands.computeenvs.platforms.Platform;
+import io.seqera.tower.cli.commands.enums.OutputType;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
 import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.responses.computeenvs.ComputeEnvAdded;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.model.ComputeConfig;
 import io.seqera.tower.model.ComputeEnv;
+import io.seqera.tower.model.ComputeEnvStatus;
 import io.seqera.tower.model.CreateComputeEnvRequest;
+import io.seqera.tower.model.CreateComputeEnvResponse;
 import io.seqera.tower.model.Credentials;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
+
+import static io.seqera.tower.cli.utils.ResponseHelper.waitStatus;
 
 @Command
 public abstract class AbstractAddCmd extends AbstractApiCmd {
@@ -42,9 +49,43 @@ public abstract class AbstractAddCmd extends AbstractApiCmd {
     @Option(names = {"-c", "--credentials"}, description = "Credentials identifier [default: workspace credentials].")
     public String credentialsRef;
 
+    @Option(names = {"--wait"}, description = "Wait until given status or fail. Valid options: ${COMPLETION-CANDIDATES}.")
+    public ComputeEnvStatus wait;
+
     @Override
     protected Response exec() throws ApiException, IOException {
         return addComputeEnv(getPlatform().type(), getPlatform().computeConfig());
+    }
+
+    @Override
+    protected Integer onBeforeExit(int exitCode, Response response) {
+
+        if (exitCode != 0 || wait == null || response == null) {
+            return exitCode;
+        }
+
+        ComputeEnvAdded added = (ComputeEnvAdded) response;
+        boolean showProgress = app().output != OutputType.json;
+
+        try {
+            return waitStatus(
+                    app().getOut(),
+                    showProgress,
+                    wait,
+                    ComputeEnvStatus.values(),
+                    () -> checkComputeEnvStatus(added.id, added.workspaceId)
+            );
+        } catch (InterruptedException e) {
+            return exitCode;
+        }
+    }
+
+    private ComputeEnvStatus checkComputeEnvStatus(String computeEnvId, Long workspaceId) {
+        try {
+            return api().describeComputeEnv(computeEnvId, workspaceId).getComputeEnv().getStatus();
+        } catch (ApiException | NullPointerException e) {
+            return null;
+        }
     }
 
     protected ComputeEnvAdded addComputeEnv(ComputeEnv.PlatformEnum platform, ComputeConfig config) throws ApiException {
@@ -52,7 +93,7 @@ public abstract class AbstractAddCmd extends AbstractApiCmd {
 
         String credsId = credentialsRef == null ? findWorkspaceCredentials(platform, wspId) : credentialsByRef(platform, wspId, credentialsRef);
 
-        api().createComputeEnv(
+        CreateComputeEnvResponse resp = api().createComputeEnv(
                 new CreateComputeEnvRequest().computeEnv(
                         new ComputeEnv()
                                 .name(name)
@@ -62,7 +103,7 @@ public abstract class AbstractAddCmd extends AbstractApiCmd {
                 ), wspId
         );
 
-        return new ComputeEnvAdded(platform.getValue(), name, workspaceRef(wspId));
+        return new ComputeEnvAdded(platform.getValue(), resp.getComputeEnvId(), name, wspId, workspaceRef(wspId));
     }
 
     private String credentialsByRef(ComputeEnv.PlatformEnum type, Long wspId, String credentialsRef) throws ApiException {

--- a/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
@@ -99,7 +99,7 @@ public class RelaunchCmd extends AbstractRunsCmd {
         Long sourceWorkspaceId = launch.getComputeEnv() != null ? launch.getComputeEnv().getWorkspaceId() : null;
         SubmitWorkflowLaunchResponse response = api().createWorkflowLaunch(submitWorkflowLaunchRequest, wspId, sourceWorkspaceId);
 
-        return new RunSubmited(response.getWorkflowId(), workflowWatchUrl(response.getWorkflowId(), wspId), workspaceRef(wspId));
+        return new RunSubmited(response.getWorkflowId(), wspId, workflowWatchUrl(response.getWorkflowId(), wspId), workspaceRef(wspId));
     }
 
     private String workflowWatchUrl(String workflowId, Long wspId) throws ApiException {

--- a/src/main/java/io/seqera/tower/cli/exceptions/ComputeEnvNotFoundException.java
+++ b/src/main/java/io/seqera/tower/cli/exceptions/ComputeEnvNotFoundException.java
@@ -16,7 +16,7 @@ public class ComputeEnvNotFoundException extends TowerException {
         super(String.format("Compute environment '%s' not found at %s workspace", name, workspaceRef));
     }
 
-    public ComputeEnvNotFoundException(String name, long workspaceId) {
-        super(String.format("Compute environment '%s' not found at %d workspace", name, workspaceId));
+    public ComputeEnvNotFoundException(String name, Long workspaceId) {
+        super(String.format("Compute environment '%s' not found at %s workspace", name, workspaceId != null ? workspaceId.toString() : "user"));
     }
 }

--- a/src/main/java/io/seqera/tower/cli/responses/computeenvs/ComputeEnvAdded.java
+++ b/src/main/java/io/seqera/tower/cli/responses/computeenvs/ComputeEnvAdded.java
@@ -16,12 +16,16 @@ import io.seqera.tower.cli.responses.Response;
 public class ComputeEnvAdded extends Response {
 
     public final String platform;
+    public final String id;
     public final String name;
+    public final Long workspaceId;
     public final String workspaceRef;
 
-    public ComputeEnvAdded(String platform, String name, String workspaceRef) {
+    public ComputeEnvAdded(String platform, String id, String name, Long workspaceId, String workspaceRef) {
         this.platform = platform;
+        this.id = id;
         this.name = name;
+        this.workspaceId = workspaceId;
         this.workspaceRef = workspaceRef;
     }
 

--- a/src/main/java/io/seqera/tower/cli/responses/runs/RunSubmited.java
+++ b/src/main/java/io/seqera/tower/cli/responses/runs/RunSubmited.java
@@ -19,11 +19,13 @@ public class RunSubmited extends Response {
 
     public final String workflowUrl;
 
+    public final Long workspaceId;
     public final String workspaceRef;
 
-    public RunSubmited(String workflowId, String baseWorkspaceUrl, String workspaceRef) {
+    public RunSubmited(String workflowId, Long workspaceId, String baseWorkspaceUrl, String workspaceRef) {
         this.workflowId = workflowId;
         this.workflowUrl = String.format("%s/watch/%s", baseWorkspaceUrl, workflowId);
+        this.workspaceId = workspaceId;
         this.workspaceRef = workspaceRef;
     }
 

--- a/src/main/java/io/seqera/tower/cli/utils/ResponseHelper.java
+++ b/src/main/java/io/seqera/tower/cli/utils/ResponseHelper.java
@@ -132,17 +132,23 @@ public class ResponseHelper {
         int maxSecondsToSleep = 120;
         int targetPos = positions.get(targetStatus);
         int currentPos;
+        S lastReported = null;
 
         if (showProgress) {
-            out.print(String.format("  Waiting '%s' status .", targetStatus));
+            out.print(String.format("  Waiting %s status...", targetStatus));
             out.flush();
         }
 
         do {
             TimeUnit.SECONDS.sleep(secondsToSleep);
-            currentPos = positions.get(checkStatus.get());
+            S status = checkStatus.get();
+            currentPos = status == null ? positions.size() : positions.get(status);
             if (showProgress) {
                 out.print('.');
+                if (lastReported != status) {
+                    out.print(String.format("%s", status));
+                    lastReported = status;
+                }
                 out.flush();
             }
             if (secondsToSleep < maxSecondsToSleep) {
@@ -151,7 +157,7 @@ public class ResponseHelper {
         } while (currentPos < targetPos);
 
         if (showProgress) {
-            out.print(currentPos == targetPos ? " OK!\n\n" : " ERROR!\n\n");
+            out.print(currentPos == targetPos ? "  [DONE]\n\n" : "  [ERROR]\n\n");
             out.flush();
         }
 

--- a/src/test/java/io/seqera/tower/cli/LaunchCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/LaunchCmdTest.java
@@ -125,7 +125,7 @@ class LaunchCmdTest extends BaseCmdTest {
         ExecOut out = exec(format, mock, "launch", "sarek");
 
         // Assert results
-        assertOutput(format, out, new RunSubmited("35aLiS0bIM5efd", baseUserUrl(mock, "jordi"), USER_WORKSPACE_NAME));
+        assertOutput(format, out, new RunSubmited("35aLiS0bIM5efd", null, baseUserUrl(mock, "jordi"), USER_WORKSPACE_NAME));
     }
 
     @ParameterizedTest
@@ -158,7 +158,7 @@ class LaunchCmdTest extends BaseCmdTest {
 
         ExecOut out = exec(format, mock, "launch", "https://github.com/nextflow-io/hello");
 
-        assertOutput(format, out, new RunSubmited("57ojrWRzTyous", baseUserUrl(mock, "jordi"), USER_WORKSPACE_NAME));
+        assertOutput(format, out, new RunSubmited("57ojrWRzTyous", null, baseUserUrl(mock, "jordi"), USER_WORKSPACE_NAME));
     }
 
     @Test
@@ -197,7 +197,7 @@ class LaunchCmdTest extends BaseCmdTest {
 
         // Assert results
         assertEquals("", out.stdErr);
-        assertEquals(new RunSubmited("35aLiS0bIM5efd", baseUserUrl(mock, "jordi"), USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new RunSubmited("35aLiS0bIM5efd", 1L, baseUserUrl(mock, "jordi"), USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -239,7 +239,7 @@ class LaunchCmdTest extends BaseCmdTest {
 
         // Assert results
         assertEquals("", out.stdErr);
-        assertEquals(new RunSubmited("52KAMEcqXFyhZ9", baseWorkspaceUrl(mock, "Seqera", "cli"), buildWorkspaceRef("Seqera", "cli")).toString(), out.stdOut);
+        assertEquals(new RunSubmited("52KAMEcqXFyhZ9", 1L, baseWorkspaceUrl(mock, "Seqera", "cli"), buildWorkspaceRef("Seqera", "cli")).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 

--- a/src/test/java/io/seqera/tower/cli/computeenvs/ComputeEnvsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/ComputeEnvsCmdTest.java
@@ -358,7 +358,7 @@ class ComputeEnvsCmdTest extends BaseCmdTest {
         );
 
         ExecOut out = exec(format, mock, "compute-envs", "import", tempFile(new String(loadResource("cejson"), StandardCharsets.UTF_8), "ce", "json"), "-n", "json", "-c", "6g0ER59L4ZoE5zpOmUP48D");
-        assertOutput(format, out, new ComputeEnvAdded(ComputeEnv.PlatformEnum.AWS_BATCH.getValue(), "json", USER_WORKSPACE_NAME));
+        assertOutput(format, out, new ComputeEnvAdded(ComputeEnv.PlatformEnum.AWS_BATCH.getValue(),  "3T6xWeFD63QIuzdAowvSTC", "json", null, USER_WORKSPACE_NAME));
     }
 
     @ParameterizedTest

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AltairPlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AltairPlatformTest.java
@@ -44,7 +44,7 @@ class AltairPlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "altair", "-n", "altair", "--work-dir", "/home/jordeu/nf", "-u", "jordi", "-H", "ssh.mydomain.net", "-q", "normal");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("altair-platform", "altair", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("altair-platform", "isnEDBLvHDAIteOEF44ow", "altair", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -66,7 +66,7 @@ class AltairPlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "altair", "-n", "altair", "--work-dir", "/home/jordeu/nf", "-u", "jordi", "-H", "ssh.mydomain.net", "-q", "normal", "--max-queue-size=200");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("altair-platform", "altair", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("altair-platform", "isnEDBLvHDAIteOEF44ow", "altair", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AwsBatchForgePlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AwsBatchForgePlatformTest.java
@@ -44,7 +44,7 @@ class AwsBatchForgePlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "aws-batch", "forge", "-n", "demo", "-r", "eu-west-1", "--work-dir", "s3://nextflow-ci/jordeu", "--max-cpus=123", "--fusion");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("aws-batch", "demo", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("aws-batch", "isnEDBLvHDAIteOEF44ow", "demo", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -66,7 +66,7 @@ class AwsBatchForgePlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "aws-batch", "forge", "-n", "demo", "-r", "eu-west-1", "--work-dir", "s3://nextflow-ci/jordeu", "--max-cpus=123", "--create-efs");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("aws-batch", "demo", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("aws-batch", "isnEDBLvHDAIteOEF44ow", "demo", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -88,7 +88,7 @@ class AwsBatchForgePlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "aws-batch", "forge", "-n", "demo", "-r", "eu-west-1", "--work-dir", "/workdir", "--max-cpus=123", "--fsx-size=1200");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("aws-batch", "demo", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("aws-batch", "isnEDBLvHDAIteOEF44ow", "demo", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -110,7 +110,7 @@ class AwsBatchForgePlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "aws-batch", "forge", "-n", "demo", "-r", "eu-west-1", "--work-dir", "s3://nextflow-ci/jordeu", "--max-cpus=123", "--fusion", "--cli-path=/bin/aws", "--min-cpus=8", "--allow-buckets=bkt1,bkt2");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("aws-batch", "demo", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("aws-batch", "isnEDBLvHDAIteOEF44ow", "demo", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AwsBatchManualPlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AwsBatchManualPlatformTest.java
@@ -44,7 +44,7 @@ class AwsBatchManualPlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "aws-batch", "manual", "-n", "manual", "-r", "eu-west-1", "--work-dir", "s3://nextflow-ci/jordeu", "--head-queue", "TowerForge-isnEDBLvHDAIteOEF44ow-head", "--compute-queue", "TowerForge-isnEDBLvHDAIteOEF44ow-work");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("aws-batch", "manual", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("aws-batch", "isnEDBLvHDAIteOEF44ow", "manual", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -66,7 +66,7 @@ class AwsBatchManualPlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "aws-batch", "manual", "-n", "manual", "-r", "eu-west-1", "--work-dir", "s3://nextflow-ci/jordeu", "--head-queue", "TowerForge-isnEDBLvHDAIteOEF44ow-head", "--compute-queue", "TowerForge-isnEDBLvHDAIteOEF44ow-work", "--cli-path=/bin/aws");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("aws-batch", "manual", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("aws-batch", "isnEDBLvHDAIteOEF44ow", "manual", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AzBatchForgePlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AzBatchForgePlatformTest.java
@@ -44,7 +44,7 @@ class AzBatchForgePlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "azure-batch", "forge", "-n", "azure", "-l", "europe", "--work-dir", "az://nextflow-ci/jordeu");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("azure-batch", "azure", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("azure-batch", "isnEDBLvHDAIteOEF44ow", "azure", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -66,7 +66,7 @@ class AzBatchForgePlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "azure-batch", "forge",  "-n", "azure", "-l", "europe", "--work-dir", "az://nextflow-ci/jordeu", "--token-duration=24");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("azure-batch", "azure", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("azure-batch", "isnEDBLvHDAIteOEF44ow", "azure", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AzBatchManualPlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AzBatchManualPlatformTest.java
@@ -44,7 +44,7 @@ class AzBatchManualPlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "azure-batch", "manual", "-n", "azure-manual", "-l", "europe", "--work-dir", "az://nextflow-ci/jordeu", "--compute-pool-name=tower_pool");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("azure-batch", "azure-manual", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("azure-batch", "isnEDBLvHDAIteOEF44ow", "azure-manual", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -66,7 +66,7 @@ class AzBatchManualPlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "azure-batch", "manual", "-n", "azure-manual", "-l", "europe", "--work-dir", "az://nextflow-ci/jordeu", "--compute-pool-name=tower_pool", "--token-duration=24");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("azure-batch", "azure-manual", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("azure-batch", "isnEDBLvHDAIteOEF44ow", "azure-manual", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/EksPlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/EksPlatformTest.java
@@ -46,7 +46,7 @@ class EksPlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "eks", "-n", "eks", "--work-dir", "/workdir", "-r", "europe", "--cluster-name", "tower", "--namespace", "nf", "--head-account", "head", "--storage-claim", "nf");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("eks-platform", "eks", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("eks-platform", "isnEDBLvHDAIteOEF44ow", "eks", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -68,7 +68,7 @@ class EksPlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "eks", "-n", "eks", "--work-dir", "/workdir", "-r", "europe", "--cluster-name", "tower", "--namespace", "nf", "--head-account", "head", "--storage-claim", "nf", "--storage-mount=/workdir");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("eks-platform", "eks", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("eks-platform", "isnEDBLvHDAIteOEF44ow", "eks", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/GkePlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/GkePlatformTest.java
@@ -46,7 +46,7 @@ class GkePlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "gke", "-n", "gke", "--work-dir", "/workdir", "-r", "europe", "--cluster-name", "tower", "--namespace", "nf", "--head-account", "head", "--storage-claim", "nf");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("gke-platform", "gke", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("gke-platform", "isnEDBLvHDAIteOEF44ow", "gke", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -68,7 +68,7 @@ class GkePlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "gke", "-n", "gke", "--work-dir", "/workdir", "-r", "europe", "--cluster-name", "tower", "--namespace", "nf", "--head-account", "head", "--storage-claim", "nf", "--storage-mount=/workdir");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("gke-platform", "gke", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("gke-platform", "isnEDBLvHDAIteOEF44ow", "gke", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/GoogleLifeSciencesPlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/GoogleLifeSciencesPlatformTest.java
@@ -46,7 +46,7 @@ class GoogleLifeSciencesPlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "google-ls", "-n", "google", "--work-dir", "gs://workdir", "-r", "europe");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("google-lifesciences", "google", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("google-lifesciences", "isnEDBLvHDAIteOEF44ow", "google", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -68,7 +68,7 @@ class GoogleLifeSciencesPlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "google-ls", "-n", "google", "--work-dir", "gs://workdir", "-r", "europe", "--use-private-address");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("google-lifesciences", "google", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("google-lifesciences", "isnEDBLvHDAIteOEF44ow", "google", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -90,7 +90,7 @@ class GoogleLifeSciencesPlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "google-ls", "-n", "google", "--work-dir", "gs://workdir", "-r", "europe", "--nfs-target=1.2.3.4:/my_share_name");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("google-lifesciences", "google", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("google-lifesciences", "isnEDBLvHDAIteOEF44ow", "google", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/K8sPlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/K8sPlatformTest.java
@@ -46,7 +46,7 @@ class K8sPlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "k8s", "-n", "k8s", "--work-dir", "/workdir", "-s", "k8s.mydomain.net", "--namespace", "nf", "--ssl-cert", tempFile("ssl_cert", "", ".crt"), "--head-account", "head", "--storage-claim", "nf");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("k8s-platform", "k8s", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("k8s-platform", "isnEDBLvHDAIteOEF44ow", "k8s", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -68,7 +68,7 @@ class K8sPlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "k8s", "-n", "k8s", "--work-dir", "/workdir", "-s", "k8s.mydomain.net", "--namespace", "nf", "--ssl-cert", tempFile("ssl_cert", "", ".crt"), "--head-account", "head", "--storage-claim", "nf", "--storage-mount", "/workdir");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("k8s-platform", "k8s", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("k8s-platform", "isnEDBLvHDAIteOEF44ow", "k8s", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -90,7 +90,7 @@ class K8sPlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "k8s", "-n", "k8s", "--work-dir", "/workdir", "-s", "k8s.mydomain.net", "--namespace", "nf", "--ssl-cert", tempFile("ssl_cert", "", ".crt"), "--head-account", "head", "--storage-claim", "nf", "--pre-run", tempFile("pre_run_me", "pre", "sh"), "--post-run", tempFile("post_run_me", "post", "sh"));
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("k8s-platform", "k8s", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("k8s-platform", "isnEDBLvHDAIteOEF44ow", "k8s", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/LsfPlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/LsfPlatformTest.java
@@ -44,7 +44,7 @@ class LsfPlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "lsf", "-n", "lsf", "--work-dir", "/home/jordeu/nf", "-u", "jordi", "-H", "ssh.mydomain.net", "-q", "normal");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("lsf-platform", "lsf", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("lsf-platform", "isnEDBLvHDAIteOEF44ow", "lsf", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -66,7 +66,7 @@ class LsfPlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "lsf", "-n", "lsf", "--work-dir", "/home/jordeu/nf", "-u", "jordi", "-H", "ssh.mydomain.net", "-q", "normal", "--max-queue-size=200");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("lsf-platform", "lsf", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("lsf-platform", "isnEDBLvHDAIteOEF44ow", "lsf", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/SlurmPlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/SlurmPlatformTest.java
@@ -44,7 +44,7 @@ class SlurmPlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "slurm", "-n", "slurm", "--work-dir", "/home/jordeu/nf", "-u", "jordi", "-H", "ssh.mydomain.net", "-q", "normal");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("slurm-platform", "slurm", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("slurm-platform", "isnEDBLvHDAIteOEF44ow", "slurm", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -66,7 +66,7 @@ class SlurmPlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "slurm", "-n", "slurm", "--work-dir", "/home/jordeu/nf", "-u", "jordi", "-H", "ssh.mydomain.net", "-q", "normal", "--max-queue-size=200");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("slurm-platform", "slurm", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("slurm-platform", "isnEDBLvHDAIteOEF44ow", "slurm", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/UnivaPlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/UnivaPlatformTest.java
@@ -44,7 +44,7 @@ class UnivaPlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "uge", "-n", "uge", "--work-dir", "/home/jordeu/nf", "-u", "jordi", "-H", "ssh.mydomain.net", "-q", "normal");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("uge-platform", "uge", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("uge-platform", "isnEDBLvHDAIteOEF44ow", "uge", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -66,7 +66,7 @@ class UnivaPlatformTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "add", "uge", "-n", "uge", "--work-dir", "/home/jordeu/nf", "-u", "jordi", "-H", "ssh.mydomain.net", "-q", "normal", "--max-queue-size=200");
 
         assertEquals("", out.stdErr);
-        assertEquals(new ComputeEnvAdded("uge-platform", "uge", USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(new ComputeEnvAdded("uge-platform", "isnEDBLvHDAIteOEF44ow", "uge", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 

--- a/src/test/java/io/seqera/tower/cli/runs/RunsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/runs/RunsCmdTest.java
@@ -493,7 +493,7 @@ class RunsCmdTest extends BaseCmdTest {
 
 
         ExecOut out = exec(format, mock, "runs", "relaunch", "-i", "5UVJlhfUAHTuAP");
-        assertOutput(format, out, new RunSubmited("35aLiS0bIM5efd", String.format("%s/user/jordi/watch/35aLiS0bIM5efd", url(mock)), "user"));
+        assertOutput(format, out, new RunSubmited("35aLiS0bIM5efd", null, String.format("%s/user/jordi/watch/35aLiS0bIM5efd", url(mock)), "user"));
     }
 
     @Test


### PR DESCRIPTION
# Description

Added new `--wait` flag that waits until a given status before exit. 

Added to commands:
- `tw compute-envs add ...`
- `tw compute-envs import ...`
- `tw launch ...`

Exit code:
- It return with a 0 exit code if the entity reaches the desired status. 
- It returns an error 1 exit code if the entity reaches a status that is incompatible with the desired status. (for example if a workflow desired status is 'RUNNING' and the job gets status 'FAILED' or 'CANCELLED' before).