### PR TITLE
Remove --no-max pagination option

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/global/PaginationOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/global/PaginationOptions.java
@@ -37,20 +37,13 @@ public class PaginationOptions {
     public static class Sizeable {
         @CommandLine.Option(names = {"--max"}, description = "Maximum number of records to display [default: " + MAX + "].")
         public Integer max;
-
-        @CommandLine.Option(names = {"--no-max"}, description = "Show all records.")
-        public Boolean noMax;
     }
 
     public static Integer getMax(PaginationOptions paginationOptions) throws TowerException {
         Integer max = PaginationOptions.MAX;
 
         if (paginationOptions.sizeable != null) {
-            if (paginationOptions.sizeable.noMax != null && paginationOptions.sizeable.max != null) {
-                throw new TowerException("Please use either --no-max or --max as pagination size parameter");
-            }
-
-            max = paginationOptions.sizeable.noMax != null ? null : paginationOptions.sizeable.max != null ? paginationOptions.sizeable.max : max;
+            max = paginationOptions.sizeable.max != null ? paginationOptions.sizeable.max : max;
         }
 
         return max;

--- a/src/test/java/io/seqera/tower/cli/members/MembersCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/members/MembersCmdTest.java
@@ -207,35 +207,6 @@ class MembersCmdTest extends BaseCmdTest {
         assertEquals(1, out.exitCode);
     }
 
-    @Test
-    void testListWithConflictingSizeable(MockServerClient mock) throws JsonProcessingException {
-        mock.when(
-                request().withMethod("GET").withPath("/user"), exactly(1)
-        ).respond(
-                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
-        );
-
-        mock.when(
-                request().withMethod("GET").withPath("/user/1264/workspaces"), exactly(1)
-        ).respond(
-                response().withStatusCode(200).withBody(loadResource("workspaces/workspaces_list")).withContentType(MediaType.APPLICATION_JSON)
-        );
-
-        mock.when(
-                request().withMethod("GET").withPath("/orgs/27736513644467/members")
-                        .withQueryStringParameter("offset", "0")
-                        .withQueryStringParameter("max", "2"), exactly(1)
-        ).respond(
-                response().withStatusCode(200).withBody(loadResource("members/members_list")).withContentType(MediaType.APPLICATION_JSON)
-        );
-
-        ExecOut out = exec(mock, "members", "list", "-o", "organization1", "--page", "1", "--no-max", "--max", "2");
-
-        assertEquals(errorMessage(out.app, new TowerException("Please use either --no-max or --max as pagination size parameter")), out.stdErr);
-        assertEquals("", out.stdOut);
-        assertEquals(1, out.exitCode);
-    }
-
     @ParameterizedTest
     @EnumSource(OutputType.class)
     void testAdd(OutputType format, MockServerClient mock) throws JsonProcessingException {

--- a/src/test/java/io/seqera/tower/cli/participants/ParticipantsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/participants/ParticipantsCmdTest.java
@@ -382,35 +382,6 @@ class ParticipantsCmdTest extends BaseCmdTest {
     }
 
     @Test
-    void testListWithConflictingSizeable(MockServerClient mock) throws JsonProcessingException {
-        mock.when(
-                request().withMethod("GET").withPath("/user"), exactly(1)
-        ).respond(
-                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
-        );
-
-        mock.when(
-                request().withMethod("GET").withPath("/user/1264/workspaces"), exactly(1)
-        ).respond(
-                response().withStatusCode(200).withBody(loadResource("workspaces/workspaces_list")).withContentType(MediaType.APPLICATION_JSON)
-        );
-
-        mock.when(
-                request().withMethod("GET").withPath("/orgs/27736513644467/workspaces/75887156211589/participants")
-                        .withQueryStringParameter("offset", "0")
-                        .withQueryStringParameter("max", "2"), exactly(1)
-        ).respond(
-                response().withStatusCode(200).withBody(loadResource("participants/participants_list")).withContentType(MediaType.APPLICATION_JSON)
-        );
-
-        ExecOut out = exec(mock, "participants", "list", "-w", "75887156211589", "--page", "1", "--no-max", "--max", "2");
-
-        assertEquals(errorMessage(out.app, new TowerException("Please use either --no-max or --max as pagination size parameter")), out.stdErr);
-        assertEquals("", out.stdOut);
-        assertEquals(1, out.exitCode);
-    }
-
-    @Test
     void testListTeam(MockServerClient mock) throws JsonProcessingException {
         mock.when(
                 request().withMethod("GET").withPath("/user"), exactly(1)

--- a/src/test/java/io/seqera/tower/cli/pipelines/PipelinesCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/pipelines/PipelinesCmdTest.java
@@ -383,24 +383,6 @@ class PipelinesCmdTest extends BaseCmdTest {
     }
 
     @Test
-    void testListWithConflictingSizeable(MockServerClient mock) {
-
-        mock.when(
-                request().withMethod("GET").withPath("/pipelines")
-                        .withQueryStringParameter("offset", "0")
-                        .withQueryStringParameter("max", "2"), exactly(1)
-        ).respond(
-                response().withStatusCode(200).withBody(loadResource("pipelines_list")).withContentType(MediaType.APPLICATION_JSON)
-        );
-
-        ExecOut out = exec(mock, "pipelines", "list", "--page", "1", "--no-max", "--max", "2");
-
-        assertEquals(errorMessage(out.app, new TowerException("Please use either --no-max or --max as pagination size parameter")), out.stdErr);
-        assertEquals("", out.stdOut);
-        assertEquals(1, out.exitCode);
-    }
-
-    @Test
     void testListEmpty(MockServerClient mock) {
 
         mock.when(

--- a/src/test/java/io/seqera/tower/cli/runs/RunsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/runs/RunsCmdTest.java
@@ -263,16 +263,6 @@ class RunsCmdTest extends BaseCmdTest {
     }
 
     @Test
-    void testListWithConflictingSizeable(MockServerClient mock) {
-
-        ExecOut out = exec(mock, "runs", "list", "--page", "1", "--no-max", "--max", "2");
-
-        assertEquals(errorMessage(out.app, new TowerException("Please use either --no-max or --max as pagination size parameter")), out.stdErr);
-        assertEquals("", out.stdOut);
-        assertEquals(1, out.exitCode);
-    }
-
-    @Test
     void testListEmpty(MockServerClient mock) {
 
         mock.when(

--- a/src/test/java/io/seqera/tower/cli/teams/TeamsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/teams/TeamsCmdTest.java
@@ -238,35 +238,6 @@ class TeamsCmdTest extends BaseCmdTest {
     }
 
     @Test
-    void testListWithConflictingSizeable(MockServerClient mock) throws JsonProcessingException {
-        mock.when(
-                request().withMethod("GET").withPath("/user"), exactly(1)
-        ).respond(
-                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
-        );
-
-        mock.when(
-                request().withMethod("GET").withPath("/user/1264/workspaces"), exactly(1)
-        ).respond(
-                response().withStatusCode(200).withBody(loadResource("workspaces/workspaces_list")).withContentType(MediaType.APPLICATION_JSON)
-        );
-
-        mock.when(
-                request().withMethod("GET").withPath("/orgs/27736513644467/teams")
-                        .withQueryStringParameter("offset", "0")
-                        .withQueryStringParameter("max", "2"), exactly(1)
-        ).respond(
-                response().withStatusCode(200).withBody(loadResource("teams/teams_list")).withContentType(MediaType.APPLICATION_JSON)
-        );
-
-        ExecOut out = exec(mock, "teams", "list", "-o", "organization1", "--page", "1", "--no-max", "--max", "2");
-
-        assertEquals(errorMessage(out.app, new TowerException("Please use either --no-max or --max as pagination size parameter")), out.stdErr);
-        assertEquals("", out.stdOut);
-        assertEquals(1, out.exitCode);
-    }
-
-    @Test
     void testListEmpty(MockServerClient mock) {
         mock.when(
                 request().withMethod("GET").withPath("/user"), exactly(1)


### PR DESCRIPTION
## Description

Removing the option `--no-max` because it is not working as expected. The API cannot return all the elements of a list, so we need to implement pagination multi requests at CLI side. Related issue #220  