### PR TITLE
Remove uneeded github action if 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,6 @@ jobs:
 
   linux-image:
     name: Linux
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
     timeout-minutes: 90
 
@@ -73,7 +72,6 @@ jobs:
 
   mac-image:
     name: MAC
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: macos-latest
     timeout-minutes: 90
 
@@ -134,7 +132,6 @@ jobs:
 
   windows-image:
     name: Windows
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: windows-latest
     timeout-minutes: 90
 


### PR DESCRIPTION
No need to explicitly skip the actions on `[skip ci]` because it is the default github behaviour.
https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/ 