### PR TITLE
Rollback to MUSL as static linked version and add JAR distribution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
           version: '22.0.0.2'
           java-version: '11'
           components: 'native-image'
+          native-image-musl: 'true'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Tests
@@ -68,6 +69,40 @@ jobs:
         with:
           name: linux-binary-test-reports
           path: build/reports/tests/test/
+
+  linux-image-dynamic:
+    name: Linux (dynamic linked)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Environment
+        run: env | sort
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Graalvm
+        uses: graalvm/setup-graalvm@v1
+        with:
+          version: '22.0.0.2'
+          java-version: '11'
+          components: 'native-image'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Native Image
+        run: ./gradlew nativeCompile
+        env:
+          GITHUB_USERNAME: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GH_SEQERA_TOKEN }}
+          PLATFORM: linux-dynamic-x86_64
+
+      - name: Upload linux native image artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: tw_linux_dynamic
+          path: build/native/nativeCompile/tw
+
 
   mac-image:
     name: MAC

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,15 @@ jobs:
           name: linux-test-reports
           path: build/reports/tests/test/
 
+      - name: Build fat JAR
+        run: ./gradlew shadowJar
+
+      - name: Upload fat JAR artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: tw_jar
+          path: build/libs/tw.jar
+
       - name: Build Native Image
         run: ./gradlew nativeCompile
         env:
@@ -69,40 +78,6 @@ jobs:
         with:
           name: linux-binary-test-reports
           path: build/reports/tests/test/
-
-  linux-image-dynamic:
-    name: Linux (dynamic linked)
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-
-    steps:
-      - name: Environment
-        run: env | sort
-
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup Graalvm
-        uses: graalvm/setup-graalvm@v1
-        with:
-          version: '22.0.0.2'
-          java-version: '11'
-          components: 'native-image'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build Native Image
-        run: ./gradlew nativeCompile
-        env:
-          GITHUB_USERNAME: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GH_SEQERA_TOKEN }}
-          PLATFORM: linux-dynamic-x86_64
-
-      - name: Upload linux native image artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: tw_linux_dynamic
-          path: build/native/nativeCompile/tw
-
 
   mac-image:
     name: MAC
@@ -227,7 +202,7 @@ jobs:
   release:
     name: Release
     if: "contains(github.event.head_commit.message, '[release]') && github.event.ref=='refs/heads/master'"
-    needs: [ linux-image, linux-image-dynamic, mac-image, windows-image ]
+    needs: [ linux-image, mac-image, windows-image ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,7 +227,7 @@ jobs:
   release:
     name: Release
     if: "contains(github.event.head_commit.message, '[release]') && github.event.ref=='refs/heads/master'"
-    needs: [ linux-image, mac-image, windows-image ]
+    needs: [ linux-image, linux-image-dynamic, mac-image, windows-image ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'jacoco'
     id 'org.cadixdev.licenser' version '0.6.1'
     id 'org.graalvm.buildtools.native'
+    id 'com.github.johnrengelman.shadow' version '7.1.2'
 }
 
 repositories {
@@ -76,6 +77,11 @@ application {
     applicationDefaultJvmArgs = ["-agentlib:native-image-agent=config-merge-dir=conf/"]
 }
 
+shadowJar {
+    archiveBaseName.set('tw')
+    archiveClassifier.set('')
+    archiveVersion.set('')
+}
 
 test {
     // Use junit platform for unit tests

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,9 @@ graalvmNative {
             mainClass = 'io.seqera.tower.cli.Tower'
             configurationFileDirectories.from(file('conf'))
 
-            buildArgs(org.gradle.nativeplatform.platform.internal.DefaultNativePlatform.currentOperatingSystem.isLinux() ? ['--static'] : [])
+            if (System.env.getOrDefault("PLATFORM", "") == "linux-x86_64") {
+                buildArgs(['--static', '--libc=musl'])
+            }
             buildArgs.add('--allow-incomplete-classpath')
             buildArgs.add('--report-unsupported-elements-at-runtime')
             buildArgs.add('-H:+AddAllCharsets')

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -79,12 +79,13 @@ distributions:
       - path: "tw_linux/tw"
         transform: "{{distributionName}}-{{projectEffectiveVersion}}-linux-x86_64"
         platform: linux-x86_64
-      - path: "tw_linux_dynamic/tw"
-        transform: "{{distributionName}}-{{projectEffectiveVersion}}-linux-dynamic-x86_64"
-        platform: linux-x86_64
       - path: "tw_mac/tw"
         transform: "{{distributionName}}-{{projectEffectiveVersion}}-osx-x86_64"
         platform: osx-x86_64
       - path: "tw_windows/tw.exe"
         transform: "{{distributionName}}-{{projectEffectiveVersion}}-windows-x86_64.exe"
         platform: windows-x86_64
+  tw-jar:
+    type: SINGLE_JAR
+    artifacts:
+      - path: "tw_jar/tw.jar"

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -79,6 +79,9 @@ distributions:
       - path: "tw_linux/tw"
         transform: "{{distributionName}}-{{projectEffectiveVersion}}-linux-x86_64"
         platform: linux-x86_64
+      - path: "tw_linux_dynamic/tw"
+        transform: "{{distributionName}}-{{projectEffectiveVersion}}-linux-dynamic-x86_64"
+        platform: linux-x86_64
       - path: "tw_mac/tw"
         transform: "{{distributionName}}-{{projectEffectiveVersion}}-osx-x86_64"
         platform: osx-x86_64


### PR DESCRIPTION
## Description

- Rollback to use MUSL to build the static linked binary. This proof to be the version that works for most of the users, except some that use a very old GLibc version.
- Add a new Tower CLI distribution that is a pure Java JAR, for users that experience problems with the MUSL static linked version. This distribution has to be use like `java -jar tw.jar ...` . Example `java -jar tw.jar info`