### PR TITLE
Allow second level help usage without defining a Tower access token

### DIFF
--- a/conf/resource-config.json
+++ b/conf/resource-config.json
@@ -17,17 +17,11 @@
   "bundles":[
     {
       "name":"org.glassfish.jersey.client.internal.localization",
-      "locales":[
-        "", 
-        "und"
-      ]
+      "locales":["und"]
     }, 
     {
       "name":"org.glassfish.jersey.internal.localization",
-      "locales":[
-        "", 
-        "und"
-      ]
+      "locales":["und"]
     }, 
     {
       "name":"org.glassfish.jersey.media.multipart.internal.localization"

--- a/src/main/java/io/seqera/tower/cli/Tower.java
+++ b/src/main/java/io/seqera/tower/cli/Tower.java
@@ -67,10 +67,10 @@ public class Tower extends AbstractCmd {
     @Spec
     public CommandSpec spec;
 
-    @Option(names = {"-t", "--access-token"}, description = "Tower personal access token (TOWER_ACCESS_TOKEN).", defaultValue = "${TOWER_ACCESS_TOKEN}", required = true)
+    @Option(names = {"-t", "--access-token"}, description = "Tower personal access token (TOWER_ACCESS_TOKEN).", defaultValue = "${TOWER_ACCESS_TOKEN}")
     public String token;
 
-    @Option(names = {"-u", "--url"}, description = "Tower server API endpoint URL (TOWER_API_ENDPOINT) [default: 'tower.nf'].", defaultValue = "${TOWER_API_ENDPOINT:-https://api.tower.nf}", required = true)
+    @Option(names = {"-u", "--url"}, description = "Tower server API endpoint URL (TOWER_API_ENDPOINT) [default: 'tower.nf'].", defaultValue = "${TOWER_API_ENDPOINT:-https://api.tower.nf}")
     public String url;
 
     @Option(names = {"-o", "--output"}, description = "Show output in defined format (only the 'json' option is available at the moment).", defaultValue = "${TOWER_CLI_OUTPUT_FORMAT:-console}")

--- a/src/main/java/io/seqera/tower/cli/commands/AbstractApiCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/AbstractApiCmd.java
@@ -17,6 +17,7 @@ import io.seqera.tower.api.DefaultApi;
 import io.seqera.tower.cli.Tower;
 import io.seqera.tower.cli.exceptions.ComputeEnvNotFoundException;
 import io.seqera.tower.cli.exceptions.InvalidWorkspaceParameterException;
+import io.seqera.tower.cli.exceptions.MissingTowerAccessTokenException;
 import io.seqera.tower.cli.exceptions.NoComputeEnvironmentException;
 import io.seqera.tower.cli.exceptions.OrganizationNotFoundException;
 import io.seqera.tower.cli.exceptions.ShowUsageException;
@@ -97,6 +98,11 @@ public abstract class AbstractApiCmd extends AbstractCmd {
         }
 
         if (api == null) {
+
+            if (app().token == null) {
+                throw new MissingTowerAccessTokenException();
+            }
+
             ApiClient client = buildApiClient();
             client.setServerIndex(null);
             client.setBasePath(app().url);

--- a/src/main/java/io/seqera/tower/cli/exceptions/MissingTowerAccessTokenException.java
+++ b/src/main/java/io/seqera/tower/cli/exceptions/MissingTowerAccessTokenException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2021, Seqera Labs.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This Source Code Form is "Incompatible With Secondary Licenses", as
+ * defined by the Mozilla Public License, v. 2.0.
+ */
+
+package io.seqera.tower.cli.exceptions;
+
+public class MissingTowerAccessTokenException extends TowerException {
+    public MissingTowerAccessTokenException() {
+        super("Missing TOWER_ACCESS_TOKEN environment variable or 'tw -t <token> ...' parameter");
+    }
+}


### PR DESCRIPTION
Fixes #228 