### PR TITLE
Support shared pipelines

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:1.7.36'
     implementation 'ch.qos.logback:logback-core:1.2.11'
     implementation 'ch.qos.logback:logback-classic:1.2.11'
-    implementation 'io.seqera.tower:tower-java-sdk:1.4.2'
+    implementation 'io.seqera.tower:tower-java-sdk:1.4.3'
     implementation 'info.picocli:picocli:4.6.3'
     annotationProcessor 'info.picocli:picocli-codegen:4.6.3'
 

--- a/conf/resource-config.json
+++ b/conf/resource-config.json
@@ -17,11 +17,17 @@
   "bundles":[
     {
       "name":"org.glassfish.jersey.client.internal.localization",
-      "locales":["und"]
+      "locales":[
+        "", 
+        "und"
+      ]
     }, 
     {
       "name":"org.glassfish.jersey.internal.localization",
-      "locales":["und"]
+      "locales":[
+        "", 
+        "und"
+      ]
     }, 
     {
       "name":"org.glassfish.jersey.media.multipart.internal.localization"

--- a/src/main/java/io/seqera/tower/cli/commands/AbstractApiCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/AbstractApiCmd.java
@@ -30,6 +30,7 @@ import io.seqera.tower.model.ComputeEnvResponseDto;
 import io.seqera.tower.model.ListComputeEnvsResponseEntry;
 import io.seqera.tower.model.ListWorkspacesAndOrgResponse;
 import io.seqera.tower.model.OrgAndWorkspaceDbDto;
+import io.seqera.tower.model.PipelineDbDto;
 import io.seqera.tower.model.User;
 import io.seqera.tower.model.WorkflowQueryAttribute;
 import org.glassfish.jersey.client.ClientConfig;
@@ -379,6 +380,19 @@ public abstract class AbstractApiCmd extends AbstractCmd {
             return USER_WORKSPACE_NAME;
         }
         return buildWorkspaceRef(orgName(workspaceId), workspaceName(workspaceId));
+    }
+
+    protected Long sourceWorkspaceId(Long currentWorkspace, PipelineDbDto pipeline) {
+        if (pipeline == null)
+            return null;
+
+        if (pipeline.getWorkspaceId() == null)
+            return null;
+
+        if (pipeline.getWorkspaceId().equals(currentWorkspace))
+            return null;
+
+        return pipeline.getWorkspaceId();
     }
 
     @Override

--- a/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
@@ -141,7 +141,7 @@ public class LaunchCmd extends AbstractRootCmd {
         }
 
         PipelineDbDto pipeline = pipelines.getPipelines().get(0);
-        Long sourceWorkspaceId = wspId.equals(pipeline.getWorkspaceId()) ? null : pipeline.getWorkspaceId();
+        Long sourceWorkspaceId = sourceWorkspaceId(wspId, pipeline);
 
         Launch launch = api().describePipelineLaunch(pipeline.getPipelineId(), wspId, sourceWorkspaceId).getLaunch();
 

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/AbstractPipelinesCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/AbstractPipelinesCmd.java
@@ -29,7 +29,7 @@ public abstract class AbstractPipelinesCmd extends AbstractApiCmd {
 
     protected PipelineDbDto pipelineByName(Long workspaceId, String name) throws ApiException {
 
-        ListPipelinesResponse list = api().listPipelines(Collections.emptyList(), workspaceId, null, null, name, null);
+        ListPipelinesResponse list = api().listPipelines(Collections.emptyList(), workspaceId, null, null, name, "all");
 
         if (list.getPipelines().isEmpty()) {
             throw new PipelineNotFoundException(name, workspaceRef(workspaceId));

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/ExportCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/ExportCmd.java
@@ -44,7 +44,7 @@ public class ExportCmd extends AbstractPipelinesCmd {
     protected Response exec() throws ApiException {
         Long wspId = workspaceId(workspace.workspace);
         PipelineDbDto pipeline = fetchPipeline(pipelineRefOptions, wspId);
-        Long sourceWorkspaceId = wspId.equals(pipeline.getWorkspaceId()) ? null : pipeline.getWorkspaceId();
+        Long sourceWorkspaceId = sourceWorkspaceId(wspId, pipeline);
         Launch launch = api().describePipelineLaunch(pipeline.getPipelineId(), wspId, sourceWorkspaceId).getLaunch();
 
         WorkflowLaunchRequest workflowLaunchRequest = ModelHelper.createLaunchRequest(launch);

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/ExportCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/ExportCmd.java
@@ -44,8 +44,8 @@ public class ExportCmd extends AbstractPipelinesCmd {
     protected Response exec() throws ApiException {
         Long wspId = workspaceId(workspace.workspace);
         PipelineDbDto pipeline = fetchPipeline(pipelineRefOptions, wspId);
-
-        Launch launch = api().describePipelineLaunch(pipeline.getPipelineId(), wspId).getLaunch();
+        Long sourceWorkspaceId = wspId.equals(pipeline.getWorkspaceId()) ? null : pipeline.getWorkspaceId();
+        Launch launch = api().describePipelineLaunch(pipeline.getPipelineId(), wspId, sourceWorkspaceId).getLaunch();
 
         WorkflowLaunchRequest workflowLaunchRequest = ModelHelper.createLaunchRequest(launch);
 

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/ListCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/ListCmd.java
@@ -36,6 +36,9 @@ public class ListCmd extends AbstractPipelinesCmd {
     @CommandLine.Option(names = {"-f", "--filter"}, description = "Show only pipelines that contain the given word.")
     public String filter;
 
+    @CommandLine.Option(names = {"--visibility"}, description = "Show pipelines: ${COMPLETION-CANDIDATES} [default: private].", defaultValue = "private")
+    public PipelineVisibility visibility;
+
     @CommandLine.Mixin
     PaginationOptions paginationOptions;
 
@@ -48,7 +51,7 @@ public class ListCmd extends AbstractPipelinesCmd {
         ListPipelinesResponse response = new ListPipelinesResponse();
 
         try {
-           response = api().listPipelines(Collections.emptyList(), wspId, max, offset, filter, null);
+           response = api().listPipelines(Collections.emptyList(), wspId, max, offset, filter, visibility.toString());
 
         } catch (ApiException apiException) {
             if (apiException.getCode() == 404){

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/PipelineVisibility.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/PipelineVisibility.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2021, Seqera Labs.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This Source Code Form is "Incompatible With Secondary Licenses", as
+ * defined by the Mozilla Public License, v. 2.0.
+ */
+
 package io.seqera.tower.cli.commands.pipelines;
 
 public enum PipelineVisibility {

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/PipelineVisibility.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/PipelineVisibility.java
@@ -1,0 +1,18 @@
+package io.seqera.tower.cli.commands.pipelines;
+
+public enum PipelineVisibility {
+    ALL("all"),
+    PRIVATE("private"),
+    SHARED("shared");
+
+    private final String value;
+
+    PipelineVisibility(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/UpdateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/UpdateCmd.java
@@ -67,7 +67,7 @@ public class UpdateCmd extends AbstractPipelinesCmd {
             id = pipe.getPipelineId();
         }
 
-        Long sourceWorkspaceId = wspId.equals(pipe.getWorkspaceId()) ? null : pipe.getWorkspaceId();
+        Long sourceWorkspaceId = sourceWorkspaceId(wspId, pipe);
         Launch launch = api().describePipelineLaunch(id, wspId, sourceWorkspaceId).getLaunch();
 
         // Retrieve the provided computeEnv or use the primary if not provided

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/UpdateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/UpdateCmd.java
@@ -67,7 +67,8 @@ public class UpdateCmd extends AbstractPipelinesCmd {
             id = pipe.getPipelineId();
         }
 
-        Launch launch = api().describePipelineLaunch(id, wspId).getLaunch();
+        Long sourceWorkspaceId = wspId.equals(pipe.getWorkspaceId()) ? null : pipe.getWorkspaceId();
+        Launch launch = api().describePipelineLaunch(id, wspId, sourceWorkspaceId).getLaunch();
 
         // Retrieve the provided computeEnv or use the primary if not provided
         String ceId = opts.computeEnv != null ? computeEnvByRef(wspId, opts.computeEnv).getId() : launch.getComputeEnv().getId();

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/ViewCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/ViewCmd.java
@@ -36,7 +36,7 @@ public class ViewCmd extends AbstractPipelinesCmd {
     protected Response exec() throws ApiException {
         Long wspId = workspaceId(workspace.workspace);
         PipelineDbDto pipeline = fetchPipeline(pipelineRefOptions, wspId);
-        Long sourceWorkspaceId = wspId.equals(pipeline.getWorkspaceId()) ? null : pipeline.getWorkspaceId();
+        Long sourceWorkspaceId = sourceWorkspaceId(wspId, pipeline);
 
         Launch launch = api().describePipelineLaunch(pipeline.getPipelineId(), wspId, sourceWorkspaceId).getLaunch();
 

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/ViewCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/ViewCmd.java
@@ -36,8 +36,9 @@ public class ViewCmd extends AbstractPipelinesCmd {
     protected Response exec() throws ApiException {
         Long wspId = workspaceId(workspace.workspace);
         PipelineDbDto pipeline = fetchPipeline(pipelineRefOptions, wspId);
+        Long sourceWorkspaceId = wspId.equals(pipeline.getWorkspaceId()) ? null : pipeline.getWorkspaceId();
 
-        Launch launch = api().describePipelineLaunch(pipeline.getPipelineId(), wspId).getLaunch();
+        Launch launch = api().describePipelineLaunch(pipeline.getPipelineId(), wspId, sourceWorkspaceId).getLaunch();
 
         return new PipelinesView(workspaceRef(wspId), pipeline, launch, baseWorkspaceUrl(wspId));
     }

--- a/src/main/java/io/seqera/tower/cli/responses/pipelines/PipelinesList.java
+++ b/src/main/java/io/seqera/tower/cli/responses/pipelines/PipelinesList.java
@@ -45,13 +45,13 @@ public class PipelinesList extends Response {
             return;
         }
 
-        TableList table = new TableList(out, 3, "ID", "Name", "Repository", "Description").sortBy(0);
+        TableList table = new TableList(out, 4, "ID", "Name", "Repository", "Visibility").sortBy(0);
         table.setPrefix("    ");
         pipelines.forEach(pipe -> table.addRow(
                 formatPipelineId(pipe.getPipelineId(), baseWorkspaceUrl),
                 pipe.getName(),
                 pipe.getRepository(),
-                pipe.getDescription()
+                pipe.getVisibility()
         ));
         table.print();
         out.println("");

--- a/src/main/java/io/seqera/tower/cli/responses/pipelines/PipelinesView.java
+++ b/src/main/java/io/seqera/tower/cli/responses/pipelines/PipelinesView.java
@@ -58,7 +58,7 @@ public class PipelinesView extends Response {
         table.addRow("Name", info.getName());
         table.addRow("Description", info.getDescription());
         table.addRow("Repository", info.getRepository());
-        table.addRow("Compute env.", launch.getComputeEnv().getName());
+        table.addRow("Compute env.", launch.getComputeEnv() == null ? "(not defined)" : launch.getComputeEnv().getName());
         table.print();
 
         out.println(String.format("%n  Configuration:%n%n%s%n", configJson.replaceAll("(?m)^", "     ")));

--- a/src/main/java/io/seqera/tower/cli/utils/ModelHelper.java
+++ b/src/main/java/io/seqera/tower/cli/utils/ModelHelper.java
@@ -25,7 +25,7 @@ public class ModelHelper {
     public static WorkflowLaunchRequest createLaunchRequest(Launch launch) {
         return new WorkflowLaunchRequest()
                 .id(launch.getId())
-                .computeEnvId(launch.getComputeEnv().getId())
+                .computeEnvId(launch.getComputeEnv() != null ? launch.getComputeEnv().getId() : null)
                 .pipeline(launch.getPipeline())
                 .workDir(launch.getWorkDir())
                 .revision(launch.getRevision())

--- a/src/test/java/io/seqera/tower/cli/LaunchCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/LaunchCmdTest.java
@@ -72,26 +72,6 @@ class LaunchCmdTest extends BaseCmdTest {
         assertEquals(1, out.exitCode);
     }
 
-    @Test
-    void testMultiplePipelinesFound(MockServerClient mock) {
-
-        mock.reset();
-
-        // Create server expectation
-        mock.when(
-                request().withMethod("GET").withPath("/pipelines"), exactly(1)
-        ).respond(
-                response().withStatusCode(200).withBody(loadResource("pipelines_multiple")).withContentType(MediaType.APPLICATION_JSON)
-        );
-
-        // Run the command
-        ExecOut out = exec(mock, "launch", "hello");
-
-        // Assert results
-        assertEquals(errorMessage(out.app, new InvalidResponseException("Multiple pipelines match 'hello'")), out.stdErr);
-        assertEquals(1, out.exitCode);
-    }
-
     @ParameterizedTest
     @EnumSource(OutputType.class)
     void testSubmitLaunchpadPipeline(OutputType format, MockServerClient mock) {


### PR DESCRIPTION
## Description

Adds support to list and launch shared pipelines.

To list all pipelines
```
$ tw pipelines list -w myorg/myworkspace --visibility all

  Pipelines at [myorg / myworkspace] workspace:

     ID              | Name         | Repository                           | Visibility 
    -----------------+--------------+--------------------------------------+------------
     151019773731768 | shared_hello | https://github.com/nextflow-io/hello | SHARED     
     46451911407565  | sarek        | https://github.com/nf-core/sarek     | PRIVATE    
```

To view 
``` 
$ tw pipelines view -n shared_hello -w myorg/myworkspace 

  Pipeline at [myorg / myworkspace] workspace:

    --------------+--------------------------------------
     ID           | 151019773731768                      
     Name         | shared_hello                         
     Description  | Shared hello world without CE        
     Repository   | https://github.com/nextflow-io/hello 
     Compute env. | (not defined)                        

  Configuration:

     {
       "id" : "26CgNMOZwFjxEKZ4vb2b4y",
       "pipeline" : "https://github.com/nextflow-io/hello",
       "resume" : false,
       "pullLatest" : false,
       "stubRun" : false,
       "dateCreated" : "2022-11-25T08:03:24Z"
     }

```

To launch them there is no new option, but now is just working when using the name:
``` 
$ tw launch -w myorg/myworkspace shared_hello

  Workflow 5W1qYuVRvzmfU7 submitted at [myorg / myworkspace] workspace.

    https://tower.nf/orgs/myorg/workspaces/myworkspace/watch/5W1qYuVRvzmfU7

```

Fixes #278 

## Guidelines for testing

- Install development version from [actions artifacts](https://github.com/seqeralabs/tower-cli/actions/runs/3547045770).
- Create a shared workspace
- Create one shared pipeline without CE
- Create one shared pipeline with CE
- Try to list them from a private workspace
- Try to launch both from a private workspace

