### PR TITLE
Add dump command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:1.7.36'
     implementation 'ch.qos.logback:logback-core:1.2.11'
     implementation 'ch.qos.logback:logback-classic:1.2.11'
-    implementation 'io.seqera.tower:tower-java-sdk:1.4.4'
+    implementation 'io.seqera.tower:tower-java-sdk:1.5.0'
     implementation 'info.picocli:picocli:4.6.3'
     implementation 'org.apache.commons:commons-compress:1.22'
     implementation 'org.tukaani:xz:1.9'

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     implementation 'ch.qos.logback:logback-classic:1.2.11'
     implementation 'io.seqera.tower:tower-java-sdk:1.4.4'
     implementation 'info.picocli:picocli:4.6.3'
+    implementation 'org.apache.commons:commons-compress:1.22'
+    implementation 'org.tukaani:xz:1.9'
     annotationProcessor 'info.picocli:picocli-codegen:4.6.3'
 
     testImplementation 'org.mock-server:mockserver-client-java:5.13.0'

--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -1242,6 +1242,12 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"io.seqera.tower.cli.commands.runs.DumpCmd",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"io.seqera.tower.cli.commands.runs.ListCmd",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
@@ -1723,6 +1729,12 @@
   "allDeclaredConstructors":true
 },
 {
+  "name":"io.seqera.tower.cli.responses.runs.RunDump",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
   "name":"io.seqera.tower.cli.responses.runs.RunFileDownloaded",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
@@ -1989,6 +2001,8 @@
   "queryAllDeclaredConstructors":true,
   "methods":[
     {"name":"<init>","parameterTypes":[] }, 
+    {"name":"getSiteId","parameterTypes":[] }, 
+    {"name":"getUrl","parameterTypes":[] }, 
     {"name":"setSiteId","parameterTypes":["java.lang.Integer"] }, 
     {"name":"setUrl","parameterTypes":["java.lang.String"] }
   ]
@@ -3130,6 +3144,12 @@
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true
+},
+{
+  "name":"java.lang.Character",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
 },
 {
   "name":"java.lang.Class[]"

--- a/conf/resource-config.json
+++ b/conf/resource-config.json
@@ -17,17 +17,11 @@
   "bundles":[
     {
       "name":"org.glassfish.jersey.client.internal.localization",
-      "locales":[
-        "", 
-        "und"
-      ]
+      "locales":["und"]
     }, 
     {
       "name":"org.glassfish.jersey.internal.localization",
-      "locales":[
-        "", 
-        "und"
-      ]
+      "locales":["und"]
     }, 
     {
       "name":"org.glassfish.jersey.media.multipart.internal.localization"

--- a/conf/resource-config.json
+++ b/conf/resource-config.json
@@ -17,11 +17,17 @@
   "bundles":[
     {
       "name":"org.glassfish.jersey.client.internal.localization",
-      "locales":["und"]
+      "locales":[
+        "", 
+        "und"
+      ]
     }, 
     {
       "name":"org.glassfish.jersey.internal.localization",
-      "locales":["und"]
+      "locales":[
+        "", 
+        "und"
+      ]
     }, 
     {
       "name":"org.glassfish.jersey.media.multipart.internal.localization"

--- a/src/main/java/io/seqera/tower/cli/commands/AbstractCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/AbstractCmd.java
@@ -38,4 +38,8 @@ public abstract class AbstractCmd implements Callable<Integer> {
     public CommandLine.Model.CommandSpec getSpec() {
         return spec;
     }
+
+    protected String ansi(String value) {
+        return CommandLine.Help.Ansi.AUTO.string(value);
+    }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/RunsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/RunsCmd.java
@@ -13,6 +13,7 @@ package io.seqera.tower.cli.commands;
 
 import io.seqera.tower.cli.commands.runs.CancelCmd;
 import io.seqera.tower.cli.commands.runs.DeleteCmd;
+import io.seqera.tower.cli.commands.runs.DumpCmd;
 import io.seqera.tower.cli.commands.runs.ListCmd;
 import io.seqera.tower.cli.commands.runs.RelaunchCmd;
 import io.seqera.tower.cli.commands.runs.ViewCmd;
@@ -26,7 +27,8 @@ import picocli.CommandLine;
                 ListCmd.class,
                 RelaunchCmd.class,
                 CancelCmd.class,
-                DeleteCmd.class
+                DeleteCmd.class,
+                DumpCmd.class
         }
 )
 public class RunsCmd extends AbstractRootCmd {

--- a/src/main/java/io/seqera/tower/cli/commands/runs/DumpCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/DumpCmd.java
@@ -11,23 +11,46 @@
 
 package io.seqera.tower.cli.commands.runs;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.seqera.tower.ApiException;
 import io.seqera.tower.JSON;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
-import io.seqera.tower.cli.exceptions.RunNotFoundException;
 import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.runs.RunDump;
+import io.seqera.tower.cli.utils.SilentPrintWriter;
+import io.seqera.tower.model.DescribeTaskResponse;
+import io.seqera.tower.model.DescribeWorkflowResponse;
+import io.seqera.tower.model.Launch;
+import io.seqera.tower.model.ListTasksResponse;
 import io.seqera.tower.model.ServiceInfo;
+import io.seqera.tower.model.Task;
+import io.seqera.tower.model.TaskStatus;
+import io.seqera.tower.model.Workflow;
+import io.seqera.tower.model.WorkflowLoad;
+import io.seqera.tower.model.WorkflowMetrics;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.apache.commons.compress.compressors.xz.XZCompressorOutputStream;
+import org.apache.commons.compress.utils.IOUtils;
 import picocli.CommandLine;
 
 import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 @CommandLine.Command(
         name = "dump",
@@ -38,48 +61,236 @@ public class DumpCmd extends AbstractRunsCmd {
     @CommandLine.Option(names = {"-i", "-id"}, description = "Pipeline run identifier.", required = true)
     public String id;
 
-    @CommandLine.Option(names = {"-o", "--output"}, description = "Output file to store the dump.", required = true)
+    @CommandLine.Option(names = {"-o", "--output"}, description = "Output file to store the dump. (supported formats: .tar.xz and .tar.gz)", required = true)
     Path outputFile;
+
+    @CommandLine.Option(names = {"--skip-tasks"}, description = "Skip all tasks logs.")
+    public boolean skipTasks;
+
+    @CommandLine.Option(names = {"--add-fusion"}, description = "Add Fusion task logs.")
+    public boolean addFusion;
+
+    @CommandLine.Option(names = {"--only-failed"}, description = "Dump only failed tasks.")
+    public boolean onlyFailed;
+
+    @CommandLine.Option(names = {"--silent"}, description = "Do not show download progress.")
+    public boolean silent;
 
     @CommandLine.Mixin
     public WorkspaceOptionalOptions workspace;
 
-    private static JSON JSON = new JSON();
+    private final static JSON JSON = new JSON();
 
-    @Override
-    protected Response exec() throws ApiException, IOException {
-        Long wspId = workspaceId(workspace.workspace);
+    private ExecutorService compressExecutor;
+    private static class AddEntry implements Runnable {
+        TarArchiveOutputStream out;
+        String fileName;
+        File file;
 
-        if (!outputFile.getFileName().toString().endsWith(".tar.xz")) {
-            throw new TowerException("Only 'tar.xz' format is supported. Output file name should end with '.tar.xz'");
+        public AddEntry(TarArchiveOutputStream out, String fileName, File file) {
+            this.out = out;
+            this.fileName = fileName;
+            this.file = file;
         }
 
-        try {
-
-            FileOutputStream fileOut = new FileOutputStream(outputFile.toFile());
-            BufferedOutputStream buffOut = new BufferedOutputStream(fileOut);
-            XZCompressorOutputStream xzOut = new XZCompressorOutputStream(buffOut);
-            TarArchiveOutputStream out = new TarArchiveOutputStream(xzOut);
-
-            addServiceInfo(out);
-
-            out.close();
-
-            return new RunDump(id, workspaceRef(wspId), outputFile);
-        } catch (ApiException e) {
-            if (e.getCode() == 403) {
-                throw new RunNotFoundException(id, workspaceRef(wspId));
+        @Override
+        public void run() {
+            TarArchiveEntry entry = new TarArchiveEntry(file, fileName);
+            try {
+                out.putArchiveEntry(entry);
+                IOUtils.copy(new FileInputStream(file), out);
+                out.closeArchiveEntry();
+            } catch (IOException e) {
+                e.printStackTrace();
             }
-            throw e;
         }
     }
 
-    private void addServiceInfo(TarArchiveOutputStream out) throws ApiException, IOException {
-        byte[] data = JSON.getContext(ServiceInfo.class).writerWithDefaultPrettyPrinter().writeValueAsBytes(api().info().getServiceInfo());
-        TarArchiveEntry entry = new TarArchiveEntry("service-info.json");
+    @Override
+    protected Response exec() throws ApiException, IOException {
+
+        Long wspId = workspaceId(workspace.workspace);
+        String workflowId = id;
+        PrintWriter progress = silent ? new SilentPrintWriter() : app().getOut();
+        FileOutputStream fileOut = new FileOutputStream(outputFile.toFile());
+        BufferedOutputStream buffOut = new BufferedOutputStream(fileOut);
+
+        String fileName = outputFile.getFileName().toString();
+        OutputStream compressOut = compressStream(fileName, buffOut);
+        if (compressOut == null) {
+            throw new TowerException("Unknown file format. Only 'tar.xz' and 'tar.gz' formats are supported.");
+        }
+
+        TarArchiveOutputStream out = new TarArchiveOutputStream(compressOut);
+        compressExecutor = Executors.newSingleThreadExecutor();
+
+        dumpTowerInfo(progress, out);
+        dumpWorkflowDetails(progress, out, wspId);
+        dumpTasks(progress, out, wspId, workflowId);
+
+        compressExecutor.shutdown();
+        try {
+            if (!compressExecutor.awaitTermination(1, TimeUnit.MINUTES)) {
+                throw new TowerException("Timeout compressing logs");
+            }
+        } catch (InterruptedException ignored) {
+        }
+        out.close();
+        return new RunDump(id, workspaceRef(wspId), outputFile);
+    }
+
+    private OutputStream compressStream(String fileName, OutputStream out) throws IOException {
+        if (fileName.endsWith(".tar.xz")) {
+            return new XZCompressorOutputStream(out);
+        }
+
+        if (fileName.endsWith(".tar.gz")) {
+            return new GzipCompressorOutputStream(out);
+        }
+
+        return null;
+    }
+
+    private void dumpTasks(PrintWriter progress, TarArchiveOutputStream out, Long wspId, String workflowId) throws ApiException, IOException {
+        progress.println(ansi("- Task details"));
+        List<Task> tasks = loadTasks(wspId, workflowId);
+        addEntry(out, "workflow-tasks.json", List.class, tasks);
+        addTaskLogs(progress, out, wspId, workflowId, tasks);
+    }
+
+    private void dumpWorkflowDetails(PrintWriter progress, TarArchiveOutputStream out, Long wspId) throws ApiException, IOException {
+        progress.println(ansi("- Workflow details"));
+
+        DescribeWorkflowResponse workflowResponse = workflowById(wspId, id);
+        Workflow workflow = workflowResponse.getWorkflow();
+        if (workflow == null) {
+            throw new TowerException("Unknown workflow");
+        }
+        WorkflowLoad workflowLoad = workflowLoadByWorkflowId(wspId, id);
+        Launch launch = workflow.getLaunchId() != null ? launchById(wspId, workflow.getLaunchId()) : null;
+        List<WorkflowMetrics> metrics = api().describeWorkflowMetrics(workflow.getId(), wspId).getMetrics();
+        addEntry(out, "workflow.json", Workflow.class, workflow);
+        addEntry(out, "workflow-load.json", WorkflowLoad.class, workflowLoad);
+        addEntry(out, "workflow-launch.json", Launch.class, launch);
+        addEntry(out, "workflow-metrics.json", List.class, metrics);
+
+        // Files
+        try {
+            File nextflowLog = api().downloadWorkflowLog(workflow.getId(), String.format("nf-%s.log", workflow.getId()), wspId);
+            addFile(out, "nextflow.log", nextflowLog);
+        } catch (ApiException e) {
+            // Ignore error 404 that means that the file it is no longer available
+            if (e.getCode() != 404) {
+                throw e;
+            }
+        }
+    }
+
+    private void dumpTowerInfo(PrintWriter progress, TarArchiveOutputStream out) throws IOException, ApiException {
+        progress.println(ansi("- Tower info"));
+        addEntry(out, "service-info.json", ServiceInfo.class, api().info().getServiceInfo());
+    }
+
+    private void addTaskLogs(PrintWriter progress, TarArchiveOutputStream out, Long wspId, String workflowId, List<Task> tasks) throws IOException, ApiException {
+        if (skipTasks) {
+            return;
+        }
+
+        if (onlyFailed) {
+            tasks = tasks.stream().filter(t -> t.getStatus() == TaskStatus.FAILED).collect(Collectors.toList());
+        }
+
+        int current = 1;
+        int total = tasks.size();
+        for (Task task : tasks) {
+            progress.println(ansi(String.format("     [%d/%d] adding task logs '%s'", current++, total, task.getName())));
+            try {
+                File taskOut = api().downloadWorkflowTaskLog(workflowId, task.getTaskId(), ".command.out", wspId);
+                addFile(out, String.format("tasks/%d/.command.out", task.getTaskId()), taskOut);
+            } catch (ApiException e) {
+                // Ignore error 404 that means that the file it is no longer available
+                if (e.getCode() != 404) {
+                    throw e;
+                }
+            }
+
+            try {
+                File taskOut = api().downloadWorkflowTaskLog(workflowId, task.getTaskId(), ".command.err", wspId);
+                addFile(out, String.format("tasks/%d/.command.err", task.getTaskId()), taskOut);
+            } catch (ApiException e) {
+                // Ignore error 404 that means that the file it is no longer available
+                if (e.getCode() != 404) {
+                    throw e;
+                }
+            }
+
+            try {
+                File taskOut = api().downloadWorkflowTaskLog(workflowId, task.getTaskId(), ".command.log", wspId);
+                addFile(out, String.format("tasks/%d/.command.log", task.getTaskId()), taskOut);
+            } catch (ApiException e) {
+                // Ignore error 404 that means that the file it is no longer available
+                if (e.getCode() != 404) {
+                    throw e;
+                }
+            }
+
+            if (addFusion) {
+                try {
+                    File taskOut = api().downloadWorkflowTaskLog(workflowId, task.getTaskId(), ".fusion.log", wspId);
+                    addFile(out, String.format("tasks/%d/.fusion.log", task.getTaskId()), taskOut);
+                } catch (ApiException e) {
+                    // Ignore error 404 that means that the file it is no longer available
+                    if (e.getCode() != 404) {
+                        throw e;
+                    }
+                }
+            }
+        }
+    }
+
+    private List<Task> loadTasks(Long wspId, String workflowId) throws ApiException {
+        int max = 100;
+        int offset = 0;
+        int added = max;
+
+        List<Task> tasks = new ArrayList<>();
+        while (added == max) {
+            added = 0;
+            ListTasksResponse response = api().listWorkflowTasks(workflowId, wspId, max, offset, null, null, null);
+            for (DescribeTaskResponse describeTaskResponse : Objects.requireNonNull(response.getTasks())) {
+                Task task = describeTaskResponse.getTask();
+                tasks.add(task);
+                added++;
+            }
+            offset += max;
+        }
+        return tasks;
+    }
+
+    private <T> void addEntry(TarArchiveOutputStream out, String fileName, Class<T> type, T value) throws IOException {
+        if (value == null) {
+            return;
+        }
+        TarArchiveEntry entry = new TarArchiveEntry(fileName);
+        byte[] data = toJSON(type, value);
         entry.setSize(data.length);
         out.putArchiveEntry(entry);
         out.write(data);
         out.closeArchiveEntry();
     }
+
+    private void addFile(TarArchiveOutputStream out, String fileName, File file) throws IOException {
+        if (file == null) {
+            return;
+        }
+        compressExecutor.submit(new AddEntry(out, fileName, file));
+    }
+
+    private <T> byte[] toJSON(Class<T> type, T value) throws JsonProcessingException {
+        return JSON
+                .getContext(type)
+                .writerWithDefaultPrettyPrinter()
+                .writeValueAsBytes(value);
+    }
 }
+

--- a/src/main/java/io/seqera/tower/cli/commands/runs/DumpCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/DumpCmd.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021, Seqera Labs.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This Source Code Form is "Incompatible With Secondary Licenses", as
+ * defined by the Mozilla Public License, v. 2.0.
+ */
+
+package io.seqera.tower.cli.commands.runs;
+
+import io.seqera.tower.ApiException;
+import io.seqera.tower.JSON;
+import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
+import io.seqera.tower.cli.exceptions.RunNotFoundException;
+import io.seqera.tower.cli.exceptions.TowerException;
+import io.seqera.tower.cli.responses.Response;
+import io.seqera.tower.cli.responses.runs.RunDump;
+import io.seqera.tower.model.ServiceInfo;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.xz.XZCompressorOutputStream;
+import picocli.CommandLine;
+
+import java.io.BufferedOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+
+@CommandLine.Command(
+        name = "dump",
+        description = "Dump all logs and details of a run into a compressed tarball file for troubleshooting."
+)
+public class DumpCmd extends AbstractRunsCmd {
+
+    @CommandLine.Option(names = {"-i", "-id"}, description = "Pipeline run identifier.", required = true)
+    public String id;
+
+    @CommandLine.Option(names = {"-o", "--output"}, description = "Output file to store the dump.", required = true)
+    Path outputFile;
+
+    @CommandLine.Mixin
+    public WorkspaceOptionalOptions workspace;
+
+    private static JSON JSON = new JSON();
+
+    @Override
+    protected Response exec() throws ApiException, IOException {
+        Long wspId = workspaceId(workspace.workspace);
+
+        if (!outputFile.getFileName().toString().endsWith(".tar.xz")) {
+            throw new TowerException("Only 'tar.xz' format is supported. Output file name should end with '.tar.xz'");
+        }
+
+        try {
+
+            FileOutputStream fileOut = new FileOutputStream(outputFile.toFile());
+            BufferedOutputStream buffOut = new BufferedOutputStream(fileOut);
+            XZCompressorOutputStream xzOut = new XZCompressorOutputStream(buffOut);
+            TarArchiveOutputStream out = new TarArchiveOutputStream(xzOut);
+
+            addServiceInfo(out);
+
+            out.close();
+
+            return new RunDump(id, workspaceRef(wspId), outputFile);
+        } catch (ApiException e) {
+            if (e.getCode() == 403) {
+                throw new RunNotFoundException(id, workspaceRef(wspId));
+            }
+            throw e;
+        }
+    }
+
+    private void addServiceInfo(TarArchiveOutputStream out) throws ApiException, IOException {
+        byte[] data = JSON.getContext(ServiceInfo.class).writerWithDefaultPrettyPrinter().writeValueAsBytes(api().info().getServiceInfo());
+        TarArchiveEntry entry = new TarArchiveEntry("service-info.json");
+        entry.setSize(data.length);
+        out.putArchiveEntry(entry);
+        out.write(data);
+        out.closeArchiveEntry();
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/responses/runs/RunDump.java
+++ b/src/main/java/io/seqera/tower/cli/responses/runs/RunDump.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021, Seqera Labs.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This Source Code Form is "Incompatible With Secondary Licenses", as
+ * defined by the Mozilla Public License, v. 2.0.
+ */
+
+package io.seqera.tower.cli.responses.runs;
+
+import io.seqera.tower.cli.responses.Response;
+
+import java.nio.file.Path;
+
+public class RunDump extends Response {
+
+    public final String id;
+    public final String workspaceRef;
+    public final Path outputFile;
+
+    public RunDump(String id, String workspaceRef, Path outputFile) {
+        this.id = id;
+        this.workspaceRef = workspaceRef;
+        this.outputFile = outputFile;
+    }
+
+    @Override
+    public String toString() {
+        return ansi(String.format("%n  @|yellow Pipeline run '%s' at %s workspace details dump at '%s' |@%n", id, workspaceRef, outputFile.getFileName()));
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/utils/SilentPrintWriter.java
+++ b/src/main/java/io/seqera/tower/cli/utils/SilentPrintWriter.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2021, Seqera Labs.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This Source Code Form is "Incompatible With Secondary Licenses", as
+ * defined by the Mozilla Public License, v. 2.0.
+ */
+
 package io.seqera.tower.cli.utils;
 
 import java.io.OutputStream;

--- a/src/main/java/io/seqera/tower/cli/utils/SilentPrintWriter.java
+++ b/src/main/java/io/seqera/tower/cli/utils/SilentPrintWriter.java
@@ -1,0 +1,24 @@
+package io.seqera.tower.cli.utils;
+
+import java.io.OutputStream;
+import java.io.PrintWriter;
+
+public class SilentPrintWriter extends PrintWriter {
+
+    public SilentPrintWriter() {
+        super(new NullOutputStream());
+    }
+
+    private static class NullOutputStream extends OutputStream {
+        public void write(int b) {}
+    }
+
+    @Override
+    public void write(int c) {}
+
+    @Override
+    public void write(char[] buf, int off, int len) {}
+
+    @Override
+    public void write(String s, int off, int len) {}
+}


### PR DESCRIPTION
## Description

Allow to dump all the details and logs of a workflow run.

## Usage

```

Usage: tw runs dump [OPTIONS]

Dump all logs and details of a run into a compressed tarball file for troubleshooting.

Options:
* -i, -id=<id>                  Pipeline run identifier.
* -o, --output=<outputFile>     Output file to store the dump. (supported formats: .tar.xz and .tar.gz)
      --add-task-logs           Add all task stdout, stderr and log files.
      --add-fusion-logs         Add all Fusion task logs.
      --only-failed             Dump only failed tasks.
      --silent                  Do not show download progress.
  -w, --workspace=<workspace>   Workspace numeric identifier (TOWER_WORKSPACE_ID as default) or workspace reference as OrganizationName/WorkspaceName
  -h, --help                    Show this help message and exit.
  -V, --version                 Print version information and exit.
```

**Example:**

```
tw -v runs dump -w myorg/myworkspace -i 1YIxzBpS37MX3P -o ~/dumps/tower-run.tar.xz --only-failed --add-task-logs --add-fusion
```

**Note:** if the task logs files are big, the dump may take a long time to finish.

**Fixes** #295 