### PR TITLE
add PaginationInfo utility class, update list responses + UTs

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/collaborators/ListCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/collaborators/ListCmd.java
@@ -15,6 +15,7 @@ import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.global.PaginationOptions;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.collaborators.CollaboratorsList;
+import io.seqera.tower.cli.utils.PaginationInfo;
 import io.seqera.tower.model.ListMembersResponse;
 import io.seqera.tower.model.OrgAndWorkspaceDbDto;
 import picocli.CommandLine;
@@ -45,6 +46,6 @@ public class ListCmd extends AbstractCollaboratorsCmd {
 
         ListMembersResponse response = api().listOrganizationCollaborators(orgAndWorkspaceDbDto.getOrgId(), max, offset, startsWith);
 
-        return new CollaboratorsList(orgAndWorkspaceDbDto.getOrgId(), response.getMembers());
+        return new CollaboratorsList(orgAndWorkspaceDbDto.getOrgId(), response.getMembers(), PaginationInfo.from(paginationOptions, response.getTotalSize()));
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/labels/ListLabelsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/labels/ListLabelsCmd.java
@@ -16,6 +16,7 @@ import io.seqera.tower.cli.commands.global.PaginationOptions;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.labels.ListLabelsCmdResponse;
+import io.seqera.tower.cli.utils.PaginationInfo;
 import io.seqera.tower.model.LabelType;
 import io.seqera.tower.model.ListLabelsResponse;
 import picocli.CommandLine;
@@ -53,6 +54,6 @@ public class ListLabelsCmd extends AbstractLabelsCmd {
 
         ListLabelsResponse res = api().listLabels(wspId, max, offset, filter == null ? "" : filter, labelType, null);
 
-        return new ListLabelsCmdResponse(wspId, labelType, res.getLabels());
+        return new ListLabelsCmdResponse(wspId, labelType, res.getLabels(), PaginationInfo.from(paginationOptions, res.getTotalSize()));
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/participants/ListCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/participants/ListCmd.java
@@ -16,6 +16,7 @@ import io.seqera.tower.cli.commands.global.PaginationOptions;
 import io.seqera.tower.cli.commands.global.WorkspaceRequiredOptions;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.participants.ParticipantsList;
+import io.seqera.tower.cli.utils.PaginationInfo;
 import io.seqera.tower.model.ParticipantDbDto;
 import io.seqera.tower.model.ParticipantType;
 import picocli.CommandLine;
@@ -55,6 +56,6 @@ public class ListCmd extends AbstractParticipantsCmd {
             response = response.stream().filter(it -> it.getType() == type).collect(Collectors.toList());
         }
 
-        return new ParticipantsList(orgName(wspId), workspaceName(wspId), response);
+        return new ParticipantsList(orgName(wspId), workspaceName(wspId), response, PaginationInfo.from(paginationOptions));
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/ListCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/ListCmd.java
@@ -18,13 +18,13 @@ import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
 import io.seqera.tower.cli.exceptions.WorkspaceNotFoundException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.pipelines.PipelinesList;
+import io.seqera.tower.cli.utils.PaginationInfo;
 import io.seqera.tower.model.ListPipelinesResponse;
 import io.seqera.tower.model.PipelineQueryAttribute;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 
 @Command(
@@ -68,6 +68,6 @@ public class ListCmd extends AbstractPipelinesCmd {
             }
         }
 
-        return new PipelinesList(workspaceRef(wspId), response.getPipelines(), baseWorkspaceUrl(wspId), showLabelsOption.showLabels);
+        return new PipelinesList(workspaceRef(wspId), response.getPipelines(), baseWorkspaceUrl(wspId), showLabelsOption.showLabels, PaginationInfo.from(paginationOptions, response.getTotalSize()));
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/runs/ListCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/ListCmd.java
@@ -17,11 +17,11 @@ import io.seqera.tower.cli.commands.global.ShowLabelsOption;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.runs.RunList;
+import io.seqera.tower.cli.utils.PaginationInfo;
 import io.seqera.tower.model.ListWorkflowsResponse;
 import io.seqera.tower.model.WorkflowQueryAttribute;
 import picocli.CommandLine;
 
-import javax.ws.rs.QueryParam;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -57,7 +57,7 @@ public class ListCmd extends AbstractRunsCmd {
         }
 
         ListWorkflowsResponse response = api().listWorkflows(queryAttribute, wspId, max, offset, startsWith);
-        return new RunList(workspaceRef(wspId), response.getWorkflows(), baseWorkspaceUrl(wspId), showLabelsOption.showLabels);
+        return new RunList(workspaceRef(wspId), response.getWorkflows(), baseWorkspaceUrl(wspId), showLabelsOption.showLabels, PaginationInfo.from(paginationOptions, response.getTotalSize()));
     }
 
 

--- a/src/main/java/io/seqera/tower/cli/commands/runs/tasks/TasksCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/tasks/TasksCmd.java
@@ -18,6 +18,7 @@ import io.seqera.tower.cli.commands.runs.ViewCmd;
 import io.seqera.tower.cli.commands.runs.tasks.enums.TaskColumn;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.runs.tasks.TasksView;
+import io.seqera.tower.cli.utils.PaginationInfo;
 import io.seqera.tower.model.DescribeTaskResponse;
 import io.seqera.tower.model.ListTasksResponse;
 import io.seqera.tower.model.Task;
@@ -65,6 +66,6 @@ public class TasksCmd extends AbstractRunsCmd {
             Task task = describeTaskResponse.getTask();
             tasks.add(task);
         }
-        return new TasksView(parentCommand.id, cols, tasks);
+        return new TasksView(parentCommand.id, cols, tasks, PaginationInfo.from(paginationOptions));
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/teams/ListCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/teams/ListCmd.java
@@ -15,6 +15,7 @@ import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.global.PaginationOptions;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.teams.TeamsList;
+import io.seqera.tower.cli.utils.PaginationInfo;
 import io.seqera.tower.model.ListTeamResponse;
 import io.seqera.tower.model.OrgAndWorkspaceDbDto;
 import picocli.CommandLine;
@@ -42,6 +43,6 @@ public class ListCmd extends AbstractTeamsCmd {
 
         ListTeamResponse teamResponse = api().listOrganizationTeams(orgAndWorkspaceDbDto.getOrgId(), max, offset, null);
 
-        return new TeamsList(organizationRef, teamResponse.getTeams(), baseOrgUrl(orgAndWorkspaceDbDto.getOrgName()));
+        return new TeamsList(organizationRef, teamResponse.getTeams(), baseOrgUrl(orgAndWorkspaceDbDto.getOrgName()), PaginationInfo.from(paginationOptions, teamResponse.getTotalSize()));
     }
 }

--- a/src/main/java/io/seqera/tower/cli/responses/collaborators/CollaboratorsList.java
+++ b/src/main/java/io/seqera/tower/cli/responses/collaborators/CollaboratorsList.java
@@ -11,10 +11,13 @@
 
 package io.seqera.tower.cli.responses.collaborators;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.seqera.tower.cli.responses.Response;
+import io.seqera.tower.cli.utils.PaginationInfo;
 import io.seqera.tower.cli.utils.TableList;
 import io.seqera.tower.model.MemberDbDto;
 
+import javax.annotation.Nullable;
 import java.io.PrintWriter;
 import java.util.List;
 
@@ -23,9 +26,14 @@ public class CollaboratorsList extends Response {
     public final Long organizationId;
     public final List<MemberDbDto> members;
 
-    public CollaboratorsList(Long organizationId, List<MemberDbDto> members) {
+    @JsonIgnore
+    @Nullable
+    private PaginationInfo paginationInfo;
+
+    public CollaboratorsList(Long organizationId, List<MemberDbDto> members, @Nullable PaginationInfo paginationInfo) {
         this.organizationId = organizationId;
         this.members = members;
+        this.paginationInfo = paginationInfo;
     }
 
     @Override
@@ -44,7 +52,9 @@ public class CollaboratorsList extends Response {
         });
 
         table.print();
-        out.println("");
 
+        PaginationInfo.addFooter(out, paginationInfo);
+
+        out.println("");
     }
 }

--- a/src/main/java/io/seqera/tower/cli/responses/labels/ListLabelsCmdResponse.java
+++ b/src/main/java/io/seqera/tower/cli/responses/labels/ListLabelsCmdResponse.java
@@ -12,11 +12,14 @@
 
 package io.seqera.tower.cli.responses.labels;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.seqera.tower.cli.responses.Response;
+import io.seqera.tower.cli.utils.PaginationInfo;
 import io.seqera.tower.cli.utils.TableList;
 import io.seqera.tower.model.LabelDbDto;
 import io.seqera.tower.model.LabelType;
 
+import javax.annotation.Nullable;
 import java.io.PrintWriter;
 import java.util.List;
 
@@ -27,10 +30,15 @@ public class ListLabelsCmdResponse extends Response {
 
     public LabelType labelType;
 
-    public ListLabelsCmdResponse(Long wspId, LabelType labelType, List<LabelDbDto> labels) {
+    @JsonIgnore
+    @Nullable
+    private PaginationInfo paginationInfo;
+
+    public ListLabelsCmdResponse(Long wspId, LabelType labelType, List<LabelDbDto> labels, @Nullable PaginationInfo paginationInfo) {
         this.workspaceId = wspId;
         this.labels = labels;
         this.labelType = labelType;
+        this.paginationInfo = paginationInfo;
     }
 
     @Override
@@ -55,9 +63,12 @@ public class ListLabelsCmdResponse extends Response {
                 label.getValue(),
                 label.getResource() ? "Resource" : "Normal"
         ));
-        table.print();
-        out.println("");
 
+        table.print();
+
+        PaginationInfo.addFooter(out, paginationInfo);
+
+        out.println("");
     }
 
 }

--- a/src/main/java/io/seqera/tower/cli/responses/participants/ParticipantsList.java
+++ b/src/main/java/io/seqera/tower/cli/responses/participants/ParticipantsList.java
@@ -11,11 +11,14 @@
 
 package io.seqera.tower.cli.responses.participants;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.seqera.tower.cli.responses.Response;
+import io.seqera.tower.cli.utils.PaginationInfo;
 import io.seqera.tower.cli.utils.TableList;
 import io.seqera.tower.model.ParticipantDbDto;
 import io.seqera.tower.model.ParticipantType;
 
+import javax.annotation.Nullable;
 import java.io.PrintWriter;
 import java.util.List;
 
@@ -27,10 +30,15 @@ public class ParticipantsList extends Response {
     public final String workspaceName;
     public final List<ParticipantDbDto> participants;
 
-    public ParticipantsList(String organizationName, String workspaceName, List<ParticipantDbDto> participants) {
+    @JsonIgnore
+    @Nullable
+    private PaginationInfo paginationInfo;
+
+    public ParticipantsList(String organizationName, String workspaceName, List<ParticipantDbDto> participants, @Nullable PaginationInfo paginationInfo) {
         this.organizationName = organizationName;
         this.workspaceName = workspaceName;
         this.participants = participants;
+        this.paginationInfo = paginationInfo;
     }
 
     @Override
@@ -50,6 +58,9 @@ public class ParticipantsList extends Response {
         });
 
         table.print();
+
+        PaginationInfo.addFooter(out, paginationInfo);
+
         out.println("");
     }
 }

--- a/src/main/java/io/seqera/tower/cli/responses/pipelines/PipelinesList.java
+++ b/src/main/java/io/seqera/tower/cli/responses/pipelines/PipelinesList.java
@@ -13,14 +13,14 @@ package io.seqera.tower.cli.responses.pipelines;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.seqera.tower.cli.responses.Response;
+import io.seqera.tower.cli.utils.PaginationInfo;
 import io.seqera.tower.cli.utils.TableList;
-import io.seqera.tower.model.ListActionsResponseActionInfo;
 import io.seqera.tower.model.PipelineDbDto;
 
+import javax.annotation.Nullable;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static io.seqera.tower.cli.utils.FormatHelper.formatPipelineId;
 import static io.seqera.tower.cli.utils.FormatHelper.formatLabels;
@@ -36,11 +36,16 @@ public class PipelinesList extends Response {
     @JsonIgnore
     private boolean includeLabels;
 
-    public PipelinesList(String workspaceRef, List<PipelineDbDto> pipelines, String baseWorkspaceUrl, boolean includeLabels) {
+    @JsonIgnore
+    @Nullable
+    private PaginationInfo paginationInfo;
+
+    public PipelinesList(String workspaceRef, List<PipelineDbDto> pipelines, String baseWorkspaceUrl, boolean includeLabels, @Nullable PaginationInfo paginationInfo) {
         this.workspaceRef = workspaceRef;
         this.pipelines = pipelines;
         this.baseWorkspaceUrl = baseWorkspaceUrl;
         this.includeLabels = includeLabels;
+        this.paginationInfo = paginationInfo;
     }
 
     @Override
@@ -70,7 +75,11 @@ public class PipelinesList extends Response {
 
             table.addRow(rows.toArray(new String[rows.size()]));
         });
+
         table.print();
+
+        PaginationInfo.addFooter(out, paginationInfo);
+
         out.println("");
     }
 

--- a/src/main/java/io/seqera/tower/cli/responses/runs/RunList.java
+++ b/src/main/java/io/seqera/tower/cli/responses/runs/RunList.java
@@ -13,13 +13,14 @@ package io.seqera.tower.cli.responses.runs;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.seqera.tower.cli.responses.Response;
+import io.seqera.tower.cli.utils.PaginationInfo;
 import io.seqera.tower.cli.utils.TableList;
 import io.seqera.tower.model.ListWorkflowsResponseListWorkflowsElement;
 
+import javax.annotation.Nullable;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static io.seqera.tower.cli.utils.FormatHelper.formatTime;
 import static io.seqera.tower.cli.utils.FormatHelper.formatWorkflowId;
@@ -36,18 +37,16 @@ public class RunList extends Response {
     @JsonIgnore
     public final String baseWorkspaceUrl;
 
-    public RunList(String workspaceRef, List<ListWorkflowsResponseListWorkflowsElement> runs, String baseWorkspaceUrl, boolean showLabels) {
+    @JsonIgnore
+    @Nullable
+    private final PaginationInfo paginationInfo;
+
+    public RunList(String workspaceRef, List<ListWorkflowsResponseListWorkflowsElement> runs, String baseWorkspaceUrl, boolean showLabels, @Nullable PaginationInfo paginationInfo) {
         this.workspaceRef = workspaceRef;
         this.workflows = runs;
         this.baseWorkspaceUrl = baseWorkspaceUrl;
         this.showLabels = showLabels;
-    }
-
-    public RunList(String workspaceRef, List<ListWorkflowsResponseListWorkflowsElement> runs, String baseWorkspaceUrl) {
-        this.workspaceRef = workspaceRef;
-        this.workflows = runs;
-        this.baseWorkspaceUrl = baseWorkspaceUrl;
-        this.showLabels = false;
+        this.paginationInfo = paginationInfo;
     }
 
     @Override
@@ -83,8 +82,10 @@ public class RunList extends Response {
             table.addRow(rowsArray);
         });
 
-
         table.print();
+
+        PaginationInfo.addFooter(out, paginationInfo);
+
         out.println("");
     }
 

--- a/src/main/java/io/seqera/tower/cli/responses/runs/tasks/TasksView.java
+++ b/src/main/java/io/seqera/tower/cli/responses/runs/tasks/TasksView.java
@@ -11,11 +11,14 @@
 
 package io.seqera.tower.cli.responses.runs.tasks;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.seqera.tower.cli.commands.runs.tasks.enums.TaskColumn;
 import io.seqera.tower.cli.responses.Response;
+import io.seqera.tower.cli.utils.PaginationInfo;
 import io.seqera.tower.cli.utils.TableList;
 import io.seqera.tower.model.Task;
 
+import javax.annotation.Nullable;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,10 +31,15 @@ public class TasksView extends Response {
     public final List<TaskColumn> columns;
     public final List<Task> tasks;
 
-    public TasksView(String runId, List<TaskColumn> columns, List<Task> tasks) {
+    @JsonIgnore
+    @Nullable
+    private PaginationInfo paginationInfo;
+
+    public TasksView(String runId, List<TaskColumn> columns, List<Task> tasks, @Nullable PaginationInfo paginationInfo) {
         this.runId = runId;
         this.columns = columns;
         this.tasks = tasks;
+        this.paginationInfo = paginationInfo;
     }
 
     @Override
@@ -64,7 +72,11 @@ public class TasksView extends Response {
         result.forEach(it -> {
             table.addRow(it.toArray(new String[0]));
         });
+
         table.print();
+
+        PaginationInfo.addFooter(out, paginationInfo);
+
         out.println("");
     }
 }

--- a/src/main/java/io/seqera/tower/cli/responses/teams/TeamsList.java
+++ b/src/main/java/io/seqera/tower/cli/responses/teams/TeamsList.java
@@ -13,9 +13,11 @@ package io.seqera.tower.cli.responses.teams;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.seqera.tower.cli.responses.Response;
+import io.seqera.tower.cli.utils.PaginationInfo;
 import io.seqera.tower.cli.utils.TableList;
 import io.seqera.tower.model.TeamDbDto;
 
+import javax.annotation.Nullable;
 import java.io.PrintWriter;
 import java.util.List;
 
@@ -29,10 +31,15 @@ public class TeamsList extends Response {
     @JsonIgnore
     private String baseOrgUrl;
 
-    public TeamsList(String organizationName, List<TeamDbDto> teams, String baseOrgUrl) {
+    @JsonIgnore
+    @Nullable
+    private PaginationInfo paginationInfo;
+
+    public TeamsList(String organizationName, List<TeamDbDto> teams, String baseOrgUrl, @Nullable PaginationInfo paginationInfo) {
         this.organizationName = organizationName;
         this.teams = teams;
         this.baseOrgUrl = baseOrgUrl;
+        this.paginationInfo = paginationInfo;
     }
 
     @Override
@@ -51,6 +58,9 @@ public class TeamsList extends Response {
         });
 
         table.print();
+
+        PaginationInfo.addFooter(out, paginationInfo);
+
         out.println("");
 
     }

--- a/src/main/java/io/seqera/tower/cli/utils/PaginationInfo.java
+++ b/src/main/java/io/seqera/tower/cli/utils/PaginationInfo.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2021, Seqera Labs.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This Source Code Form is "Incompatible With Secondary Licenses", as
+ * defined by the Mozilla Public License, v. 2.0.
+ */
+
+
+package io.seqera.tower.cli.utils;
+
+import io.seqera.tower.cli.commands.global.PaginationOptions;
+import io.seqera.tower.cli.exceptions.TowerException;
+import io.seqera.tower.cli.responses.Response;
+
+import javax.annotation.Nullable;
+import java.io.PrintWriter;
+
+public class PaginationInfo extends Response {
+
+    private PaginationOptions paginationOptions;
+    private @Nullable Long totalSize;
+
+    private PaginationInfo(final PaginationOptions paginationOptions, final @Nullable Long totalSize) {
+        this.paginationOptions = paginationOptions;
+        this.totalSize = totalSize;
+    }
+
+    public static PaginationInfo from(final PaginationOptions paginationOptions) {
+        return new PaginationInfo(paginationOptions, null);
+    }
+    public static PaginationInfo from(
+            final PaginationOptions paginationOptions,
+            final Long totalSize
+    ) {
+        return new PaginationInfo(paginationOptions, totalSize);
+    }
+
+    public static PaginationInfo from(
+            final Integer offset,
+            final Integer max,
+            final Integer page,
+            final Long totalSize
+    ) {
+        PaginationOptions options = new PaginationOptions();
+        options.pageable = new PaginationOptions.Pageable();
+        options.sizeable = new PaginationOptions.Sizeable();
+        options.pageable.offset = offset;
+        options.pageable.page = page;
+        options.sizeable.max = max;
+        return new PaginationInfo(options, totalSize);
+    }
+
+    public static PaginationInfo from(
+            final Integer offset,
+            final Integer max,
+            final Long totalSize
+    ) {
+        return PaginationInfo.from(offset, max, null, totalSize);
+    }
+
+    public static PaginationInfo from(
+            final Integer offset,
+            final Integer max
+    ) {
+        return PaginationInfo.from(offset, max, null, null);
+    }
+
+    public static void addFooter(final PrintWriter out, final PaginationInfo paginationInfo) {
+        if (paginationInfo != null) paginationInfo.toString(out);
+    }
+
+    @Override
+    public void toString(PrintWriter out) {
+        try {
+            if (paginationOptions == null) return;
+            if (paginationOptions.pageable == null) return;
+
+            String msg = "";
+
+            if (paginationOptions.pageable.page != null) {
+                msg += String.format("Page %d, ", paginationOptions.pageable.page);
+                msg += "showing ";
+            } else {
+                msg += "Showing ";
+            }
+
+            Integer max = PaginationOptions.getMax(paginationOptions);
+            Integer offset = PaginationOptions.getOffset(paginationOptions, max);
+
+            msg += String.format("from %d to %d", offset, offset + max - 1);
+
+            if (totalSize != null) {
+                msg += String.format(" from a total of %d entries", totalSize);
+            }
+
+            out.println(ansi(String.format("%n  @|bold %s. |@%n", msg)));
+
+        } catch (TowerException ignore) {
+            // we expect the pagination options to throw way before we print the results
+        }
+    }
+
+}

--- a/src/test/java/io/seqera/tower/cli/collaborators/CollaboratorsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/collaborators/CollaboratorsCmdTest.java
@@ -73,6 +73,6 @@ class CollaboratorsCmdTest extends BaseCmdTest {
                         "      \"avatar\": \"https://www.gravatar.com/avatar/72918a9f674eaa696729917bec58760b?d=404\",\n" +
                         "      \"role\" : \"collaborator\"" +
                         "    }", MemberDbDto.class)
-        )));
+        ), null));
     }
 }

--- a/src/test/java/io/seqera/tower/cli/labels/LabelsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/labels/LabelsCmdTest.java
@@ -117,7 +117,8 @@ public class LabelsCmdTest extends BaseCmdTest {
                 List.of(makeLabelDbDto(97027588903667L,"awesome-label",null, false),
                         makeLabelDbDto(250670995082875L, "new-label", null, false),
                         makeLabelDbDto(55286297817389L, "newx-label",null, false),
-                        makeLabelDbDto(232243090533688L, "res-label","aaaa", true))
+                        makeLabelDbDto(232243090533688L, "res-label","aaaa", true)),
+                null
         ));
     }
 
@@ -147,7 +148,8 @@ public class LabelsCmdTest extends BaseCmdTest {
                 LabelType.SIMPLE,
                 List.of(makeLabelDbDto(97027588903667L,"awesome-label",null, false),
                         makeLabelDbDto(250670995082875L, "new-label", null, false),
-                        makeLabelDbDto(55286297817389L, "newx-label",null, false))
+                        makeLabelDbDto(55286297817389L, "newx-label",null, false)),
+                null
         ));
     }
 
@@ -177,7 +179,8 @@ public class LabelsCmdTest extends BaseCmdTest {
                 LabelType.RESOURCE,
                 List.of(makeLabelDbDto(97027588903667L,"awesome-label","aaa", true),
                         makeLabelDbDto(250670995082875L, "new-label", "bbb", true),
-                        makeLabelDbDto(55286297817389L, "newx-label","ccc", true))
+                        makeLabelDbDto(55286297817389L, "newx-label","ccc", true)),
+                null
         ));
     }
 
@@ -207,7 +210,8 @@ public class LabelsCmdTest extends BaseCmdTest {
                 LabelType.ALL,
                 List.of(makeLabelDbDto(97027588903667L,"res-find-label","aaa", true),
                         makeLabelDbDto(250670995082875L, "label-to-find", null, false),
-                        makeLabelDbDto(55286297817389L, "find-label","ccc", true))
+                        makeLabelDbDto(55286297817389L, "find-label","ccc", true)),
+                null
         ));
     }
 

--- a/src/test/java/io/seqera/tower/cli/participants/ParticipantsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/participants/ParticipantsCmdTest.java
@@ -20,6 +20,7 @@ import io.seqera.tower.cli.responses.participants.ParticipantDeleted;
 import io.seqera.tower.cli.responses.participants.ParticipantLeft;
 import io.seqera.tower.cli.responses.participants.ParticipantUpdated;
 import io.seqera.tower.cli.responses.participants.ParticipantsList;
+import io.seqera.tower.cli.utils.PaginationInfo;
 import io.seqera.tower.model.ParticipantDbDto;
 import io.seqera.tower.model.WspRole;
 import org.junit.jupiter.api.Test;
@@ -139,7 +140,7 @@ class ParticipantsCmdTest extends BaseCmdTest {
                                 "      \"type\": \"TEAM\",\n" +
                                 "      \"teamAvatarUrl\": null,\n" +
                                 "      \"userAvatarUrl\": null\n" +
-                                "    }", ParticipantDbDto.class))));
+                                "    }", ParticipantDbDto.class)), null));
     }
 
     @Test
@@ -243,7 +244,7 @@ class ParticipantsCmdTest extends BaseCmdTest {
                                 "      \"type\": \"TEAM\",\n" +
                                 "      \"teamAvatarUrl\": null,\n" +
                                 "      \"userAvatarUrl\": null\n" +
-                                "    }", ParticipantDbDto.class))).toString()), out.stdOut);
+                                "    }", ParticipantDbDto.class)), PaginationInfo.from(1, 2, null, null)).toString()), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -348,7 +349,7 @@ class ParticipantsCmdTest extends BaseCmdTest {
                                 "      \"type\": \"TEAM\",\n" +
                                 "      \"teamAvatarUrl\": null,\n" +
                                 "      \"userAvatarUrl\": null\n" +
-                                "    }", ParticipantDbDto.class))).toString()), out.stdOut);
+                                "    }", ParticipantDbDto.class)), PaginationInfo.from(null, 2, 1, null)).toString()), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -420,7 +421,7 @@ class ParticipantsCmdTest extends BaseCmdTest {
                                 "      \"type\": \"TEAM\",\n" +
                                 "      \"teamAvatarUrl\": null,\n" +
                                 "      \"userAvatarUrl\": null\n" +
-                                "    }", ParticipantDbDto.class))).toString()), out.stdOut);
+                                "    }", ParticipantDbDto.class)), null).toString()), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 

--- a/src/test/java/io/seqera/tower/cli/pipelines/PipelinesCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/pipelines/PipelinesCmdTest.java
@@ -32,6 +32,7 @@ import io.seqera.tower.cli.responses.pipelines.PipelinesList;
 import io.seqera.tower.cli.responses.pipelines.PipelinesUpdated;
 import io.seqera.tower.cli.responses.pipelines.PipelinesView;
 import io.seqera.tower.cli.utils.ModelHelper;
+import io.seqera.tower.cli.utils.PaginationInfo;
 import io.seqera.tower.model.ComputeEnv;
 import io.seqera.tower.model.CreatePipelineRequest;
 import io.seqera.tower.model.Launch;
@@ -307,7 +308,7 @@ class PipelinesCmdTest extends BaseCmdTest {
                         .repository("https://github.com/pditommaso/nf-sleep")
                         .userId(4L)
                         .userName("jordi")
-        ), baseUserUrl(mock, USER_WORKSPACE_NAME), false));
+        ), baseUserUrl(mock, USER_WORKSPACE_NAME), false, null));
     }
 
     @Test
@@ -331,7 +332,7 @@ class PipelinesCmdTest extends BaseCmdTest {
                         .repository("https://github.com/pditommaso/nf-sleep")
                         .userId(4L)
                         .userName("jordi")
-        ), baseUserUrl(mock, USER_WORKSPACE_NAME), false).toString()), out.stdOut);
+        ), baseUserUrl(mock, USER_WORKSPACE_NAME), false, PaginationInfo.from(1, 2, 1L)).toString()), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -362,7 +363,7 @@ class PipelinesCmdTest extends BaseCmdTest {
                         .repository("https://github.com/pditommaso/nf-sleep")
                         .userId(4L)
                         .userName("jordi")
-        ), baseUserUrl(mock, USER_WORKSPACE_NAME), false).toString()), out.stdOut);
+        ), baseUserUrl(mock, USER_WORKSPACE_NAME), false, PaginationInfo.from(null, 2,1, 1L)).toString()), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -402,7 +403,7 @@ class PipelinesCmdTest extends BaseCmdTest {
         ExecOut out = exec(mock, "pipelines", "list");
 
         assertEquals("", out.stdErr);
-        assertEquals(chop(new PipelinesList(USER_WORKSPACE_NAME, List.of(), baseUserUrl(mock, USER_WORKSPACE_NAME), false).toString()), out.stdOut);
+        assertEquals(chop(new PipelinesList(USER_WORKSPACE_NAME, List.of(), baseUserUrl(mock, USER_WORKSPACE_NAME), false, null).toString()), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -485,7 +486,7 @@ class PipelinesCmdTest extends BaseCmdTest {
         ExecOut out = exec(mock, "pipelines", "list", "-w", "222756650686576");
 
         assertEquals("", out.stdErr);
-        assertEquals(chop(new PipelinesList(buildWorkspaceRef("Seqera", "cli"), List.of(), baseWorkspaceUrl(mock, "Seqera", "cli"), false).toString()), out.stdOut);
+        assertEquals(chop(new PipelinesList(buildWorkspaceRef("Seqera", "cli"), List.of(), baseWorkspaceUrl(mock, "Seqera", "cli"), false, null).toString()), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 

--- a/src/test/java/io/seqera/tower/cli/runs/RunsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/runs/RunsCmdTest.java
@@ -25,6 +25,7 @@ import io.seqera.tower.cli.responses.runs.RunFileDownloaded;
 import io.seqera.tower.cli.responses.runs.RunList;
 import io.seqera.tower.cli.responses.runs.RunSubmited;
 import io.seqera.tower.cli.responses.runs.RunView;
+import io.seqera.tower.cli.utils.PaginationInfo;
 import io.seqera.tower.model.ListWorkflowsResponseListWorkflowsElement;
 import io.seqera.tower.model.Workflow;
 import io.seqera.tower.model.WorkflowLoad;
@@ -151,7 +152,7 @@ class RunsCmdTest extends BaseCmdTest {
                         "        \"runName\": \"spontaneous_easley\"\n" +
                         "      }\n" +
                         "    }", ListWorkflowsResponseListWorkflowsElement.class)
-        ), baseUserUrl(mock, USER_WORKSPACE_NAME)));
+        ), baseUserUrl(mock, USER_WORKSPACE_NAME), false, null));
     }
 
     @Test
@@ -199,7 +200,7 @@ class RunsCmdTest extends BaseCmdTest {
                         "        \"runName\": \"spontaneous_easley\"\n" +
                         "      }\n" +
                         "    }", ListWorkflowsResponseListWorkflowsElement.class)
-        ), baseUserUrl(mock, USER_WORKSPACE_NAME)).toString()), out.stdOut);
+        ), baseUserUrl(mock, USER_WORKSPACE_NAME), false, PaginationInfo.from(1, 2)).toString()), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -248,7 +249,7 @@ class RunsCmdTest extends BaseCmdTest {
                         "        \"runName\": \"spontaneous_easley\"\n" +
                         "      }\n" +
                         "    }", ListWorkflowsResponseListWorkflowsElement.class)
-        ), baseUserUrl(mock, USER_WORKSPACE_NAME)).toString()), out.stdOut);
+        ), baseUserUrl(mock, USER_WORKSPACE_NAME), false, PaginationInfo.from(null, 2, 1, null)).toString()), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -280,7 +281,7 @@ class RunsCmdTest extends BaseCmdTest {
         ExecOut out = exec(mock, "runs", "list");
 
         assertEquals("", out.stdErr);
-        assertEquals(chop(new RunList(USER_WORKSPACE_NAME, List.of(), baseUserUrl(mock, USER_WORKSPACE_NAME)).toString()), out.stdOut);
+        assertEquals(chop(new RunList(USER_WORKSPACE_NAME, List.of(), baseUserUrl(mock, USER_WORKSPACE_NAME), false, null).toString()), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 

--- a/src/test/java/io/seqera/tower/cli/runs/TasksCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/runs/TasksCmdTest.java
@@ -58,7 +58,7 @@ class TasksCmdTest extends BaseCmdTest {
         );
 
         assertEquals("", out.stdErr);
-        assertEquals(StringUtils.chop(new TasksView("2zGxKoqlnVmGL", cols, tasks).toString()), out.stdOut);
+        assertEquals(StringUtils.chop(new TasksView("2zGxKoqlnVmGL", cols, tasks, null).toString()), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 }

--- a/src/test/java/io/seqera/tower/cli/teams/TeamsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/teams/TeamsCmdTest.java
@@ -19,6 +19,7 @@ import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.responses.teams.TeamAdded;
 import io.seqera.tower.cli.responses.teams.TeamDeleted;
 import io.seqera.tower.cli.responses.teams.TeamsList;
+import io.seqera.tower.cli.utils.PaginationInfo;
 import io.seqera.tower.model.TeamDbDto;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -89,7 +90,7 @@ class TeamsCmdTest extends BaseCmdTest {
                         "      \"avatarUrl\": null,\n" +
                         "      \"membersCount\": 1\n" +
                         "    }", TeamDbDto.class)
-        ), baseOrgUrl(mock, "organization1")));
+        ), baseOrgUrl(mock, "organization1"), null));
     }
 
     @Test
@@ -111,20 +112,13 @@ class TeamsCmdTest extends BaseCmdTest {
                         .withQueryStringParameter("offset", "1")
                         .withQueryStringParameter("max", "2"), exactly(1)
         ).respond(
-                response().withStatusCode(200).withBody(loadResource("teams/teams_list")).withContentType(MediaType.APPLICATION_JSON)
+                response().withStatusCode(200).withBody(loadResource("teams/teams_list_redux")).withContentType(MediaType.APPLICATION_JSON)
         );
 
         ExecOut out = exec(mock, "teams", "list", "-o", "organization1", "--offset", "1", "--max", "2");
 
         assertEquals("", out.stdErr);
         assertEquals(chop(new TeamsList("organization1", Arrays.asList(
-                parseJson(" {\n" +
-                        "      \"teamId\": 249211453903161,\n" +
-                        "      \"name\": \"team-test-3\",\n" +
-                        "      \"description\": \"AAAAAA\",\n" +
-                        "      \"avatarUrl\": null,\n" +
-                        "      \"membersCount\": 0\n" +
-                        "    }", TeamDbDto.class),
                 parseJson(" {\n" +
                         "      \"teamId\": 69076469523589,\n" +
                         "      \"name\": \"team-test-1\",\n" +
@@ -138,15 +132,8 @@ class TeamsCmdTest extends BaseCmdTest {
                         "      \"description\": \"a new team\",\n" +
                         "      \"avatarUrl\": null,\n" +
                         "      \"membersCount\": 0\n" +
-                        "    }", TeamDbDto.class),
-                parseJson("{\n" +
-                        "      \"teamId\": 267477500890054,\n" +
-                        "      \"name\": \"team1\",\n" +
-                        "      \"description\": \"Team 1\",\n" +
-                        "      \"avatarUrl\": null,\n" +
-                        "      \"membersCount\": 1\n" +
                         "    }", TeamDbDto.class)
-        ), baseOrgUrl(mock, "organization1")).toString()), out.stdOut);
+        ), baseOrgUrl(mock, "organization1"), PaginationInfo.from(1, 2)).toString()), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -204,7 +191,7 @@ class TeamsCmdTest extends BaseCmdTest {
                         "      \"avatarUrl\": null,\n" +
                         "      \"membersCount\": 1\n" +
                         "    }", TeamDbDto.class)
-        ), baseOrgUrl(mock, "organization1")).toString()), out.stdOut);
+        ), baseOrgUrl(mock, "organization1"), PaginationInfo.from(null, 2, 1, null)).toString()), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 
@@ -260,7 +247,7 @@ class TeamsCmdTest extends BaseCmdTest {
         ExecOut out = exec(mock, "teams", "list", "-o", "organization1");
 
         assertEquals("", out.stdErr);
-        assertEquals(chop(new TeamsList("organization1", List.of(), baseOrgUrl(mock, "organization1")).toString()), out.stdOut);
+        assertEquals(chop(new TeamsList("organization1", List.of(), baseOrgUrl(mock, "organization1"), null).toString()), out.stdOut);
         assertEquals(0, out.exitCode);
     }
 

--- a/src/test/resources/runcmd/teams/teams_list_redux.json
+++ b/src/test/resources/runcmd/teams/teams_list_redux.json
@@ -1,0 +1,18 @@
+{
+  "teams": [
+    {
+      "teamId": 69076469523589,
+      "name": "team-test-1",
+      "description": "a new team",
+      "avatarUrl": null,
+      "membersCount": 0
+    },
+    {
+      "teamId": 255717345477198,
+      "name": "team-test-2",
+      "description": "a new team",
+      "avatarUrl": null,
+      "membersCount": 0
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Closes #223

Show pagination info in commands listing multiple items.
When providing pagination flags to commands the CLI will show page, offset and total size (if available) in the collection being listed.

## Guidelines for testing
**For each** of the subcommands: `collaborators list`, `labels list`, `participants list`, `pipelines list` and `runs view tasks`
**When** listing items using pagination parameters.
**Then** the results include a footer note showing the pagination parameters.
```
$> tw pipelines list -w community/showcase --page 1 --max 4

  Pipelines at [community / showcase] workspace:

     ID              | Name                      | Repository                                               | Visibility 
    -----------------+---------------------------+----------------------------------------------------------+------------
     262581335123346 | nf-core-atacseq           | https://github.com/nf-core/atacseq                       | PRIVATE    
     264225095367312 | nf-core-bacass            | https://github.com/nf-core/bacass                        | PRIVATE    
     276638579624743 | gatk-germline-snps-indels | https://github.com/seqeralabs/gatk4-germline-snps-indels | PRIVATE    
     79927646238767  | nf-core-ampliseq          | https://github.com/nf-core/ampliseq                      | PRIVATE    

  Page 1, showing from 0 to 3 from a total of 14 entries. 
```
```
$> tw pipelines list -w community/showcase --offset 2 --max 4

  Pipelines at [community / showcase] workspace:

     ID              | Name             | Repository                          | Visibility 
    -----------------+------------------+-------------------------------------+------------
     179266895536423 | nf-core-chipseq  | https://github.com/nf-core/chipseq  | PRIVATE    
     192001841863803 | nf-core-mhcquant | https://github.com/nf-core/mhcquant | PRIVATE    
     262581335123346 | nf-core-atacseq  | https://github.com/nf-core/atacseq  | PRIVATE    
     264225095367312 | nf-core-bacass   | https://github.com/nf-core/bacass   | PRIVATE    

  Showing from 2 to 5 from a total of 14 entries. 
```

