### PR TITLE
Add fusionV2 and wave for Azure CE

### DIFF
--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -2150,19 +2150,22 @@
   "name":"io.seqera.tower.model.AzBatchConfig",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"getAutoPoolMode","parameterTypes":[] }, {"name":"getDeleteJobsOnCompletion","parameterTypes":[] }, {"name":"getDeletePoolsOnCompletion","parameterTypes":[] }, {"name":"getDiscriminator","parameterTypes":[] }, {"name":"getEnvironment","parameterTypes":[] }, {"name":"getForge","parameterTypes":[] }, {"name":"getFusion2Enabled","parameterTypes":[] }, {"name":"getHeadPool","parameterTypes":[] }, {"name":"getPostRunScript","parameterTypes":[] }, {"name":"getPreRunScript","parameterTypes":[] }, {"name":"getRegion","parameterTypes":[] }, {"name":"getTokenDuration","parameterTypes":[] }, {"name":"getWaveEnabled","parameterTypes":[] }, {"name":"getWorkDir","parameterTypes":[] }]
 },
 {
   "name":"io.seqera.tower.model.AzBatchForgeConfig",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"getAutoScale","parameterTypes":[] }, {"name":"getContainerRegIds","parameterTypes":[] }, {"name":"getDisposeOnDeletion","parameterTypes":[] }, {"name":"getVmCount","parameterTypes":[] }, {"name":"getVmType","parameterTypes":[] }]
 },
 {
   "name":"io.seqera.tower.model.AzureSecurityKeys",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setBatchKey","parameterTypes":["java.lang.String"] }, {"name":"setBatchName","parameterTypes":["java.lang.String"] }, {"name":"setStorageKey","parameterTypes":["java.lang.String"] }, {"name":"setStorageName","parameterTypes":["java.lang.String"] }]
 },
 {
   "name":"io.seqera.tower.model.BitBucketSecurityKeys",

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchForgePlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchForgePlatform.java
@@ -48,7 +48,7 @@ public class AzBatchForgePlatform extends AbstractPlatform<AzBatchConfig> {
     @Option(names = {"--registry-credentials"}, split = ",", paramLabel = "<credential_name>", description = "Comma-separated list of container registry credentials name.")
     public List<String> registryCredentials;
 
-    @Option(names = {"--fusion-v2"}, description = "With Fusion v2 enabled, S3 buckets specified in the Pipeline work directory and Allowed S3 Buckets fields will be accessible in the compute nodes storage (requires Wave containers service).")
+    @Option(names = {"--fusion-v2"}, description = "With Fusion v2 enabled, Azure blob containers specified in the pipeline work directory and blob containers within the Azure storage account will be accessible in the compute nodes storage (requires Wave containers service).")
     public boolean fusionV2;
 
     @Option(names = {"--wave"}, description = "Allow access to private container repositories and the provisioning of containers in your Nextflow pipelines via the Wave containers service.")

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchForgePlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchForgePlatform.java
@@ -48,6 +48,11 @@ public class AzBatchForgePlatform extends AbstractPlatform<AzBatchConfig> {
     @Option(names = {"--registry-credentials"}, split = ",", paramLabel = "<credential_name>", description = "Comma-separated list of container registry credentials name.")
     public List<String> registryCredentials;
 
+    @Option(names = {"--fusion-v2"}, description = "With Fusion v2 enabled, S3 buckets specified in the Pipeline work directory and Allowed S3 Buckets fields will be accessible in the compute nodes storage (requires Wave containers service).")
+    public boolean fusionV2;
+
+    @Option(names = {"--wave"}, description = "Allow access to private container repositories and the provisioning of containers in your Nextflow pipelines via the Wave containers service.")
+    public boolean wave;
 
     @ArgGroup(heading = "%nAdvanced options:%n", validate = false)
     public AdvancedOptions adv;
@@ -66,6 +71,8 @@ public class AzBatchForgePlatform extends AbstractPlatform<AzBatchConfig> {
                 .preRunScript(preRunScriptString())
                 .postRunScript(postRunScriptString())
                 .environment(environmentVariables())
+                .fusion2Enabled(fusionV2)
+                .waveEnabled(wave)
                 .region(location);
 
         if (adv != null) {

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchManualPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchManualPlatform.java
@@ -28,6 +28,12 @@ public class AzBatchManualPlatform extends AbstractPlatform<AzBatchConfig> {
     @Option(names = {"--compute-pool-name"}, description = "The Azure Batch compute pool to be used to run the Nextflow jobs. This needs to be a pre-configured Batch compute pool which includes the azcopy command line (see the Tower documentation for details).", required = true)
     public String computePoolName;
 
+    @Option(names = {"--fusion-v2"}, description = "With Fusion v2 enabled, S3 buckets specified in the Pipeline work directory and Allowed S3 Buckets fields will be accessible in the compute nodes storage (requires Wave containers service).")
+    public boolean fusionV2;
+
+    @Option(names = {"--wave"}, description = "Allow access to private container repositories and the provisioning of containers in your Nextflow pipelines via the Wave containers service.")
+    public boolean wave;
+
     @ArgGroup(heading = "%nAdvanced options:%n", validate = false)
     public AdvancedOptions adv;
 
@@ -45,6 +51,8 @@ public class AzBatchManualPlatform extends AbstractPlatform<AzBatchConfig> {
                 .preRunScript(preRunScriptString())
                 .postRunScript(postRunScriptString())
                 .environment(environmentVariables())
+                .fusion2Enabled(fusionV2)
+                .waveEnabled(wave)
                 .region(location)
                 .headPool(computePoolName);
 

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchManualPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchManualPlatform.java
@@ -28,7 +28,7 @@ public class AzBatchManualPlatform extends AbstractPlatform<AzBatchConfig> {
     @Option(names = {"--compute-pool-name"}, description = "The Azure Batch compute pool to be used to run the Nextflow jobs. This needs to be a pre-configured Batch compute pool which includes the azcopy command line (see the Tower documentation for details).", required = true)
     public String computePoolName;
 
-    @Option(names = {"--fusion-v2"}, description = "With Fusion v2 enabled, S3 buckets specified in the Pipeline work directory and Allowed S3 Buckets fields will be accessible in the compute nodes storage (requires Wave containers service).")
+    @Option(names = {"--fusion-v2"}, description = "With Fusion v2 enabled, Azure blob containers specified in the pipeline work directory and blob containers within the Azure storage account will be accessible in the compute nodes storage (requires Wave containers service).")
     public boolean fusionV2;
 
     @Option(names = {"--wave"}, description = "Allow access to private container repositories and the provisioning of containers in your Nextflow pipelines via the Wave containers service.")

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AzBatchForgePlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AzBatchForgePlatformTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockserver.client.MockServerClient;
+import org.mockserver.model.JsonBody;
 import org.mockserver.model.MediaType;
 
 import static io.seqera.tower.cli.commands.AbstractApiCmd.USER_WORKSPACE_NAME;
@@ -33,6 +34,8 @@ class AzBatchForgePlatformTest extends BaseCmdTest {
     @EnumSource(OutputType.class)
     void testAdd(OutputType format, MockServerClient mock) {
 
+        mock.reset();
+
         mock.when(
                 request().withMethod("GET").withPath("/credentials").withQueryStringParameter("platformId", "azure-batch"), exactly(1)
         ).respond(
@@ -40,7 +43,7 @@ class AzBatchForgePlatformTest extends BaseCmdTest {
         );
 
         mock.when(
-                request().withMethod("POST").withPath("/compute-envs").withBody("{\"computeEnv\":{\"name\":\"azure\",\"platform\":\"azure-batch\",\"config\":{\"workDir\":\"az://nextflow-ci/jordeu\",\"region\":\"europe\",\"forge\":{\"vmCount\":10,\"autoScale\":true,\"disposeOnDeletion\":true}},\"credentialsId\":\"57Ic6reczFn78H1DTaaXkp\"}}"), exactly(1)
+                request().withMethod("POST").withPath("/compute-envs").withBody(JsonBody.json("{\"computeEnv\":{\"name\":\"azure\",\"platform\":\"azure-batch\",\"config\":{\"workDir\":\"az://nextflow-ci/jordeu\",\"region\":\"europe\",\"forge\":{\"vmCount\":10,\"autoScale\":true,\"disposeOnDeletion\":true}},\"credentialsId\":\"57Ic6reczFn78H1DTaaXkp\"}}")), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}").withContentType(MediaType.APPLICATION_JSON)
         );
@@ -52,6 +55,8 @@ class AzBatchForgePlatformTest extends BaseCmdTest {
     @Test
     void testAddWithAdvancedOptions(MockServerClient mock) {
 
+        mock.reset();
+
         mock.when(
                 request().withMethod("GET").withPath("/credentials").withQueryStringParameter("platformId", "azure-batch"), exactly(1)
         ).respond(
@@ -59,12 +64,12 @@ class AzBatchForgePlatformTest extends BaseCmdTest {
         );
 
         mock.when(
-                request().withMethod("POST").withPath("/compute-envs").withBody("{\"computeEnv\":{\"name\":\"azure\",\"platform\":\"azure-batch\",\"config\":{\"workDir\":\"az://nextflow-ci/jordeu\",\"region\":\"europe\",\"forge\":{\"vmCount\":10,\"autoScale\":true,\"disposeOnDeletion\":true},\"tokenDuration\":\"24\"},\"credentialsId\":\"57Ic6reczFn78H1DTaaXkp\"}}"), exactly(1)
+                request().withMethod("POST").withPath("/compute-envs").withBody(JsonBody.json("{\"computeEnv\":{\"name\":\"azure\",\"platform\":\"azure-batch\",\"config\":{\"workDir\":\"az://nextflow-ci/jordeu\",\"region\":\"europe\",\"fusion2Enabled\":true,\"waveEnabled\":true,\"forge\":{\"vmCount\":10,\"autoScale\":true,\"disposeOnDeletion\":true},\"tokenDuration\":\"24\"},\"credentialsId\":\"57Ic6reczFn78H1DTaaXkp\"}}")), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}").withContentType(MediaType.APPLICATION_JSON)
         );
 
-        ExecOut out = exec(mock, "compute-envs", "add", "azure-batch", "forge",  "-n", "azure", "-l", "europe", "--work-dir", "az://nextflow-ci/jordeu", "--token-duration=24", "--vm-count", "10");
+        ExecOut out = exec(mock, "compute-envs", "add", "azure-batch", "forge",  "-n", "azure", "-l", "europe", "--work-dir", "az://nextflow-ci/jordeu", "--fusion-v2", "--wave", "--token-duration=24", "--vm-count", "10");
 
         assertEquals("", out.stdErr);
         assertEquals(new ComputeEnvAdded("azure-batch", "isnEDBLvHDAIteOEF44ow", "azure", null, USER_WORKSPACE_NAME).toString(), out.stdOut);

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AzBatchManualPlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AzBatchManualPlatformTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockserver.client.MockServerClient;
+import org.mockserver.model.JsonBody;
 import org.mockserver.model.MediaType;
 
 import static io.seqera.tower.cli.commands.AbstractApiCmd.USER_WORKSPACE_NAME;
@@ -33,14 +34,16 @@ class AzBatchManualPlatformTest extends BaseCmdTest {
     @EnumSource(OutputType.class)
     void testAdd(OutputType format, MockServerClient mock) {
 
+        mock.reset();
+
         mock.when(
                 request().withMethod("GET").withPath("/credentials").withQueryStringParameter("platformId", "azure-batch"), exactly(1)
         ).respond(
-                response().withStatusCode(200).withBody("{\"credentials\":[{\"id\":\"57Ic6reczFn78H1DTaaXkp\",\"name\":\"azure\",\"description\":null,\"discriminator\":\"azure\",\"baseUrl\":null,\"category\":null,\"deleted\":null,\"lastUsed\":null,\"dateCreated\":\"2021-09-07T13:50:21Z\",\"lastUpdated\":\"2021-09-07T13:50:21Z\"}]}").withContentType(MediaType.APPLICATION_JSON)
+                response().withStatusCode(200).withBody(JsonBody.json("{\"credentials\":[{\"id\":\"57Ic6reczFn78H1DTaaXkp\",\"name\":\"azure\",\"description\":null,\"discriminator\":\"azure\",\"baseUrl\":null,\"category\":null,\"deleted\":null,\"lastUsed\":null,\"dateCreated\":\"2021-09-07T13:50:21Z\",\"lastUpdated\":\"2021-09-07T13:50:21Z\"}]}")).withContentType(MediaType.APPLICATION_JSON)
         );
 
         mock.when(
-                request().withMethod("POST").withPath("/compute-envs").withBody("{\"computeEnv\":{\"name\":\"azure-manual\",\"platform\":\"azure-batch\",\"config\":{\"workDir\":\"az://nextflow-ci/jordeu\",\"region\":\"europe\",\"headPool\":\"tower_pool\"},\"credentialsId\":\"57Ic6reczFn78H1DTaaXkp\"}}"), exactly(1)
+                request().withMethod("POST").withPath("/compute-envs").withBody(JsonBody.json("{\"computeEnv\":{\"name\":\"azure-manual\",\"platform\":\"azure-batch\",\"config\":{\"workDir\":\"az://nextflow-ci/jordeu\",\"region\":\"europe\",\"fusion2Enabled\":false,\"waveEnabled\":false,\"headPool\":\"tower_pool\"},\"credentialsId\":\"57Ic6reczFn78H1DTaaXkp\"}}")), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}").withContentType(MediaType.APPLICATION_JSON)
         );
@@ -52,6 +55,8 @@ class AzBatchManualPlatformTest extends BaseCmdTest {
     @Test
     void testAddWithAdvancedOptions(MockServerClient mock) {
 
+        mock.reset();
+
         mock.when(
                 request().withMethod("GET").withPath("/credentials").withQueryStringParameter("platformId", "azure-batch"), exactly(1)
         ).respond(
@@ -59,12 +64,12 @@ class AzBatchManualPlatformTest extends BaseCmdTest {
         );
 
         mock.when(
-                request().withMethod("POST").withPath("/compute-envs").withBody("{\"computeEnv\":{\"name\":\"azure-manual\",\"platform\":\"azure-batch\",\"config\":{\"workDir\":\"az://nextflow-ci/jordeu\",\"region\":\"europe\",\"headPool\":\"tower_pool\",\"tokenDuration\":\"24\"},\"credentialsId\":\"57Ic6reczFn78H1DTaaXkp\"}}"), exactly(1)
+                request().withMethod("POST").withPath("/compute-envs").withBody(JsonBody.json("{\"computeEnv\":{\"name\":\"azure-manual\",\"platform\":\"azure-batch\",\"config\":{\"workDir\":\"az://nextflow-ci/jordeu\",\"region\":\"europe\",\"fusion2Enabled\":true,\"waveEnabled\":true,\"headPool\":\"tower_pool\",\"tokenDuration\":\"24\"},\"credentialsId\":\"57Ic6reczFn78H1DTaaXkp\"}}")), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}").withContentType(MediaType.APPLICATION_JSON)
         );
 
-        ExecOut out = exec(mock, "compute-envs", "add", "azure-batch", "manual", "-n", "azure-manual", "-l", "europe", "--work-dir", "az://nextflow-ci/jordeu", "--compute-pool-name=tower_pool", "--token-duration=24");
+        ExecOut out = exec(mock, "compute-envs", "add", "azure-batch", "manual", "-n", "azure-manual", "-l", "europe", "--work-dir", "az://nextflow-ci/jordeu", "--fusion-v2", "--wave", "--compute-pool-name=tower_pool", "--token-duration=24");
 
         assertEquals("", out.stdErr);
         assertEquals(new ComputeEnvAdded("azure-batch", "isnEDBLvHDAIteOEF44ow", "azure-manual", null, USER_WORKSPACE_NAME).toString(), out.stdOut);


### PR DESCRIPTION
## Description

Add support for Fusion v2 and Wave when creating Azure CEs (forge and manual)
Closes #337 

## Guidelines for testing
To try the CE creation the following is needed:

+ Valid Azure credentials
+ Existing Azure storage path


```
./tw compute-envs add azure-batch forge \
-n AzureFusionTest \
-w Org/Wsp \
-c AzDevCreds \
--location westeurope \
--work-dir az://nf-scratch/work \
--vm-count 1 \
--fusion-v2 \
--wave
```
