### PR TITLE
Add Fusion v2 and Wave support for Google Batch CE

### DIFF
--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -1667,12 +1667,6 @@
   "queryAllDeclaredConstructors":true
 },
 {
-  "name":"io.seqera.tower.cli.responses.computeenvs.ComputeEnvUpdated",
-  "allDeclaredFields":true,
-  "queryAllDeclaredMethods":true,
-  "queryAllDeclaredConstructors":true
-},
-{
   "name":"io.seqera.tower.cli.responses.computeenvs.ComputeEnvExport",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
@@ -1680,6 +1674,12 @@
 },
 {
   "name":"io.seqera.tower.cli.responses.computeenvs.ComputeEnvList",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "name":"io.seqera.tower.cli.responses.computeenvs.ComputeEnvUpdated",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true

--- a/conf/resource-config.json
+++ b/conf/resource-config.json
@@ -19,10 +19,10 @@
   }]},
   "bundles":[{
     "name":"org.glassfish.jersey.client.internal.localization",
-    "locales":["", "und"]
+    "locales":["und"]
   }, {
     "name":"org.glassfish.jersey.internal.localization",
-    "locales":["", "und"]
+    "locales":["und"]
   }, {
     "name":"org.glassfish.jersey.media.multipart.internal.localization"
   }]

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/GoogleBatchPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/GoogleBatchPlatform.java
@@ -27,6 +27,12 @@ public class GoogleBatchPlatform extends AbstractPlatform<GoogleBatchConfig> {
     @Option(names = {"--spot"}, description = "Use Spot virtual machines.")
     public Boolean spot;
 
+    @Option(names = {"--fusion-v2"}, description = "With Fusion v2 enabled, S3 buckets specified in the Pipeline work directory and Allowed S3 Buckets fields will be accessible in the compute nodes storage (requires Wave containers service).")
+    public boolean fusionV2;
+
+    @Option(names = {"--wave"}, description = "Allow access to private container repositories and the provisioning of containers in your Nextflow pipelines via the Wave containers service.")
+    public boolean wave;
+
     @ArgGroup(heading = "%nAdvanced options:%n", validate = false)
     public AdvancedOptions adv;
 
@@ -44,6 +50,8 @@ public class GoogleBatchPlatform extends AbstractPlatform<GoogleBatchConfig> {
                 .preRunScript(preRunScriptString())
                 .postRunScript(postRunScriptString())
                 .environment(environmentVariables())
+                .fusion2Enabled(fusionV2)
+                .waveEnabled(wave)
 
                 // Main
                 .location(location)

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/GoogleBatchPlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/GoogleBatchPlatformTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockserver.client.MockServerClient;
+import org.mockserver.model.JsonBody;
 import org.mockserver.model.MediaType;
 
 import java.io.IOException;
@@ -35,6 +36,8 @@ class GoogleBatchPlatformTest extends BaseCmdTest {
     @EnumSource(OutputType.class)
     void testAdd(OutputType format, MockServerClient mock) throws IOException {
 
+        mock.reset();
+
         mock.when(
                 request().withMethod("GET").withPath("/credentials").withQueryStringParameter("platformId", "google-batch"), exactly(1)
         ).respond(
@@ -42,7 +45,8 @@ class GoogleBatchPlatformTest extends BaseCmdTest {
         );
 
         mock.when(
-                request().withMethod("POST").withPath("/compute-envs").withBody("{\"computeEnv\":{\"name\":\"google\",\"platform\":\"google-batch\",\"config\":{\"location\":\"europe\",\"workDir\":\"gs://workdir\"},\"credentialsId\":\"6XfOhoztUq6de3Dw3X9LSb\"}}"), exactly(1)
+                request().withMethod("POST").withPath("/compute-envs")
+                        .withBody(JsonBody.json("{\"computeEnv\":{\"name\":\"google\",\"platform\":\"google-batch\",\"config\":{\"location\":\"europe\",\"fusion2Enabled\":false,\"waveEnabled\":false,\"workDir\":\"gs://workdir\"},\"credentialsId\":\"6XfOhoztUq6de3Dw3X9LSb\"}}")), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}").withContentType(MediaType.APPLICATION_JSON)
         );
@@ -54,6 +58,8 @@ class GoogleBatchPlatformTest extends BaseCmdTest {
     @Test
     void testAddWithAdvancedOptions(MockServerClient mock) throws IOException {
 
+        mock.reset();
+
         mock.when(
                 request().withMethod("GET").withPath("/credentials").withQueryStringParameter("platformId", "google-batch"), exactly(1)
         ).respond(
@@ -61,12 +67,13 @@ class GoogleBatchPlatformTest extends BaseCmdTest {
         );
 
         mock.when(
-                request().withMethod("POST").withPath("/compute-envs").withBody("{\"computeEnv\":{\"name\":\"google\",\"platform\":\"google-batch\",\"config\":{\"location\":\"europe\",\"workDir\":\"gs://workdir\",\"usePrivateAddress\":true},\"credentialsId\":\"6XfOhoztUq6de3Dw3X9LSb\"}}"), exactly(1)
+                request().withMethod("POST").withPath("/compute-envs")
+                        .withBody(JsonBody.json("{\"computeEnv\":{\"name\":\"google\",\"platform\":\"google-batch\",\"config\":{\"location\":\"europe\",\"fusion2Enabled\":true,\"waveEnabled\":true,\"workDir\":\"gs://workdir\",\"usePrivateAddress\":true},\"credentialsId\":\"6XfOhoztUq6de3Dw3X9LSb\"}}")), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}").withContentType(MediaType.APPLICATION_JSON)
         );
 
-        ExecOut out = exec(mock, "compute-envs", "add", "google-batch", "-n", "google", "--work-dir", "gs://workdir", "-l", "europe", "--use-private-address");
+        ExecOut out = exec(mock, "compute-envs", "add", "google-batch", "-n", "google", "--work-dir", "gs://workdir", "-l", "europe", "--fusion-v2", "--wave", "--use-private-address");
         assertEquals("", out.stdErr);
         assertEquals(new ComputeEnvAdded("google-batch", "isnEDBLvHDAIteOEF44ow", "google", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
         assertEquals(0, out.exitCode);


### PR DESCRIPTION
## Description

Add support for Fusion v2 and Wave when creating Google Batch CEs.
Closes #311 

## Guidelines for testing
To try the CE creation the following is needed:

+ Valid AWS credentials
+ Existing Google storage bucket

```
$> tw compute-envs add google-batch \
-n GoogleFusionTest \
-w Org/Wsp \
-c GoogleDevCreds \
-l europe-west2 \
--work-dir <google_storage_bucket> \
--spot \
--wave \
--fusion-v2
```
