### PR TITLE
Add overwrite option for tower entities

### DIFF
--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -123,6 +123,9 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"com.sun.jndi.url.java.javaURLContextFactory"
+},
+{
   "name":"groovy.lang.Closure"
 },
 {
@@ -2190,12 +2193,14 @@
   "name":"io.seqera.tower.model.ComputeEnv",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"getConfig","parameterTypes":[] }, {"name":"getCredentialsId","parameterTypes":[] }, {"name":"getDateCreated","parameterTypes":[] }, {"name":"getDeleted","parameterTypes":[] }, {"name":"getDescription","parameterTypes":[] }, {"name":"getId","parameterTypes":[] }, {"name":"getLastUpdated","parameterTypes":[] }, {"name":"getLastUsed","parameterTypes":[] }, {"name":"getMessage","parameterTypes":[] }, {"name":"getName","parameterTypes":[] }, {"name":"getOrgId","parameterTypes":[] }, {"name":"getPlatform","parameterTypes":[] }, {"name":"getPrimary","parameterTypes":[] }, {"name":"getStatus","parameterTypes":[] }, {"name":"getWorkspaceId","parameterTypes":[] }]
 },
 {
   "name":"io.seqera.tower.model.ComputeEnv$PlatformEnum",
   "allDeclaredFields":true,
-  "allDeclaredMethods":true
+  "allDeclaredMethods":true,
+  "methods":[{"name":"getValue","parameterTypes":[] }]
 },
 {
   "name":"io.seqera.tower.model.ComputeEnvDbDto",
@@ -2257,13 +2262,15 @@
   "name":"io.seqera.tower.model.CreateComputeEnvRequest",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"getComputeEnv","parameterTypes":[] }, {"name":"getLabelIds","parameterTypes":[] }]
 },
 {
   "name":"io.seqera.tower.model.CreateComputeEnvResponse",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setComputeEnvId","parameterTypes":["java.lang.String"] }]
 },
 {
   "name":"io.seqera.tower.model.CreateCredentialsRequest",
@@ -2377,12 +2384,14 @@
   "name":"io.seqera.tower.model.Credentials",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setBaseUrl","parameterTypes":["java.lang.String"] }, {"name":"setCategory","parameterTypes":["java.lang.String"] }, {"name":"setDescription","parameterTypes":["java.lang.String"] }, {"name":"setId","parameterTypes":["java.lang.String"] }, {"name":"setKeys","parameterTypes":["io.seqera.tower.model.SecurityKeys"] }, {"name":"setName","parameterTypes":["java.lang.String"] }, {"name":"setProvider","parameterTypes":["io.seqera.tower.model.Credentials$ProviderEnum"] }]
 },
 {
   "name":"io.seqera.tower.model.Credentials$ProviderEnum",
   "allDeclaredFields":true,
-  "allDeclaredMethods":true
+  "allDeclaredMethods":true,
+  "methods":[{"name":"fromValue","parameterTypes":["java.lang.String"] }]
 },
 {
   "name":"io.seqera.tower.model.Dataset",
@@ -2563,7 +2572,8 @@
   "name":"io.seqera.tower.model.GoogleSecurityKeys",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setData","parameterTypes":["java.lang.String"] }]
 },
 {
   "name":"io.seqera.tower.model.JobCleanupPolicy",
@@ -2649,7 +2659,8 @@
   "name":"io.seqera.tower.model.ListCredentialsResponse",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setCredentials","parameterTypes":["java.util.List"] }]
 },
 {
   "name":"io.seqera.tower.model.ListDatasetVersionsResponse",
@@ -2766,7 +2777,7 @@
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true,
-  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setOrgId","parameterTypes":["java.lang.Long"] }, {"name":"setOrgLogoUrl","parameterTypes":["java.lang.String"] }, {"name":"setOrgName","parameterTypes":["java.lang.String"] }, {"name":"setWorkspaceFullName","parameterTypes":["java.lang.String"] }, {"name":"setWorkspaceId","parameterTypes":["java.lang.Long"] }, {"name":"setWorkspaceName","parameterTypes":["java.lang.String"] }]
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setOrgId","parameterTypes":["java.lang.Long"] }, {"name":"setOrgLogoUrl","parameterTypes":["java.lang.String"] }, {"name":"setOrgName","parameterTypes":["java.lang.String"] }, {"name":"setVisibility","parameterTypes":["io.seqera.tower.model.Visibility"] }, {"name":"setWorkspaceFullName","parameterTypes":["java.lang.String"] }, {"name":"setWorkspaceId","parameterTypes":["java.lang.Long"] }, {"name":"setWorkspaceName","parameterTypes":["java.lang.String"] }]
 },
 {
   "name":"io.seqera.tower.model.OrgRole",
@@ -3011,7 +3022,7 @@
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true,
-  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setAvatar","parameterTypes":["java.lang.String"] }, {"name":"setDescription","parameterTypes":["java.lang.String"] }, {"name":"setFirstName","parameterTypes":["java.lang.String"] }, {"name":"setId_JsonNullable","parameterTypes":["org.openapitools.jackson.nullable.JsonNullable"] }, {"name":"setLastName","parameterTypes":["java.lang.String"] }, {"name":"setNotification","parameterTypes":["java.lang.Boolean"] }, {"name":"setOrganization","parameterTypes":["java.lang.String"] }, {"name":"setUserName","parameterTypes":["java.lang.String"] }]
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setAvatar","parameterTypes":["java.lang.String"] }, {"name":"setAvatarId","parameterTypes":["java.lang.String"] }, {"name":"setDateCreated","parameterTypes":["java.time.OffsetDateTime"] }, {"name":"setDeleted","parameterTypes":["java.lang.Boolean"] }, {"name":"setDescription","parameterTypes":["java.lang.String"] }, {"name":"setEmail","parameterTypes":["java.lang.String"] }, {"name":"setFirstName","parameterTypes":["java.lang.String"] }, {"name":"setId","parameterTypes":["java.lang.Long"] }, {"name":"setId_JsonNullable","parameterTypes":["org.openapitools.jackson.nullable.JsonNullable"] }, {"name":"setLastAccess","parameterTypes":["java.time.OffsetDateTime"] }, {"name":"setLastName","parameterTypes":["java.lang.String"] }, {"name":"setLastUpdated","parameterTypes":["java.time.OffsetDateTime"] }, {"name":"setMarketingConsent","parameterTypes":["java.lang.Boolean"] }, {"name":"setNotification","parameterTypes":["java.lang.Boolean"] }, {"name":"setOrganization","parameterTypes":["java.lang.String"] }, {"name":"setTermsOfUseConsent","parameterTypes":["java.lang.Boolean"] }, {"name":"setUserName","parameterTypes":["java.lang.String"] }]
 },
 {
   "name":"io.seqera.tower.model.UserOptions",
@@ -3023,7 +3034,8 @@
 {
   "name":"io.seqera.tower.model.Visibility",
   "allDeclaredFields":true,
-  "allDeclaredMethods":true
+  "allDeclaredMethods":true,
+  "methods":[{"name":"fromValue","parameterTypes":["java.lang.String"] }]
 },
 {
   "name":"io.seqera.tower.model.WfManifest",

--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -1670,12 +1670,6 @@
   "queryAllDeclaredConstructors":true
 },
 {
-  "name":"io.seqera.tower.cli.responses.computeenvs.ComputeEnvUpdated",
-  "allDeclaredFields":true,
-  "queryAllDeclaredMethods":true,
-  "queryAllDeclaredConstructors":true
-},
-{
   "name":"io.seqera.tower.cli.responses.computeenvs.ComputeEnvExport",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
@@ -1683,6 +1677,12 @@
 },
 {
   "name":"io.seqera.tower.cli.responses.computeenvs.ComputeEnvList",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "name":"io.seqera.tower.cli.responses.computeenvs.ComputeEnvUpdated",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true
@@ -2094,7 +2094,7 @@
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true,
-  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"getConnectionId","parameterTypes":[] }, {"name":"getDiscriminator","parameterTypes":[] }, {"name":"getShared","parameterTypes":[] }, {"name":"getWorkDir","parameterTypes":[] }, {"name":"setConnectionId","parameterTypes":["java.lang.String"] }, {"name":"setWorkDir","parameterTypes":["java.lang.String"] }]
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"getConnectionId","parameterTypes":[] }, {"name":"getDiscriminator","parameterTypes":[] }, {"name":"getShared","parameterTypes":[] }, {"name":"getWorkDir","parameterTypes":[] }, {"name":"setConnectionId","parameterTypes":["java.lang.String"] }, {"name":"setShared","parameterTypes":["java.lang.Boolean"] }, {"name":"setWorkDir","parameterTypes":["java.lang.String"] }]
 },
 {
   "name":"io.seqera.tower.model.AltairPbsComputeConfig",
@@ -2165,7 +2165,8 @@
   "name":"io.seqera.tower.model.AzureSecurityKeys",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setBatchKey","parameterTypes":["java.lang.String"] }, {"name":"setBatchName","parameterTypes":["java.lang.String"] }, {"name":"setStorageKey","parameterTypes":["java.lang.String"] }, {"name":"setStorageName","parameterTypes":["java.lang.String"] }]
 },
 {
   "name":"io.seqera.tower.model.BitBucketSecurityKeys",
@@ -2276,13 +2277,15 @@
   "name":"io.seqera.tower.model.CreateCredentialsRequest",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"getCredentials","parameterTypes":[] }]
 },
 {
   "name":"io.seqera.tower.model.CreateCredentialsResponse",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setCredentialsId","parameterTypes":["java.lang.String"] }]
 },
 {
   "name":"io.seqera.tower.model.CreateDatasetRequest",
@@ -2385,13 +2388,13 @@
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true,
-  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setBaseUrl","parameterTypes":["java.lang.String"] }, {"name":"setCategory","parameterTypes":["java.lang.String"] }, {"name":"setDescription","parameterTypes":["java.lang.String"] }, {"name":"setId","parameterTypes":["java.lang.String"] }, {"name":"setKeys","parameterTypes":["io.seqera.tower.model.SecurityKeys"] }, {"name":"setName","parameterTypes":["java.lang.String"] }, {"name":"setProvider","parameterTypes":["io.seqera.tower.model.Credentials$ProviderEnum"] }]
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"getBaseUrl","parameterTypes":[] }, {"name":"getCategory","parameterTypes":[] }, {"name":"getDateCreated","parameterTypes":[] }, {"name":"getDeleted","parameterTypes":[] }, {"name":"getDescription","parameterTypes":[] }, {"name":"getId","parameterTypes":[] }, {"name":"getKeys","parameterTypes":[] }, {"name":"getLastUpdated","parameterTypes":[] }, {"name":"getLastUsed","parameterTypes":[] }, {"name":"getName","parameterTypes":[] }, {"name":"getProvider","parameterTypes":[] }, {"name":"setBaseUrl","parameterTypes":["java.lang.String"] }, {"name":"setCategory","parameterTypes":["java.lang.String"] }, {"name":"setDescription","parameterTypes":["java.lang.String"] }, {"name":"setId","parameterTypes":["java.lang.String"] }, {"name":"setKeys","parameterTypes":["io.seqera.tower.model.SecurityKeys"] }, {"name":"setName","parameterTypes":["java.lang.String"] }, {"name":"setProvider","parameterTypes":["io.seqera.tower.model.Credentials$ProviderEnum"] }]
 },
 {
   "name":"io.seqera.tower.model.Credentials$ProviderEnum",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "methods":[{"name":"fromValue","parameterTypes":["java.lang.String"] }]
+  "methods":[{"name":"fromValue","parameterTypes":["java.lang.String"] }, {"name":"getValue","parameterTypes":[] }]
 },
 {
   "name":"io.seqera.tower.model.Dataset",
@@ -2523,7 +2526,8 @@
   "name":"io.seqera.tower.model.GitHubSecurityKeys",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setPassword","parameterTypes":["java.lang.String"] }, {"name":"setUsername","parameterTypes":["java.lang.String"] }]
 },
 {
   "name":"io.seqera.tower.model.GitLabSecurityKeys",
@@ -2859,7 +2863,8 @@
   "name":"io.seqera.tower.model.SSHSecurityKeys",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setPassphrase","parameterTypes":["java.lang.String"] }, {"name":"setPrivateKey","parameterTypes":["java.lang.String"] }]
 },
 {
   "name":"io.seqera.tower.model.SecurityKeys",
@@ -3452,13 +3457,15 @@
   "name":"javax.ws.rs.client.Entity",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"getAnnotations","parameterTypes":[] }, {"name":"getEncoding","parameterTypes":[] }, {"name":"getEntity","parameterTypes":[] }, {"name":"getLanguage","parameterTypes":[] }, {"name":"getMediaType","parameterTypes":[] }, {"name":"getVariant","parameterTypes":[] }]
 },
 {
   "name":"javax.ws.rs.core.MediaType",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"getParameters","parameterTypes":[] }, {"name":"getSubtype","parameterTypes":[] }, {"name":"getType","parameterTypes":[] }, {"name":"isWildcardSubtype","parameterTypes":[] }, {"name":"isWildcardType","parameterTypes":[] }]
 },
 {
   "name":"javax.ws.rs.core.MediaType[]"
@@ -3467,7 +3474,8 @@
   "name":"javax.ws.rs.core.Variant",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"getEncoding","parameterTypes":[] }, {"name":"getLanguage","parameterTypes":[] }, {"name":"getLanguageString","parameterTypes":[] }, {"name":"getMediaType","parameterTypes":[] }]
 },
 {
   "name":"long[]"

--- a/src/main/java/io/seqera/tower/cli/commands/actions/AbstractActionsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/actions/AbstractActionsCmd.java
@@ -18,7 +18,6 @@ import io.seqera.tower.model.ActionQueryAttribute;
 import io.seqera.tower.model.DescribeActionResponse;
 import io.seqera.tower.model.ListActionsResponse;
 import io.seqera.tower.model.ListActionsResponseActionInfo;
-import io.seqera.tower.model.ListLabelsResponse;
 import picocli.CommandLine;
 
 import java.util.List;
@@ -58,6 +57,15 @@ public abstract class AbstractActionsCmd extends AbstractApiCmd {
         }
 
         return response;
+    }
+
+    protected void deleteActionByName(String actionName, Long wspId) throws ActionNotFoundException, ApiException {
+        ListActionsResponseActionInfo info = actionByName(wspId, actionName);
+        deleteActionById(info.getId(), wspId);
+    }
+
+    protected void deleteActionById(String actionId, Long wspId) throws ActionNotFoundException, ApiException {
+        api().deleteAction(actionId, wspId);
     }
 
 }

--- a/src/main/java/io/seqera/tower/cli/commands/actions/DeleteCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/actions/DeleteCmd.java
@@ -49,7 +49,7 @@ public class DeleteCmd extends AbstractActionsCmd {
         }
 
         try {
-            api().deleteAction(id, wspId);
+            deleteActionById(id, wspId);
         } catch (Exception e) {
             throw new TowerException(String.format("Unable to delete action '%s' for workspace '%s'", actionRef, workspaceRef(wspId)));
         }

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/ImportCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/ImportCmd.java
@@ -15,14 +15,11 @@ import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.computeenvs.add.AbstractAddCmd;
 import io.seqera.tower.cli.commands.computeenvs.platforms.Platform;
 import io.seqera.tower.cli.exceptions.ComputeEnvNotFoundException;
-import io.seqera.tower.cli.exceptions.PipelineNotFoundException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.utils.FilesHelper;
 import io.seqera.tower.model.ComputeConfig;
 import io.seqera.tower.model.ComputeEnv;
-import io.seqera.tower.model.ComputeEnvDbDto;
 import io.seqera.tower.model.ComputeEnvResponseDto;
-import io.seqera.tower.model.PipelineDbDto;
 import picocli.CommandLine;
 
 import java.io.IOException;
@@ -49,7 +46,7 @@ public class ImportCmd extends AbstractAddCmd {
 
         Long wspId = workspaceId(workspace.workspace);
 
-        if (overwrite) deleteCE(name, wspId);
+        if (overwrite) tryDeleteCE(name, wspId);
 
         return addComputeEnv(platform, configObj);
     }
@@ -59,7 +56,7 @@ public class ImportCmd extends AbstractAddCmd {
         throw new UnsupportedOperationException("Unknown platform");
     }
 
-    private void deleteCE(String name, Long wspId) throws ApiException {
+    private void tryDeleteCE(String name, Long wspId) throws ApiException {
         try {
             ComputeEnvResponseDto ce = computeEnvByRef(wspId, name);
             api().deleteComputeEnv(ce.getId(), wspId);

--- a/src/main/java/io/seqera/tower/cli/commands/credentials/AbstractCredentialsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/credentials/AbstractCredentialsCmd.java
@@ -54,6 +54,15 @@ public abstract class AbstractCredentialsCmd extends AbstractApiCmd {
         return credentials;
     }
 
+    protected void deleteCredentialsByName(String name, Long wspId) throws CredentialsNotFoundException, ApiException {
+        Credentials credentials = findCredentialsByName(wspId, name);
+        deleteCredentialsById(credentials.getId(), wspId);
+    }
+
+    protected void deleteCredentialsById(String id, Long wspId) throws CredentialsNotFoundException, ApiException {
+        api().deleteCredentials(id, wspId);
+    }
+
 }
 
 

--- a/src/main/java/io/seqera/tower/cli/commands/credentials/DeleteCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/credentials/DeleteCmd.java
@@ -45,7 +45,7 @@ public class DeleteCmd extends AbstractCredentialsCmd {
         }
 
         try {
-            api().deleteCredentials(id, wspId);
+            deleteCredentialsById(id, wspId);
             return new CredentialsDeleted(id, workspaceRef(wspId));
         } catch (ApiException e) {
             if (e.getCode() == 403) {

--- a/src/main/java/io/seqera/tower/cli/commands/datasets/AbstractDatasetsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datasets/AbstractDatasetsCmd.java
@@ -123,4 +123,15 @@ public abstract class AbstractDatasetsCmd extends AbstractApiCmd {
     protected String getDatasetRef(DatasetRefOptions datasetRefOptions) {
         return datasetRefOptions.dataset.datasetName != null ? datasetRefOptions.dataset.datasetName : datasetRefOptions.dataset.datasetId;
     }
+
+    protected void deleteDatasetByName(String datasetName, Long wspId) throws DatasetNotFoundException, ApiException {
+        Dataset response = datasetByName(wspId, datasetName);
+        deleteDatasetById(response.getId(), wspId);
+    }
+
+    protected void deleteDatasetById(String datasetId, Long wspId) throws DatasetNotFoundException, ApiException {
+        api().deleteDataset(wspId, datasetId);
+    }
+
+
 }

--- a/src/main/java/io/seqera/tower/cli/commands/datasets/DeleteCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datasets/DeleteCmd.java
@@ -38,7 +38,7 @@ public class DeleteCmd extends AbstractDatasetsCmd {
         Long wspId = workspaceId(workspace.workspace);
         Dataset dataset = fetchDescribeDatasetResponse(datasetRefOptions, wspId);
 
-        api().deleteDataset(wspId, dataset.getId());
+        deleteDatasetById(dataset.getId(), wspId);
 
         return new DatasetDelete(getDatasetRef(datasetRefOptions), workspace.workspace);
     }

--- a/src/main/java/io/seqera/tower/cli/commands/organizations/AbstractOrganizationsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/organizations/AbstractOrganizationsCmd.java
@@ -63,4 +63,13 @@ public class AbstractOrganizationsCmd extends AbstractApiCmd {
 
         return response;
     }
+
+    protected void deleteOrgById(Long orgId) throws OrganizationNotFoundException, ApiException {
+        api().deleteOrganization(orgId);
+    }
+
+    protected void deleteOrgByName(String orgName) throws OrganizationNotFoundException, ApiException {
+        OrgAndWorkspaceDbDto org = organizationByName(orgName);
+        deleteOrgById(org.getOrgId());
+    }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/organizations/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/organizations/AddCmd.java
@@ -12,6 +12,7 @@
 package io.seqera.tower.cli.commands.organizations;
 
 import io.seqera.tower.ApiException;
+import io.seqera.tower.cli.exceptions.OrganizationNotFoundException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.organizations.OrganizationsAdded;
 import io.seqera.tower.model.CreateOrganizationRequest;
@@ -36,6 +37,9 @@ public class AddCmd extends AbstractOrganizationsCmd {
     @CommandLine.Mixin
     OrganizationsOptions opts;
 
+    @CommandLine.Option(names = {"--overwrite"}, description = "Overwrite the organization if it already exists.", defaultValue = "false")
+    public Boolean overwrite;
+
     @Override
     protected Response exec() throws ApiException, IOException {
         CreateOrganizationResponse response;
@@ -50,8 +54,16 @@ public class AddCmd extends AbstractOrganizationsCmd {
         CreateOrganizationRequest request = new CreateOrganizationRequest();
         request.setOrganization(organization);
 
+        if (overwrite) tryDeleteOrg(name);
+
         response = api().createOrganization(request);
 
         return new OrganizationsAdded(response.getOrganization());
+    }
+
+    private void tryDeleteOrg(final String name) throws ApiException {
+        try {
+            deleteOrgByName(name);
+        } catch (OrganizationNotFoundException ignored){}
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/organizations/DeleteCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/organizations/DeleteCmd.java
@@ -44,7 +44,7 @@ public class DeleteCmd extends AbstractOrganizationsCmd {
         }
 
         try {
-            api().deleteOrganization(id);
+            deleteOrgById(id);
         } catch (Exception e) {
             throw new TowerException(String.format("Organization %s could not be deleted", ref));
         }

--- a/src/main/java/io/seqera/tower/cli/commands/participants/AbstractParticipantsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/participants/AbstractParticipantsCmd.java
@@ -92,4 +92,9 @@ public class AbstractParticipantsCmd extends AbstractApiCmd {
 
         throw new ParticipantNotFoundException(workspaceId, name);
     }
+
+    protected void deleteParticipantByNameAndType(Long wspId, String participantName, ParticipantType type) throws ParticipantNotFoundException, ApiException {
+        ParticipantDbDto participant = findWorkspaceParticipant(orgId(wspId), wspId, participantName, type);
+        api().deleteWorkspaceParticipant(orgId(wspId), wspId, participant.getParticipantId());
+    }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/participants/DeleteCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/participants/DeleteCmd.java
@@ -40,8 +40,7 @@ public class DeleteCmd extends AbstractParticipantsCmd {
     protected Response exec() throws ApiException, IOException {
         Long wspId = workspaceId(workspace.workspace);
 
-        ParticipantDbDto participant = findWorkspaceParticipant(orgId(wspId), wspId, name, type);
-        api().deleteWorkspaceParticipant(orgId(wspId), wspId, participant.getParticipantId());
+        deleteParticipantByNameAndType(wspId, name, type);
 
         return new ParticipantDeleted(name, workspaceName(wspId));
     }

--- a/src/main/java/io/seqera/tower/cli/commands/secrets/AbstractSecretsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/secrets/AbstractSecretsCmd.java
@@ -38,6 +38,15 @@ public abstract class AbstractSecretsCmd extends AbstractApiCmd {
         return ref.secret.id != null ? api().describePipelineSecret(ref.secret.id, wspId).getPipelineSecret() : secretByName(wspId, ref.secret.name);
     }
 
+    protected void deleteSecretByName(String name, Long wspId) throws SecretNotFoundException, ApiException {
+        PipelineSecret secret = secretByName(wspId, name);
+        deleteSecretById(secret.getId(), wspId);
+    }
+
+    protected void deleteSecretById(Long id, Long wspId) throws SecretNotFoundException, ApiException {
+        api().deletePipelineSecret(id, wspId);
+    }
+
 }
 
 

--- a/src/main/java/io/seqera/tower/cli/commands/secrets/DeleteCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/secrets/DeleteCmd.java
@@ -36,7 +36,7 @@ public class DeleteCmd extends AbstractSecretsCmd {
     protected Response exec() throws ApiException, IOException {
         Long wspId = workspaceId(workspace.workspace);
         PipelineSecret secret = fetchSecret(ref, wspId);
-        api().deletePipelineSecret(secret.getId(), wspId);
+        deleteSecretById(secret.getId(), wspId);
         return new SecretDeleted(secret, workspaceRef(wspId));
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/teams/AbstractTeamsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/teams/AbstractTeamsCmd.java
@@ -61,8 +61,12 @@ public abstract class AbstractTeamsCmd extends AbstractApiCmd {
                 .orElseThrow(() -> new TeamNotFoundException(orgId, teamName));
     }
 
-    public void deleteTeamByID(String orgRef, Long teamId) throws OrganizationNotFoundException, ApiException {
+    public void deleteTeamById(Long teamId, String orgRef) throws OrganizationNotFoundException, ApiException {
         OrgAndWorkspaceDbDto orgAndWorkspaceDbDto = findOrganizationByRef(orgRef);
-        api().deleteOrganizationTeam(orgAndWorkspaceDbDto.getOrgId(), teamId);
+        deleteTeamById(teamId, orgAndWorkspaceDbDto.getOrgId());
+    }
+
+    public void deleteTeamById(Long teamId, Long orgId) throws OrganizationNotFoundException, ApiException {
+        api().deleteOrganizationTeam(orgId, teamId);
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/teams/AbstractTeamsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/teams/AbstractTeamsCmd.java
@@ -14,10 +14,12 @@ package io.seqera.tower.cli.commands.teams;
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.AbstractApiCmd;
 import io.seqera.tower.cli.exceptions.MemberNotFoundException;
+import io.seqera.tower.cli.exceptions.OrganizationNotFoundException;
 import io.seqera.tower.cli.exceptions.TeamNotFoundException;
 import io.seqera.tower.model.ListMembersResponse;
 import io.seqera.tower.model.ListTeamResponse;
 import io.seqera.tower.model.MemberDbDto;
+import io.seqera.tower.model.OrgAndWorkspaceDbDto;
 import io.seqera.tower.model.TeamDbDto;
 import picocli.CommandLine.Command;
 
@@ -57,5 +59,10 @@ public abstract class AbstractTeamsCmd extends AbstractApiCmd {
                 .filter(item -> Objects.equals(item.getName(), teamName))
                 .findFirst()
                 .orElseThrow(() -> new TeamNotFoundException(orgId, teamName));
+    }
+
+    public void deleteTeamByID(String orgRef, Long teamId) throws OrganizationNotFoundException, ApiException {
+        OrgAndWorkspaceDbDto orgAndWorkspaceDbDto = findOrganizationByRef(orgRef);
+        api().deleteOrganizationTeam(orgAndWorkspaceDbDto.getOrgId(), teamId);
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/teams/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/teams/AddCmd.java
@@ -52,17 +52,17 @@ public class AddCmd extends AbstractTeamsCmd {
         CreateTeamRequest request = new CreateTeamRequest();
         request.setTeam(team);
 
-        if(overwrite) tryDeleteTeam(orgAndWorkspaceDbDto.getOrgId(), organizationRef, teamName);
+        if(overwrite) tryDeleteTeam(orgAndWorkspaceDbDto.getOrgId(), teamName);
 
         api().createOrganizationTeam(orgAndWorkspaceDbDto.getOrgId(), request);
 
         return new TeamAdded(organizationRef, teamName);
     }
 
-    private void tryDeleteTeam(Long orgId, String orgRef, String teamName) throws ApiException {
+    private void tryDeleteTeam(Long orgId, String teamName) throws ApiException {
         try {
             TeamDbDto team = findTeamByName(orgId, teamName);
-            deleteTeamByID(orgRef, team.getTeamId());
+            deleteTeamById(team.getTeamId(), orgId);
         } catch (TeamNotFoundException ignored) {}
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/teams/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/teams/AddCmd.java
@@ -12,12 +12,13 @@
 package io.seqera.tower.cli.commands.teams;
 
 import io.seqera.tower.ApiException;
+import io.seqera.tower.cli.exceptions.TeamNotFoundException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.teams.TeamAdded;
 import io.seqera.tower.model.CreateTeamRequest;
-import io.seqera.tower.model.CreateTeamResponse;
 import io.seqera.tower.model.OrgAndWorkspaceDbDto;
 import io.seqera.tower.model.Team;
+import io.seqera.tower.model.TeamDbDto;
 import picocli.CommandLine;
 
 import java.io.IOException;
@@ -37,6 +38,9 @@ public class AddCmd extends AbstractTeamsCmd {
     @CommandLine.Option(names = {"-d", "--description"}, description = "Team description.")
     public String teamDescription;
 
+    @CommandLine.Option(names = {"--overwrite"}, description = "Overwrite the team if it already exists.", defaultValue = "false")
+    public Boolean overwrite;
+
     @Override
     protected Response exec() throws ApiException, IOException {
         OrgAndWorkspaceDbDto orgAndWorkspaceDbDto = findOrganizationByRef(organizationRef);
@@ -48,8 +52,17 @@ public class AddCmd extends AbstractTeamsCmd {
         CreateTeamRequest request = new CreateTeamRequest();
         request.setTeam(team);
 
-        CreateTeamResponse response = api().createOrganizationTeam(orgAndWorkspaceDbDto.getOrgId(), request);
+        if(overwrite) tryDeleteTeam(orgAndWorkspaceDbDto.getOrgId(), organizationRef, teamName);
+
+        api().createOrganizationTeam(orgAndWorkspaceDbDto.getOrgId(), request);
 
         return new TeamAdded(organizationRef, teamName);
+    }
+
+    private void tryDeleteTeam(Long orgId, String orgRef, String teamName) throws ApiException {
+        try {
+            TeamDbDto team = findTeamByName(orgId, teamName);
+            deleteTeamByID(orgRef, team.getTeamId());
+        } catch (TeamNotFoundException ignored) {}
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/teams/DeleteCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/teams/DeleteCmd.java
@@ -32,7 +32,7 @@ public class DeleteCmd extends AbstractTeamsCmd {
 
     @Override
     protected Response exec() throws ApiException, IOException {
-        deleteTeamByID(organizationRef, teamId);
+        deleteTeamById(teamId, organizationRef);
         return new TeamDeleted(organizationRef, teamId.toString());
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/teams/DeleteCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/teams/DeleteCmd.java
@@ -14,7 +14,6 @@ package io.seqera.tower.cli.commands.teams;
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.teams.TeamDeleted;
-import io.seqera.tower.model.OrgAndWorkspaceDbDto;
 import picocli.CommandLine;
 
 import java.io.IOException;
@@ -33,10 +32,7 @@ public class DeleteCmd extends AbstractTeamsCmd {
 
     @Override
     protected Response exec() throws ApiException, IOException {
-        OrgAndWorkspaceDbDto orgAndWorkspaceDbDto = findOrganizationByRef(organizationRef);
-
-        api().deleteOrganizationTeam(orgAndWorkspaceDbDto.getOrgId(), teamId);
-
+        deleteTeamByID(organizationRef, teamId);
         return new TeamDeleted(organizationRef, teamId.toString());
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/workspaces/AbstractWorkspaceCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/workspaces/AbstractWorkspaceCmd.java
@@ -80,6 +80,10 @@ public abstract class AbstractWorkspaceCmd extends AbstractApiCmd {
 
         return ws;
     }
+
+    protected void deleteWorkspaceById(Long wspId, Long orgId) throws WorkspaceNotFoundException, ApiException {
+        api().deleteWorkspace(orgId, wspId);
+    }
 }
 
 

--- a/src/main/java/io/seqera/tower/cli/commands/workspaces/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/workspaces/AddCmd.java
@@ -52,10 +52,12 @@ public class AddCmd extends AbstractWorkspaceCmd {
     @Override
     protected Response exec() throws ApiException, IOException {
 
-        OrgAndWorkspaceDbDto orgWspDto = findOrgAndWorkspaceByName(organizationName, workspaceName);
-
-        if (overwrite && orgWspDto.getWorkspaceId() != null){
+        OrgAndWorkspaceDbDto orgWspDto;
+        if (overwrite) { // check also wsp existence
+            orgWspDto = findOrgAndWorkspaceByName(organizationName, workspaceName);
             tryDeleteWsp(orgWspDto.getWorkspaceId(), orgWspDto.getOrgId());
+        } else { // normal 'add'
+            orgWspDto = organizationByName(organizationName);
         }
 
         Workspace workspace = new Workspace();

--- a/src/main/java/io/seqera/tower/cli/commands/workspaces/DeleteCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/workspaces/DeleteCmd.java
@@ -33,7 +33,7 @@ public class DeleteCmd extends AbstractWorkspaceCmd {
     protected Response exec() throws ApiException, IOException {
         OrgAndWorkspaceDbDto ws = fetchOrgAndWorkspaceDbDto(workspaceRefOptions);
 
-        api().deleteWorkspace(ws.getOrgId(), ws.getWorkspaceId());
+        deleteWorkspaceById(ws.getWorkspaceId(), ws.getOrgId());
 
         return new WorkspaceDeleted(ws.getWorkspaceName(), ws.getOrgName());
     }

--- a/src/test/java/io/seqera/tower/cli/organizations/OrganizationsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/organizations/OrganizationsCmdTest.java
@@ -251,6 +251,50 @@ class OrganizationsCmdTest extends BaseCmdTest {
                 "  }", OrganizationDbDto.class)));
     }
 
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testAddWithOverwrite(OutputType format, MockServerClient mock) throws JsonProcessingException {
+
+        mock.when(
+                request().withMethod("GET").withPath("/user-info"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/user/1264/workspaces"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workspaces/workspaces_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("POST").withPath("/orgs"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("organizations/organizations_add_response")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("DELETE").withPath("/orgs/275484385882108"),
+                exactly(1)
+        ).respond(
+                response().withStatusCode(200)
+        );
+
+        ExecOut out = exec(format, mock, "organizations", "add", "--overwrite", "-n", "sample-organization", "-f", "sample organization");
+        assertOutput(format, out, new OrganizationsAdded(parseJson("{\n" +
+                "    \"orgId\": 275484385882108,\n" +
+                "    \"name\": \"sample-organization\",\n" +
+                "    \"fullName\": \"sample organization\",\n" +
+                "    \"description\": \"sample organization description\",\n" +
+                "    \"location\": \"office\",\n" +
+                "    \"website\": \"http://www.seqera.io\",\n" +
+                "    \"logoId\": null,\n" +
+                "    \"logoUrl\": null,\n" +
+                "    \"memberId\": null,\n" +
+                "    \"memberRole\": null\n" +
+                "  }", OrganizationDbDto.class)));
+    }
+
     @Test
     void testAddError(MockServerClient mock) {
         mock.when(

--- a/src/test/java/io/seqera/tower/cli/participants/ParticipantsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/participants/ParticipantsCmdTest.java
@@ -580,7 +580,7 @@ class ParticipantsCmdTest extends BaseCmdTest {
 
     @ParameterizedTest
     @EnumSource(OutputType.class)
-    void testCreateMemberParticipantRole(OutputType format, MockServerClient mock) throws JsonProcessingException {
+    void testAddMemberParticipantRole(OutputType format, MockServerClient mock) throws JsonProcessingException {
         mock.when(
                 request().withMethod("GET").withPath("/user-info"), exactly(1)
         ).respond(
@@ -606,6 +606,65 @@ class ParticipantsCmdTest extends BaseCmdTest {
         );
 
         ExecOut out = exec(format, mock, "participants", "add", "-w", "75887156211589", "-n", "julio", "-t", "MEMBER");
+
+        assertOutput(format, out, new ParticipantAdded(parseJson("{\n" +
+                "    \"participantId\": 110330443206779,\n" +
+                "    \"memberId\": 80726606082762,\n" +
+                "    \"userName\": \"julio\",\n" +
+                "    \"firstName\": null,\n" +
+                "    \"lastName\": null,\n" +
+                "    \"email\": \"user@seqera.io\",\n" +
+                "    \"orgRole\": \"member\",\n" +
+                "    \"teamId\": null,\n" +
+                "    \"teamName\": null,\n" +
+                "    \"wspRole\": \"launch\",\n" +
+                "    \"type\": \"MEMBER\",\n" +
+                "    \"teamAvatarUrl\": null,\n" +
+                "    \"userAvatarUrl\": null\n" +
+                "  }", ParticipantDbDto.class), "workspace1"));
+    }
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testAddParticipantWithOverwrite(OutputType format, MockServerClient mock) throws JsonProcessingException {
+
+        mock.when(
+                request().withMethod("GET").withPath("/user-info"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/user/1264/workspaces"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workspaces/workspaces_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/orgs/27736513644467/workspaces/75887156211589/participants"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("participants/participants_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/orgs/27736513644467/members"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("members/members_list_filter")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("PUT").withPath("/orgs/27736513644467/workspaces/75887156211589/participants/add"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("participants/participant_add")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("DELETE").withPath("/orgs/27736513644467/workspaces/75887156211589/participants/48516118433516"), exactly(1)
+        ).respond(
+                response().withStatusCode(204)
+        );
+
+        ExecOut out = exec(format, mock, "participants", "add", "--overwrite", "-w", "75887156211589", "-n", "julio", "-t", "MEMBER");
 
         assertOutput(format, out, new ParticipantAdded(parseJson("{\n" +
                 "    \"participantId\": 110330443206779,\n" +

--- a/src/test/java/io/seqera/tower/cli/secrets/SecretsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/secrets/SecretsCmdTest.java
@@ -76,6 +76,35 @@ public class SecretsCmdTest extends BaseCmdTest {
 
     @ParameterizedTest
     @EnumSource(OutputType.class)
+    void testAddWithOverride(OutputType format, MockServerClient mock) {
+
+        // Mock API
+        mock.when(
+                request().withMethod("GET").withPath("/pipeline-secrets"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"pipelineSecrets\":[{\"id\":5002114781502,\"name\":\"name01\",\"lastUsed\":null,\"dateCreated\":\"2022-10-25T12:42:21Z\",\"lastUpdated\":\"2022-10-25T12:42:21Z\"},{\"id\":171740984431657,\"name\":\"name02\",\"lastUsed\":null,\"dateCreated\":\"2022-10-25T13:21:15Z\",\"lastUpdated\":\"2022-10-25T13:21:15Z\"},{\"id\":164410928765888,\"name\":\"name03\",\"lastUsed\":null,\"dateCreated\":\"2022-10-26T07:05:17Z\",\"lastUpdated\":\"2022-10-26T07:05:17Z\"}],\"totalSize\":3}").withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("DELETE").withPath("/pipeline-secrets/164410928765888"), exactly(1)
+        ).respond(
+                response().withStatusCode(204)
+        );
+        mock.when(
+                request().withMethod("POST").withPath("/pipeline-secrets").withBody("{\"name\":\"name03\",\"value\":\"value03\"}"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"secretId\":164410928765888}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        // Run command
+        ExecOut out = exec(format, mock, "secrets", "add", "--overwrite", "-n", "name03", "-v", "value03");
+
+        // Assert output
+        assertOutput(format, out, new SecretAdded(USER_WORKSPACE_NAME, 164410928765888L, "name03"));
+
+    }
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
     void testDelete(OutputType format, MockServerClient mock) throws JsonProcessingException {
         mock.when(
                 request().withMethod("GET").withPath("/pipeline-secrets"), exactly(1)

--- a/src/test/java/io/seqera/tower/cli/teams/TeamsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/teams/TeamsCmdTest.java
@@ -299,6 +299,43 @@ class TeamsCmdTest extends BaseCmdTest {
 
     @ParameterizedTest
     @EnumSource(OutputType.class)
+    void testAddWithOverwrite(OutputType format, MockServerClient mock) {
+        mock.when(
+                request().withMethod("GET").withPath("/user-info"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/user/1264/workspaces"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workspaces/workspaces_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/orgs/27736513644467/teams"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("teams/teams_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("DELETE").withPath("/orgs/27736513644467/teams/249211453903161"), exactly(1)
+        ).respond(
+                response().withStatusCode(200)
+        );
+
+        mock.when(
+                request().withMethod("POST").withPath("/orgs/27736513644467/teams"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("teams/teams_add")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(format, mock, "teams", "add", "-o", "organization1", "-n", "team-test-3", "--overwrite");
+        assertOutput(format, out, new TeamAdded("organization1", "team-test-3"));
+    }
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
     void testDeleteTeam(OutputType format, MockServerClient mock) {
         mock.when(
                 request().withMethod("GET").withPath("/user-info"), exactly(1)


### PR DESCRIPTION
## Description

Add `--overwrite` option when creating:
+ Organizations
+ Teams
+ Workspaces
+ Participants
+ Credentials
+ Secrets
+ Actions
+ Datasets

Closes #338 

## Guidelines for testing
For each of the entity types in the description:

When trying to `add` (create) a new entity using a name/identifier that already exists in the context (workspace/personal wsp/organization)

Then the `add` command should fail ("Entity already exists")

When trying again adding the `--overwrite` option

Then the `add` command should create the new entity deleting the previous one with the same name

i.e.
```
# Given that an Organization named JaimeOrg already exists

# This should fail
$> tw organizations add -n JaimeOrg -f jaime-org

# This should work
$> tw organizations add --overwrite -n JaimeOrg -f jaime-new-org -d this is my new org
```



