### PR TITLE
Include labels when exporting/importing compute environments

### DIFF
--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -1670,6 +1670,12 @@
   "queryAllDeclaredConstructors":true
 },
 {
+  "name":"io.seqera.tower.cli.responses.computeenvs.ComputeEnvUpdated",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
   "name":"io.seqera.tower.cli.responses.computeenvs.ComputeEnvExport",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
@@ -1677,12 +1683,6 @@
 },
 {
   "name":"io.seqera.tower.cli.responses.computeenvs.ComputeEnvList",
-  "allDeclaredFields":true,
-  "queryAllDeclaredMethods":true,
-  "queryAllDeclaredConstructors":true
-},
-{
-  "name":"io.seqera.tower.cli.responses.computeenvs.ComputeEnvUpdated",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true
@@ -2292,13 +2292,15 @@
   "name":"io.seqera.tower.model.CreateCredentialsRequest",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"getCredentials","parameterTypes":[] }]
 },
 {
   "name":"io.seqera.tower.model.CreateCredentialsResponse",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setCredentialsId","parameterTypes":["java.lang.String"] }]
 },
 {
   "name":"io.seqera.tower.model.CreateDatasetRequest",
@@ -2401,13 +2403,13 @@
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true,
-  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setBaseUrl","parameterTypes":["java.lang.String"] }, {"name":"setCategory","parameterTypes":["java.lang.String"] }, {"name":"setDescription","parameterTypes":["java.lang.String"] }, {"name":"setId","parameterTypes":["java.lang.String"] }, {"name":"setKeys","parameterTypes":["io.seqera.tower.model.SecurityKeys"] }, {"name":"setName","parameterTypes":["java.lang.String"] }, {"name":"setProvider","parameterTypes":["io.seqera.tower.model.Credentials$ProviderEnum"] }]
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"getBaseUrl","parameterTypes":[] }, {"name":"getCategory","parameterTypes":[] }, {"name":"getDateCreated","parameterTypes":[] }, {"name":"getDeleted","parameterTypes":[] }, {"name":"getDescription","parameterTypes":[] }, {"name":"getId","parameterTypes":[] }, {"name":"getKeys","parameterTypes":[] }, {"name":"getLastUpdated","parameterTypes":[] }, {"name":"getLastUsed","parameterTypes":[] }, {"name":"getName","parameterTypes":[] }, {"name":"getProvider","parameterTypes":[] }, {"name":"setBaseUrl","parameterTypes":["java.lang.String"] }, {"name":"setCategory","parameterTypes":["java.lang.String"] }, {"name":"setDescription","parameterTypes":["java.lang.String"] }, {"name":"setId","parameterTypes":["java.lang.String"] }, {"name":"setKeys","parameterTypes":["io.seqera.tower.model.SecurityKeys"] }, {"name":"setName","parameterTypes":["java.lang.String"] }, {"name":"setProvider","parameterTypes":["io.seqera.tower.model.Credentials$ProviderEnum"] }]
 },
 {
   "name":"io.seqera.tower.model.Credentials$ProviderEnum",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "methods":[{"name":"fromValue","parameterTypes":["java.lang.String"] }]
+  "methods":[{"name":"fromValue","parameterTypes":["java.lang.String"] }, {"name":"getValue","parameterTypes":[] }]
 },
 {
   "name":"io.seqera.tower.model.Dataset",

--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -123,6 +123,9 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"com.sun.jndi.url.java.javaURLContextFactory"
+},
+{
   "name":"groovy.lang.Closure"
 },
 {
@@ -2766,7 +2769,7 @@
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true,
-  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setOrgId","parameterTypes":["java.lang.Long"] }, {"name":"setOrgLogoUrl","parameterTypes":["java.lang.String"] }, {"name":"setOrgName","parameterTypes":["java.lang.String"] }, {"name":"setWorkspaceFullName","parameterTypes":["java.lang.String"] }, {"name":"setWorkspaceId","parameterTypes":["java.lang.Long"] }, {"name":"setWorkspaceName","parameterTypes":["java.lang.String"] }]
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setOrgId","parameterTypes":["java.lang.Long"] }, {"name":"setOrgLogoUrl","parameterTypes":["java.lang.String"] }, {"name":"setOrgName","parameterTypes":["java.lang.String"] }, {"name":"setVisibility","parameterTypes":["io.seqera.tower.model.Visibility"] }, {"name":"setWorkspaceFullName","parameterTypes":["java.lang.String"] }, {"name":"setWorkspaceId","parameterTypes":["java.lang.Long"] }, {"name":"setWorkspaceName","parameterTypes":["java.lang.String"] }]
 },
 {
   "name":"io.seqera.tower.model.OrgRole",
@@ -3011,7 +3014,7 @@
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true,
-  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setAvatar","parameterTypes":["java.lang.String"] }, {"name":"setDescription","parameterTypes":["java.lang.String"] }, {"name":"setFirstName","parameterTypes":["java.lang.String"] }, {"name":"setId_JsonNullable","parameterTypes":["org.openapitools.jackson.nullable.JsonNullable"] }, {"name":"setLastName","parameterTypes":["java.lang.String"] }, {"name":"setNotification","parameterTypes":["java.lang.Boolean"] }, {"name":"setOrganization","parameterTypes":["java.lang.String"] }, {"name":"setUserName","parameterTypes":["java.lang.String"] }]
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setAvatar","parameterTypes":["java.lang.String"] }, {"name":"setAvatarId","parameterTypes":["java.lang.String"] }, {"name":"setDateCreated","parameterTypes":["java.time.OffsetDateTime"] }, {"name":"setDeleted","parameterTypes":["java.lang.Boolean"] }, {"name":"setDescription","parameterTypes":["java.lang.String"] }, {"name":"setEmail","parameterTypes":["java.lang.String"] }, {"name":"setFirstName","parameterTypes":["java.lang.String"] }, {"name":"setId","parameterTypes":["java.lang.Long"] }, {"name":"setId_JsonNullable","parameterTypes":["org.openapitools.jackson.nullable.JsonNullable"] }, {"name":"setLastAccess","parameterTypes":["java.time.OffsetDateTime"] }, {"name":"setLastName","parameterTypes":["java.lang.String"] }, {"name":"setLastUpdated","parameterTypes":["java.time.OffsetDateTime"] }, {"name":"setMarketingConsent","parameterTypes":["java.lang.Boolean"] }, {"name":"setNotification","parameterTypes":["java.lang.Boolean"] }, {"name":"setOrganization","parameterTypes":["java.lang.String"] }, {"name":"setTermsOfUseConsent","parameterTypes":["java.lang.Boolean"] }, {"name":"setUserName","parameterTypes":["java.lang.String"] }]
 },
 {
   "name":"io.seqera.tower.model.UserOptions",
@@ -3023,7 +3026,8 @@
 {
   "name":"io.seqera.tower.model.Visibility",
   "allDeclaredFields":true,
-  "allDeclaredMethods":true
+  "allDeclaredMethods":true,
+  "methods":[{"name":"fromValue","parameterTypes":["java.lang.String"] }]
 },
 {
   "name":"io.seqera.tower.model.WfManifest",

--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -1670,12 +1670,6 @@
   "queryAllDeclaredConstructors":true
 },
 {
-  "name":"io.seqera.tower.cli.responses.computeenvs.ComputeEnvUpdated",
-  "allDeclaredFields":true,
-  "queryAllDeclaredMethods":true,
-  "queryAllDeclaredConstructors":true
-},
-{
   "name":"io.seqera.tower.cli.responses.computeenvs.ComputeEnvExport",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
@@ -1683,6 +1677,12 @@
 },
 {
   "name":"io.seqera.tower.cli.responses.computeenvs.ComputeEnvList",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "name":"io.seqera.tower.cli.responses.computeenvs.ComputeEnvUpdated",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true
@@ -2006,6 +2006,21 @@
   "queryAllDeclaredConstructors":true
 },
 {
+  "name":"io.seqera.tower.cli.shared.ComputeConfigMixin",
+  "queryAllDeclaredMethods":true
+},
+{
+  "name":"io.seqera.tower.cli.shared.ComputeEnvExportFormat",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"getConfig","parameterTypes":[] }]
+},
+{
+  "name":"io.seqera.tower.cli.shared.ComputeEnvExportFormat$ComputeConfigMixin",
+  "queryAllDeclaredMethods":true
+},
+{
   "name":"io.seqera.tower.cli.utils.VersionProvider",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
@@ -2147,7 +2162,8 @@
   "name":"io.seqera.tower.model.AwsSecurityKeys",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setAccessKey","parameterTypes":["java.lang.String"] }, {"name":"setAssumeRoleArn","parameterTypes":["java.lang.String"] }, {"name":"setSecretKey","parameterTypes":["java.lang.String"] }]
 },
 {
   "name":"io.seqera.tower.model.AzBatchConfig",
@@ -2193,12 +2209,14 @@
   "name":"io.seqera.tower.model.ComputeEnv",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"getConfig","parameterTypes":[] }, {"name":"getCredentialsId","parameterTypes":[] }, {"name":"getDateCreated","parameterTypes":[] }, {"name":"getDeleted","parameterTypes":[] }, {"name":"getDescription","parameterTypes":[] }, {"name":"getId","parameterTypes":[] }, {"name":"getLastUpdated","parameterTypes":[] }, {"name":"getLastUsed","parameterTypes":[] }, {"name":"getMessage","parameterTypes":[] }, {"name":"getName","parameterTypes":[] }, {"name":"getOrgId","parameterTypes":[] }, {"name":"getPlatform","parameterTypes":[] }, {"name":"getPrimary","parameterTypes":[] }, {"name":"getStatus","parameterTypes":[] }, {"name":"getWorkspaceId","parameterTypes":[] }]
 },
 {
   "name":"io.seqera.tower.model.ComputeEnv$PlatformEnum",
   "allDeclaredFields":true,
-  "allDeclaredMethods":true
+  "allDeclaredMethods":true,
+  "methods":[{"name":"getValue","parameterTypes":[] }]
 },
 {
   "name":"io.seqera.tower.model.ComputeEnvDbDto",
@@ -2260,13 +2278,15 @@
   "name":"io.seqera.tower.model.CreateComputeEnvRequest",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"getComputeEnv","parameterTypes":[] }, {"name":"getLabelIds","parameterTypes":[] }]
 },
 {
   "name":"io.seqera.tower.model.CreateComputeEnvResponse",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setComputeEnvId","parameterTypes":["java.lang.String"] }]
 },
 {
   "name":"io.seqera.tower.model.CreateCredentialsRequest",
@@ -2380,12 +2400,14 @@
   "name":"io.seqera.tower.model.Credentials",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setBaseUrl","parameterTypes":["java.lang.String"] }, {"name":"setCategory","parameterTypes":["java.lang.String"] }, {"name":"setDescription","parameterTypes":["java.lang.String"] }, {"name":"setId","parameterTypes":["java.lang.String"] }, {"name":"setKeys","parameterTypes":["io.seqera.tower.model.SecurityKeys"] }, {"name":"setName","parameterTypes":["java.lang.String"] }, {"name":"setProvider","parameterTypes":["io.seqera.tower.model.Credentials$ProviderEnum"] }]
 },
 {
   "name":"io.seqera.tower.model.Credentials$ProviderEnum",
   "allDeclaredFields":true,
-  "allDeclaredMethods":true
+  "allDeclaredMethods":true,
+  "methods":[{"name":"fromValue","parameterTypes":["java.lang.String"] }]
 },
 {
   "name":"io.seqera.tower.model.Dataset",
@@ -2652,7 +2674,8 @@
   "name":"io.seqera.tower.model.ListCredentialsResponse",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setCredentials","parameterTypes":["java.util.List"] }]
 },
 {
   "name":"io.seqera.tower.model.ListDatasetVersionsResponse",
@@ -3444,13 +3467,15 @@
   "name":"javax.ws.rs.client.Entity",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"getAnnotations","parameterTypes":[] }, {"name":"getEncoding","parameterTypes":[] }, {"name":"getEntity","parameterTypes":[] }, {"name":"getLanguage","parameterTypes":[] }, {"name":"getMediaType","parameterTypes":[] }, {"name":"getVariant","parameterTypes":[] }]
 },
 {
   "name":"javax.ws.rs.core.MediaType",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"getParameters","parameterTypes":[] }, {"name":"getSubtype","parameterTypes":[] }, {"name":"getType","parameterTypes":[] }, {"name":"isWildcardSubtype","parameterTypes":[] }, {"name":"isWildcardType","parameterTypes":[] }]
 },
 {
   "name":"javax.ws.rs.core.MediaType[]"
@@ -3459,7 +3484,8 @@
   "name":"javax.ws.rs.core.Variant",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"getEncoding","parameterTypes":[] }, {"name":"getLanguage","parameterTypes":[] }, {"name":"getLanguageString","parameterTypes":[] }, {"name":"getMediaType","parameterTypes":[] }]
 },
 {
   "name":"long[]"

--- a/conf/resource-config.json
+++ b/conf/resource-config.json
@@ -19,10 +19,10 @@
   }]},
   "bundles":[{
     "name":"org.glassfish.jersey.client.internal.localization",
-    "locales":["", "und"]
+    "locales":["und"]
   }, {
     "name":"org.glassfish.jersey.internal.localization",
-    "locales":["", "und"]
+    "locales":["und"]
   }, {
     "name":"org.glassfish.jersey.media.multipart.internal.localization"
   }]

--- a/conf/resource-config.json
+++ b/conf/resource-config.json
@@ -19,10 +19,10 @@
   }]},
   "bundles":[{
     "name":"org.glassfish.jersey.client.internal.localization",
-    "locales":["und"]
+    "locales":["", "und"]
   }, {
     "name":"org.glassfish.jersey.internal.localization",
-    "locales":["und"]
+    "locales":["", "und"]
   }, {
     "name":"org.glassfish.jersey.media.multipart.internal.localization"
   }]

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/ExportCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/ExportCmd.java
@@ -12,19 +12,21 @@
 package io.seqera.tower.cli.commands.computeenvs;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.seqera.tower.ApiException;
-import io.seqera.tower.JSON;
 import io.seqera.tower.cli.commands.computeenvs.platforms.AwsBatchForgePlatform;
 import io.seqera.tower.cli.commands.computeenvs.platforms.AwsBatchManualPlatform;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.computeenvs.ComputeEnvExport;
+import io.seqera.tower.cli.shared.ComputeEnvExportFormat;
 import io.seqera.tower.cli.utils.FilesHelper;
 import io.seqera.tower.model.AwsBatchConfig;
-import io.seqera.tower.model.ComputeConfig;
 import io.seqera.tower.model.ComputeEnv;
 import io.seqera.tower.model.ComputeEnvResponseDto;
 import picocli.CommandLine;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 @CommandLine.Command(
         name = "export",
@@ -64,10 +66,17 @@ public class ExportCmd extends AbstractComputeEnvCmd {
             }
         }
 
+        ComputeEnvExportFormat ceData = new ComputeEnvExportFormat(ce.getConfig(), ce.getLabels());
+
         String configOutput = "";
 
         try {
-            configOutput = new JSON().getContext(ComputeConfig.class).writerWithDefaultPrettyPrinter().writeValueAsString(computeEnv.getConfig());
+            configOutput = new ObjectMapper()
+                    .setSerializationInclusion(Include.NON_NULL)
+                    .setSerializationInclusion(Include.NON_EMPTY)
+                    .writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(ceData);
+
         } catch (JsonProcessingException e) {
             e.printStackTrace();
         }
@@ -78,4 +87,5 @@ public class ExportCmd extends AbstractComputeEnvCmd {
 
         return new ComputeEnvExport(configOutput, fileName);
     }
+
 }

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/ExportCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/ExportCmd.java
@@ -12,7 +12,6 @@
 package io.seqera.tower.cli.commands.computeenvs;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.computeenvs.platforms.AwsBatchForgePlatform;
 import io.seqera.tower.cli.commands.computeenvs.platforms.AwsBatchManualPlatform;
@@ -25,8 +24,6 @@ import io.seqera.tower.model.AwsBatchConfig;
 import io.seqera.tower.model.ComputeEnv;
 import io.seqera.tower.model.ComputeEnvResponseDto;
 import picocli.CommandLine;
-
-import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 @CommandLine.Command(
         name = "export",
@@ -66,17 +63,14 @@ public class ExportCmd extends AbstractComputeEnvCmd {
             }
         }
 
-        ComputeEnvExportFormat ceData = new ComputeEnvExportFormat(ce.getConfig(), ce.getLabels());
+        ComputeEnvExportFormat ceData = new ComputeEnvExportFormat(
+                ce.getConfig(),
+                ce.getLabels()
+        );
 
         String configOutput = "";
-
         try {
-            configOutput = new ObjectMapper()
-                    .setSerializationInclusion(Include.NON_NULL)
-                    .setSerializationInclusion(Include.NON_EMPTY)
-                    .writerWithDefaultPrettyPrinter()
-                    .writeValueAsString(ceData);
-
+            configOutput = ComputeEnvExportFormat.serialize(ceData);
         } catch (JsonProcessingException e) {
             e.printStackTrace();
         }
@@ -87,5 +81,6 @@ public class ExportCmd extends AbstractComputeEnvCmd {
 
         return new ComputeEnvExport(configOutput, fileName);
     }
+
 
 }

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/ImportCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/ImportCmd.java
@@ -11,7 +11,6 @@
 
 package io.seqera.tower.cli.commands.computeenvs;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.computeenvs.add.AbstractAddCmd;
 import io.seqera.tower.cli.commands.computeenvs.platforms.Platform;
@@ -44,10 +43,7 @@ public class ImportCmd extends AbstractAddCmd {
     @Override
     protected Response exec() throws ApiException, IOException {
 
-        ComputeEnvExportFormat ceData = new ObjectMapper().readValue(
-            FilesHelper.readString(fileName),
-            ComputeEnvExportFormat.class
-        );
+        ComputeEnvExportFormat ceData = ComputeEnvExportFormat.deserialize(FilesHelper.readString(fileName));
 
         ComputeEnv.PlatformEnum platform = ComputeEnv.PlatformEnum.fromValue(ceData.getConfig().getDiscriminator());
 

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/ImportCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/ImportCmd.java
@@ -51,18 +51,19 @@ public class ImportCmd extends AbstractAddCmd {
 
         if (overwrite) deleteCE(name, wspId);
 
-        List<Long> labelIds = Collections.emptyList();
-        if (ceData.getLabels() != null) {
-            List<LabelDbDto> dtos = ceData.getLabels();
-            labelIds = dtos.stream().map(LabelDbDto::getId).collect(Collectors.toList());
+        // prefer specified user labels before imported ones
+        if (labels != null && !labels.isEmpty()) {
+            return addComputeEnv(platform, ceData.getConfig()); // handles 'labels' parameter
         }
-
-        return addComputeEnvWithLabels(
-                platform,
-                ceData.getConfig(),
-                labelIds
-        );
-
+        // use imported labels
+        if (ceData.getLabels() != null) {
+            List<Long> labelIds = ceData.getLabels().stream()
+                    .map(LabelDbDto::getId)
+                    .collect(Collectors.toList());
+            return addComputeEnvWithLabels(platform, ceData.getConfig(), labelIds);
+        }
+        // no labels
+        return addComputeEnvWithLabels(platform, ceData.getConfig(), null);
     }
 
     @Override

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/ImportCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/ImportCmd.java
@@ -14,18 +14,17 @@ package io.seqera.tower.cli.commands.computeenvs;
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.computeenvs.add.AbstractAddCmd;
 import io.seqera.tower.cli.commands.computeenvs.platforms.Platform;
+import io.seqera.tower.cli.commands.labels.Label;
 import io.seqera.tower.cli.exceptions.ComputeEnvNotFoundException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.shared.ComputeEnvExportFormat;
 import io.seqera.tower.cli.utils.FilesHelper;
 import io.seqera.tower.model.ComputeEnv;
 import io.seqera.tower.model.ComputeEnvResponseDto;
-import io.seqera.tower.model.LabelDbDto;
 import picocli.CommandLine;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -53,14 +52,16 @@ public class ImportCmd extends AbstractAddCmd {
 
         // prefer specified user labels before imported ones
         if (labels != null && !labels.isEmpty()) {
-            return addComputeEnv(platform, ceData.getConfig()); // handles 'labels' parameter
+            // handles 'labels' parameter, creates labels if they do not exist
+            return addComputeEnv(platform, ceData.getConfig());
         }
         // use imported labels
         if (ceData.getLabels() != null) {
-            List<Long> labelIds = ceData.getLabels().stream()
-                    .map(LabelDbDto::getId)
+            List<Label> importLabels = ceData.getLabels().stream()
+                    .map(dto -> new Label(dto.getName(), dto.getValue()))
                     .collect(Collectors.toList());
-            return addComputeEnvWithLabels(platform, ceData.getConfig(), labelIds);
+            // creates labels if they do not exist
+            return addComputeEnvWithLabels(platform, ceData.getConfig(), importLabels);
         }
         // no labels
         return addComputeEnvWithLabels(platform, ceData.getConfig(), null);

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/add/AbstractAddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/add/AbstractAddCmd.java
@@ -96,17 +96,24 @@ public abstract class AbstractAddCmd extends AbstractApiCmd {
 
     protected ComputeEnvAdded addComputeEnv(ComputeEnv.PlatformEnum platform, ComputeConfig config) throws ApiException {
         Long wspId = workspaceId(workspace.workspace);
+        List<Long> labelIds = findLabels(wspId, labels);
+        return addComputeEnvWithLabels(platform, config, labelIds);
+    }
+
+    protected ComputeEnvAdded addComputeEnvWithLabels(ComputeEnv.PlatformEnum platform, ComputeConfig config, List<Long> labelIds) throws ApiException {
+        Long wspId = workspaceId(workspace.workspace);
 
         String credsId = credentialsRef == null ? findWorkspaceCredentials(platform, wspId) : credentialsByRef(platform, wspId, credentialsRef);
 
-        List<Long> labelIds = findLabels(wspId, labels);
-        CreateComputeEnvRequest request =  new CreateComputeEnvRequest().computeEnv(
-                new ComputeEnv()
-                        .name(name)
-                        .platform(platform)
-                        .credentialsId(credsId)
-                        .config(config)
-        ).labelIds(labelIds);
+        CreateComputeEnvRequest request =  new CreateComputeEnvRequest()
+                .computeEnv(
+                        new ComputeEnv()
+                                .name(name)
+                                .platform(platform)
+                                .credentialsId(credsId)
+                                .config(config)
+                )
+                .labelIds(labelIds);
 
         CreateComputeEnvResponse resp = api().createComputeEnv(request, wspId);
 

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/add/AbstractAddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/add/AbstractAddCmd.java
@@ -95,13 +95,14 @@ public abstract class AbstractAddCmd extends AbstractApiCmd {
     }
 
     protected ComputeEnvAdded addComputeEnv(ComputeEnv.PlatformEnum platform, ComputeConfig config) throws ApiException {
-        Long wspId = workspaceId(workspace.workspace);
-        List<Long> labelIds = findLabels(wspId, labels);
-        return addComputeEnvWithLabels(platform, config, labelIds);
+        return addComputeEnvWithLabels(platform, config, labels);
     }
 
-    protected ComputeEnvAdded addComputeEnvWithLabels(ComputeEnv.PlatformEnum platform, ComputeConfig config, List<Long> labelIds) throws ApiException {
+    protected ComputeEnvAdded addComputeEnvWithLabels(ComputeEnv.PlatformEnum platform, ComputeConfig config, List<Label> labels) throws ApiException {
+
         Long wspId = workspaceId(workspace.workspace);
+
+        List<Long> labelIds = findLabels(wspId, labels);
 
         String credsId = credentialsRef == null ? findWorkspaceCredentials(platform, wspId) : credentialsByRef(platform, wspId, credentialsRef);
 

--- a/src/main/java/io/seqera/tower/cli/shared/ComputeEnvExportFormat.java
+++ b/src/main/java/io/seqera/tower/cli/shared/ComputeEnvExportFormat.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, Seqera Labs.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This Source Code Form is "Incompatible With Secondary Licenses", as
+ * defined by the Mozilla Public License, v. 2.0.
+ */
+
+package io.seqera.tower.cli.shared;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import io.seqera.tower.model.ComputeConfig;
+import io.seqera.tower.model.LabelDbDto;
+
+import java.util.List;
+
+/**
+ * This is the class used by ExportCmd to structure CE data as JSON.
+ * The class {@link ComputeConfig} does not include labels so this envelope
+ * class is needed to export them along the rest of the data.
+ */
+public final class ComputeEnvExportFormat<T extends ComputeConfig> {
+
+    @JsonUnwrapped
+    private T config;
+
+    private List<LabelDbDto> labels;
+
+    public ComputeEnvExportFormat(final T config, final List<LabelDbDto> labels) {
+        this.config = config;
+        this.labels = labels;
+    }
+
+    public T getConfig() {
+        return config;
+    }
+
+    public List<LabelDbDto> getLabels() {
+        return labels;
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/shared/ComputeEnvExportFormat.java
+++ b/src/main/java/io/seqera/tower/cli/shared/ComputeEnvExportFormat.java
@@ -11,34 +11,116 @@
 
 package io.seqera.tower.cli.shared;
 
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonAppend;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.seqera.tower.model.ComputeConfig;
 import io.seqera.tower.model.LabelDbDto;
 
+import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
 /**
  * This is the class used by ExportCmd to structure CE data as JSON.
  * The class {@link ComputeConfig} does not include labels so this envelope
- * class is needed to export them along the rest of the data.
+ * class is needed to export/import them along the rest of the data.
  */
-public final class ComputeEnvExportFormat<T extends ComputeConfig> {
+public final class ComputeEnvExportFormat {
 
-    @JsonUnwrapped
-    private T config;
+    private ComputeConfig config;
 
     private List<LabelDbDto> labels;
 
-    public ComputeEnvExportFormat(final T config, final List<LabelDbDto> labels) {
+    public ComputeEnvExportFormat(final ComputeConfig config, final List<LabelDbDto> labels) {
         this.config = config;
         this.labels = labels;
     }
 
-    public T getConfig() {
+    public ComputeConfig getConfig() {
         return config;
     }
 
     public List<LabelDbDto> getLabels() {
         return labels;
+    }
+
+    public static ComputeEnvExportFormat deserialize(final String json) throws JsonProcessingException {
+        return buildMapper()
+                .registerModule(
+                        new SimpleModule()
+                                .addDeserializer(ComputeEnvExportFormat.class, new ComputeEnvExportFormatDeserializer())
+                )
+                .readValue(json, ComputeEnvExportFormat.class);
+    }
+
+    public static String serialize(final ComputeEnvExportFormat ceExport) throws JsonProcessingException {
+        return buildMapper()
+                .writerWithDefaultPrettyPrinter()
+                .withAttribute("labels", ceExport.getLabels())
+                .writeValueAsString(ceExport.getConfig());
+    }
+
+    private static ObjectMapper buildMapper() {
+        ObjectMapper mapper = new ObjectMapper()
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                .addMixIn(ComputeConfig.class, ComputeConfigMixin.class);
+        mapper.configOverride(List.class).setSetterInfo(JsonSetter.Value.forContentNulls(Nulls.AS_EMPTY));
+        return mapper;
+    }
+
+    /**
+     * This mixin class allows to add a virtual 'labels' field to {@link ComputeConfig}.
+     * See attribute inclusion in {@link ComputeEnvExportFormat#serialize(ComputeEnvExportFormat)}
+     */
+    @JsonAppend(
+            attrs = {
+                    @JsonAppend.Attr(value = "labels")
+            }
+    )
+    public static abstract class ComputeConfigMixin {}
+
+    /**
+     * Custom deserializer for extended {@link ComputeConfig} JSON representation including 'labels' field.
+     * Handles the case where 'labels' field is non-existent.
+     */
+    public static class ComputeEnvExportFormatDeserializer extends StdDeserializer<ComputeEnvExportFormat> {
+
+        public ComputeEnvExportFormatDeserializer() {
+            this(null);
+        }
+
+        public ComputeEnvExportFormatDeserializer(Class<ComputeEnvExportFormat> vc) {
+            super(vc);
+        }
+
+        @Override
+        public ComputeEnvExportFormat deserialize(JsonParser parser, DeserializationContext ctx) throws IOException, JsonProcessingException {
+
+            JsonNode root = parser.getCodec().readTree(parser);
+
+            ObjectMapper mapper = new ObjectMapper()
+                    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false); // ignore 'labels' field for now
+
+            ComputeConfig cfg = mapper.readValue(root.toString(), ComputeConfig.class);
+
+            JsonNode labels = root.get("labels");
+            if (labels != null) {
+                List<LabelDbDto> labelDbDtos = mapper.readValue(labels.toString(), new TypeReference<List<LabelDbDto>>() {});
+                return new ComputeEnvExportFormat(cfg, labelDbDtos);
+            }
+
+            return new ComputeEnvExportFormat(cfg, Collections.emptyList());
+        }
     }
 }

--- a/src/test/java/io/seqera/tower/cli/computeenvs/ComputeEnvsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/ComputeEnvsCmdTest.java
@@ -356,6 +356,25 @@ class ComputeEnvsCmdTest extends BaseCmdTest {
         );
 
         mock.when(
+                request().withMethod("GET").withPath("/labels")
+        ).respond(
+                response().withStatusCode(200).withBody(JsonBody.json("{}"))
+        );
+        mock.when(
+                request().withMethod("POST").withPath("/labels")
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withBody(JsonBody.json("{\n" +
+                                "\"id\": 10,\n" +
+                                "\"name\": \"res\",\n" +
+                                "\"resource\": true,\n" +
+                                "\"value\": \"val\"\n" +
+                                "}"
+                        ))
+        );
+
+        mock.when(
                 request().withMethod("POST").withPath("/compute-envs").withBody(JsonBody.json("{\n" +
                         "  \"computeEnv\":{\n" +
                         "    \"name\": \"json\",\n" +
@@ -377,8 +396,7 @@ class ComputeEnvsCmdTest extends BaseCmdTest {
                         "      \"discriminator\": \"aws-batch\"\n" +
                         "    },\n" +
                         "    \"credentialsId\": \"6g0ER59L4ZoE5zpOmUP48D\"\n" +
-                        "  },\n" +
-                        "  \"labelIds\": []\n" +
+                        "  }\n" +
                         "}")), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody("{\"computeEnvId\":\"3T6xWeFD63QIuzdAowvSTC\"}").withContentType(MediaType.APPLICATION_JSON)
@@ -444,8 +462,7 @@ class ComputeEnvsCmdTest extends BaseCmdTest {
                                 "      \"discriminator\": \"aws-batch\"\n" +
                                 "    },\n" +
                                 "    \"credentialsId\": \"6g0ER59L4ZoE5zpOmUP48D\"\n" +
-                                "},\n" +
-                                "  \"labelIds\": []\n" +
+                                "}\n" +
                                 "}\n" +
                                 "  ")), exactly(1)
         ).respond(
@@ -463,6 +480,25 @@ class ComputeEnvsCmdTest extends BaseCmdTest {
                 request().withMethod("GET").withPath("/credentials").withQueryStringParameter("platformId", "aws-batch"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody("{\"credentials\":[{\"id\":\"6g0ER59L4ZoE5zpOmUP48D\",\"name\":\"aws\",\"description\":null,\"discriminator\":\"aws\",\"baseUrl\":null,\"category\":null,\"deleted\":null,\"lastUsed\":\"2021-09-09T07:20:53Z\",\"dateCreated\":\"2021-09-08T05:48:51Z\",\"lastUpdated\":\"2021-09-08T05:48:51Z\"}]}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/labels")
+        ).respond(
+                response().withStatusCode(200).withBody(JsonBody.json("{}"))
+        );
+        mock.when(
+                request().withMethod("POST").withPath("/labels")
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withBody(JsonBody.json("{\n" +
+                                "\"id\": 10,\n" +
+                                "\"name\": \"res\",\n" +
+                                "\"resource\": true,\n" +
+                                "\"value\": \"val\"\n" +
+                                "}"
+                        ))
         );
 
         ExecOut out = exec(format, mock, "compute-envs", "import", "--overwrite", tempFile(new String(loadResource("cejson"), StandardCharsets.UTF_8), "ce", "json"), "-n", "demo", "-c", "6g0ER59L4ZoE5zpOmUP48D");

--- a/src/test/java/io/seqera/tower/cli/computeenvs/ComputeEnvsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/ComputeEnvsCmdTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockserver.client.MockServerClient;
+import org.mockserver.model.JsonBody;
 import org.mockserver.model.MediaType;
 
 import java.io.IOException;
@@ -355,7 +356,30 @@ class ComputeEnvsCmdTest extends BaseCmdTest {
         );
 
         mock.when(
-                request().withMethod("POST").withPath("/compute-envs").withBody("{\"computeEnv\":{\"name\":\"json\",\"platform\":\"aws-batch\",\"config\":{\"region\":\"eu-west-1\",\"cliPath\":\"/home/ec2-user/miniconda/bin/aws\",\"workDir\":\"s3://nextflow-ci/jordeu\",\"forge\":{\"type\":\"SPOT\",\"minCpus\":0,\"maxCpus\":123,\"gpuEnabled\":false,\"ebsAutoScale\":true,\"disposeOnDeletion\":true,\"fusionEnabled\":false,\"efsCreate\":true},\"discriminator\":\"aws-batch\"},\"credentialsId\":\"6g0ER59L4ZoE5zpOmUP48D\"}}"), exactly(1)
+                request().withMethod("POST").withPath("/compute-envs").withBody(JsonBody.json("{\n" +
+                        "  \"computeEnv\":{\n" +
+                        "    \"name\": \"json\",\n" +
+                        "    \"platform\": \"aws-batch\",\n" +
+                        "    \"config\": {\n" +
+                        "      \"region\": \"eu-west-1\",\n" +
+                        "      \"cliPath\": \"/home/ec2-user/miniconda/bin/aws\",\n" +
+                        "      \"workDir\": \"s3://nextflow-ci/jordeu\",\n" +
+                        "      \"forge\": {\n" +
+                        "        \"type\": \"SPOT\",\n" +
+                        "        \"minCpus\": 0,\n" +
+                        "        \"maxCpus\": 123,\n" +
+                        "        \"gpuEnabled\": false,\n" +
+                        "        \"ebsAutoScale\": true,\n" +
+                        "        \"disposeOnDeletion\": true,\n" +
+                        "        \"fusionEnabled\": false,\n" +
+                        "        \"efsCreate\": true\n" +
+                        "      },\n" +
+                        "      \"discriminator\": \"aws-batch\"\n" +
+                        "    },\n" +
+                        "    \"credentialsId\": \"6g0ER59L4ZoE5zpOmUP48D\"\n" +
+                        "  },\n" +
+                        "  \"labelIds\": []\n" +
+                        "}")), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody("{\"computeEnvId\":\"3T6xWeFD63QIuzdAowvSTC\"}").withContentType(MediaType.APPLICATION_JSON)
         );
@@ -398,7 +422,32 @@ class ComputeEnvsCmdTest extends BaseCmdTest {
         );
 
         mock.when(
-                request().withMethod("POST").withPath("/compute-envs").withBody("{\"computeEnv\":{\"name\":\"demo\",\"platform\":\"aws-batch\",\"config\":{\"region\":\"eu-west-1\",\"cliPath\":\"/home/ec2-user/miniconda/bin/aws\",\"workDir\":\"s3://nextflow-ci/jordeu\",\"forge\":{\"type\":\"SPOT\",\"minCpus\":0,\"maxCpus\":123,\"gpuEnabled\":false,\"ebsAutoScale\":true,\"disposeOnDeletion\":true,\"fusionEnabled\":false,\"efsCreate\":true},\"discriminator\":\"aws-batch\"},\"credentialsId\":\"6g0ER59L4ZoE5zpOmUP48D\"}}"), exactly(1)
+                request().withMethod("POST").withPath("/compute-envs")
+                        .withBody(JsonBody.json("{\n" +
+                                "  \"computeEnv\":{\n" +
+                                "    \"name\": \"demo\",\n" +
+                                "    \"platform\": \"aws-batch\",\n" +
+                                "    \"config\": {\n" +
+                                "      \"region\": \"eu-west-1\",\n" +
+                                "      \"cliPath\": \"/home/ec2-user/miniconda/bin/aws\",\n" +
+                                "      \"workDir\": \"s3://nextflow-ci/jordeu\",\n" +
+                                "      \"forge\": {\n" +
+                                "        \"type\": \"SPOT\",\n" +
+                                "        \"minCpus\": 0,\n" +
+                                "        \"maxCpus\": 123,\n" +
+                                "        \"gpuEnabled\": false,\n" +
+                                "        \"ebsAutoScale\": true,\n" +
+                                "        \"disposeOnDeletion\": true,\n" +
+                                "        \"fusionEnabled\": false,\n" +
+                                "        \"efsCreate\": true\n" +
+                                "      },\n" +
+                                "      \"discriminator\": \"aws-batch\"\n" +
+                                "    },\n" +
+                                "    \"credentialsId\": \"6g0ER59L4ZoE5zpOmUP48D\"\n" +
+                                "},\n" +
+                                "  \"labelIds\": []\n" +
+                                "}\n" +
+                                "  ")), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody("{\"computeEnvId\":\"3T6xWeFD63QIuzdAowvSTC\"}").withContentType(MediaType.APPLICATION_JSON)
         );

--- a/src/test/java/io/seqera/tower/cli/shared/ComputeEnvExportFormatTest.java
+++ b/src/test/java/io/seqera/tower/cli/shared/ComputeEnvExportFormatTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2021, Seqera Labs.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This Source Code Form is "Incompatible With Secondary Licenses", as
+ * defined by the Mozilla Public License, v. 2.0.
+ */
+
+package io.seqera.tower.cli.shared;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.seqera.tower.model.AwsBatchConfig;
+import io.seqera.tower.model.ForgeConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static io.seqera.tower.cli.utils.JsonHelper.parseJson;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ComputeEnvExportFormatTest {
+
+    @Test
+    void testFormatDeserialization() throws JsonProcessingException {
+        String json = "{\n" +
+                "  \"region\" : \"eu-west-2\",\n" +
+                "  \"executionRole\" : \"arn:aws:iam::<redacted>:role/TowerForge-<redacted>-ExecutionRole\",\n" +
+                "  \"headJobRole\" : \"arn:aws:iam::<redacted>:role/TowerForge-<redacted>-FargateRole\",\n" +
+                "  \"workDir\" : \"s3://jaime-testing\",\n" +
+                "  \"waveEnabled\" : true,\n" +
+                "  \"fusion2Enabled\" : true,\n" +
+                "  \"nvnmeStorageEnabled\" : false,\n" +
+                "  \"forge\" : {\n" +
+                "    \"type\" : \"SPOT\",\n" +
+                "    \"minCpus\" : 0,\n" +
+                "    \"maxCpus\" : 2,\n" +
+                "    \"gpuEnabled\" : false,\n" +
+                "    \"disposeOnDeletion\" : true,\n" +
+                "    \"efsCreate\" : false,\n" +
+                "    \"fargateHeadEnabled\" : true,\n" +
+                "    \"arm64Enabled\" : false\n" +
+                "  },\n" +
+                "  \"discriminator\" : \"aws-batch\",\n" +
+                "  \"labels\" : [ {\n" +
+                "    \"id\" : 130065807872087,\n" +
+                "    \"name\" : \"owner\",\n" +
+                "    \"value\" : \"jaime\",\n" +
+                "    \"resource\" : true,\n" +
+                "    \"isDefault\" : false\n" +
+                "  } ]\n" +
+                "}\n";
+
+        ComputeEnvExportFormat ce = ComputeEnvExportFormat.deserialize(json);
+
+        assertNotNull(ce.getConfig());
+        assertNotNull(ce.getLabels());
+
+        assertTrue(ce.getLabels().size() == 1);
+        assertEquals("eu-west-2", ce.getConfig().getDiscriminator());
+    }
+
+    @Test
+    void testFormatSerialization() throws JsonProcessingException {
+
+        AwsBatchConfig cfg = parseJson(" {\"discriminator\": \"aws-batch\"}", AwsBatchConfig.class)
+                .region("eu-west-2")
+                .cliPath("/home/ec2-user/miniconda/bin/aws")
+                .workDir("s3://jaime-testing")
+                .volumes(Collections.emptyList())
+                .computeQueue("TowerForge-<redacted>-work")
+                .headQueue("TowerForge-<redacted>-head")
+                .forge(
+                        new ForgeConfig()
+                                .type(ForgeConfig.TypeEnum.SPOT)
+                                .minCpus(0)
+                                .maxCpus(123)
+                                .gpuEnabled(false)
+                                .ebsAutoScale(true)
+                                .disposeOnDeletion(true)
+                                .fusionEnabled(true)
+                ).forgedResources(
+                        List.of(
+                                Map.of("IamRole", "arn:aws:iam::<redacted>:role/TowerForge-<redacted>-ServiceRole"),
+                                Map.of("IamRole", "arn:aws:iam::<redacted>:role/TowerForge-<redacted>-FleetRole")
+                        )
+                );
+
+        ComputeEnvExportFormat fmt = new ComputeEnvExportFormat(cfg, Collections.emptyList());
+        String json = ComputeEnvExportFormat.serialize(fmt);
+        ComputeEnvExportFormat newFmt = ComputeEnvExportFormat.deserialize(json);
+
+        assertEquals(fmt.getConfig(), newFmt.getConfig());
+        assertEquals(fmt.getLabels(), newFmt.getLabels());
+    }
+
+}

--- a/src/test/java/io/seqera/tower/cli/shared/ComputeEnvExportFormatTest.java
+++ b/src/test/java/io/seqera/tower/cli/shared/ComputeEnvExportFormatTest.java
@@ -63,7 +63,7 @@ class ComputeEnvExportFormatTest {
         assertNotNull(ce.getLabels());
 
         assertTrue(ce.getLabels().size() == 1);
-        assertEquals("eu-west-2", ce.getConfig().getDiscriminator());
+        assertEquals("aws-batch", ce.getConfig().getDiscriminator());
     }
 
     @Test


### PR DESCRIPTION
## Description

Append 'labels' field to exported CE JSON data structure and include that field when importing the CE from JSON file.

Closes #313 

## Guidelines for testing

The example shows the import/export of an AWS Batch CE but the same principles should apply to any CE platform type.

Given an `ExportTest` CE with resource labels already created in Tower:

When exporting the CE as JSON using:
```
$> tw compute-envs export data.json -n ExportTest -w Org/Wsp
```
Then the export file `data.json` should include a `labels` field with the resource labels:
```
{
  "region" : "eu-west-2",
  "executionRole" : "arn:aws:iam::<redacted>:role/TowerForge-<redacted>-ExecutionRole",
  "headJobRole" : "arn:aws:iam::<redacted>:role/TowerForge-<redacted>-FargateRole",
  "workDir" : "s3://jaime-testing",
  "waveEnabled" : true,
  "fusion2Enabled" : true,
  "nvnmeStorageEnabled" : false,
  "forge" : {
    "type" : "SPOT",
    "minCpus" : 0,
    "maxCpus" : 2,
    "gpuEnabled" : false,
    "disposeOnDeletion" : true,
    "efsCreate" : false,
    "fargateHeadEnabled" : true,
    "arm64Enabled" : false
  },
  "discriminator" : "aws-batch",
  "labels" : [ { // <----------------------------- Here
    "id" : 130065807872087,
    "name" : "owner",
    "value" : "jaime",
    "resource" : true,
    "isDefault" : false
  } ]
}
```
When importing the CE from the JSON file as a new CE using:
```
$> tw compute-envs import data.json -n ImportTest -w Org/Wsp -c AwsDevCreds
```
Then the imported CE should appear in Tower with the same configuration including the resource labels.
