### PR TITLE
notask: fixed tw script to support zsh and bash (tested on mac)

### DIFF
--- a/tw
+++ b/tw
@@ -1,6 +1,14 @@
 #!/bin/bash
 
+current_shell=$(basename -- "$SHELL")
 
-bash -c "./gradlew run -q --args=\"${*@Q}\""
-#./gradlew run -q --args="$@"
-
+if [ "$current_shell" = "bash" ]; then
+    echo "Running in Bash"
+    ./gradlew run -q --args="${*@Q}"
+elif [[ "$current_shell" = *"zsh"* ]]; then
+    echo "Running in Zsh"
+    ./gradlew run -q --args="$@"
+else
+    echo "Unknown shell: $current_shell"
+    exit 1
+fi


### PR DESCRIPTION
## Description

Fix the tw script to detect which shell we are on, because the syntax changes a bit from bash

## Testing guidelines

1. Check if the script still works from bash
2. Test from linux (currently tested from Mac and Zsh)