### PR TITLE
Fix 'runs view' user permissions

### DIFF
--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -2294,7 +2294,8 @@
   "name":"io.seqera.tower.model.CreatePipelineRequest",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"getDescription","parameterTypes":[] }, {"name":"getIcon","parameterTypes":[] }, {"name":"getLabelIds","parameterTypes":[] }, {"name":"getLaunch","parameterTypes":[] }, {"name":"getName","parameterTypes":[] }]
 },
 {
   "name":"io.seqera.tower.model.CreatePipelineResponse",
@@ -2416,7 +2417,8 @@
   "name":"io.seqera.tower.model.DescribePipelineResponse",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
-  "allDeclaredConstructors":true
+  "allDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setPipeline","parameterTypes":["io.seqera.tower.model.PipelineDbDto"] }]
 },
 {
   "name":"io.seqera.tower.model.DescribeTaskResponse",
@@ -3049,7 +3051,7 @@
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true,
-  "methods":[{"name":"<init>","parameterTypes":[] }]
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"getComputeEnvId","parameterTypes":[] }, {"name":"getConfigProfiles","parameterTypes":[] }, {"name":"getConfigText","parameterTypes":[] }, {"name":"getDateCreated","parameterTypes":[] }, {"name":"getEntryName","parameterTypes":[] }, {"name":"getHeadJobCpus","parameterTypes":[] }, {"name":"getHeadJobMemoryMb","parameterTypes":[] }, {"name":"getId","parameterTypes":[] }, {"name":"getLabelIds","parameterTypes":[] }, {"name":"getMainScript","parameterTypes":[] }, {"name":"getOptimizationId","parameterTypes":[] }, {"name":"getOptimizationTargets","parameterTypes":[] }, {"name":"getParamsText","parameterTypes":[] }, {"name":"getPipeline","parameterTypes":[] }, {"name":"getPostRunScript","parameterTypes":[] }, {"name":"getPreRunScript","parameterTypes":[] }, {"name":"getPullLatest","parameterTypes":[] }, {"name":"getResume","parameterTypes":[] }, {"name":"getRevision","parameterTypes":[] }, {"name":"getRunName","parameterTypes":[] }, {"name":"getSchemaName","parameterTypes":[] }, {"name":"getSessionId","parameterTypes":[] }, {"name":"getStubRun","parameterTypes":[] }, {"name":"getTowerConfig","parameterTypes":[] }, {"name":"getUserSecrets","parameterTypes":[] }, {"name":"getWorkDir","parameterTypes":[] }, {"name":"getWorkspaceSecrets","parameterTypes":[] }]
 },
 {
   "name":"io.seqera.tower.model.WorkflowLaunchResponse",

--- a/src/main/java/io/seqera/tower/cli/commands/runs/ViewCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/ViewCmd.java
@@ -18,7 +18,6 @@
 package io.seqera.tower.cli.commands.runs;
 
 import io.seqera.tower.ApiException;
-import io.seqera.tower.cli.commands.global.ShowLabelsOption;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
 import io.seqera.tower.cli.commands.runs.download.DownloadCmd;
 import io.seqera.tower.cli.commands.runs.metrics.MetricsCmd;
@@ -28,8 +27,8 @@ import io.seqera.tower.cli.exceptions.RunNotFoundException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.runs.RunView;
 import io.seqera.tower.model.ComputeEnv;
+import io.seqera.tower.model.DescribeWorkflowLaunchResponse;
 import io.seqera.tower.model.DescribeWorkflowResponse;
-import io.seqera.tower.model.ListLabelsResponse;
 import io.seqera.tower.model.ProgressData;
 import io.seqera.tower.model.Workflow;
 import io.seqera.tower.model.WorkflowLoad;
@@ -42,7 +41,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import static io.seqera.tower.cli.utils.FormatHelper.formatLabels;
 
@@ -81,7 +79,8 @@ public class ViewCmd extends AbstractRunsCmd {
             Workflow workflow = workflowResponse.getWorkflow();
             WorkflowLoad workflowLoad = workflowLoadByWorkflowId(wspId, id);
 
-            ComputeEnv computeEnv = workflow.getLaunchId() != null ? launchById(wspId, workflow.getLaunchId()).getComputeEnv() : null;
+            DescribeWorkflowLaunchResponse wfLaunch = api().describeWorkflowLaunch(workflow.getId(), wspId);
+            ComputeEnv computeEnv = wfLaunch.getLaunch() != null ? wfLaunch.getLaunch().getComputeEnv() : null;
 
             ProgressData progress = null;
             if (opts.processes || opts.stats || opts.load || opts.utilization) {

--- a/src/test/java/io/seqera/tower/cli/runs/RunsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/runs/RunsCmdTest.java
@@ -295,26 +295,27 @@ class RunsCmdTest extends BaseCmdTest {
     @ParameterizedTest
     @EnumSource(OutputType.class)
     void testView(OutputType format, MockServerClient mock) throws JsonProcessingException {
+
         mock.when(
-                request().withMethod("GET").withPath("/workflow/5dAZoXrcmZXRO4"), exactly(1)
+                request().withMethod("GET").withPath("/workflow/5mDfiUtqyptDib"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("workflow_view")).withContentType(MediaType.APPLICATION_JSON)
         );
 
         mock.when(
-                request().withMethod("GET").withPath("/workflow/5dAZoXrcmZXRO4/progress"), exactly(1)
+                request().withMethod("GET").withPath("/workflow/5mDfiUtqyptDib/progress"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("workflow_progress")).withContentType(MediaType.APPLICATION_JSON)
         );
 
         mock.when(
-                request().withMethod("GET").withPath("/launch/5SCyEXKrCqFoGzOXGpesr5"), exactly(1)
+                request().withMethod("GET").withPath("/workflow/5mDfiUtqyptDib/launch"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("launch_view")).withContentType(MediaType.APPLICATION_JSON)
         );
 
         mock.when(
-                request().withMethod("GET").withPath("/compute-envs/isnEDBLvHDAIteOEF44ow"), exactly(1)
+                request().withMethod("GET").withPath("/compute-envs/3xkkzYH2nbD3nZjrzKm0oR"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("compute_env_view")).withContentType(MediaType.APPLICATION_JSON)
         );
@@ -325,7 +326,7 @@ class RunsCmdTest extends BaseCmdTest {
                 response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
         );
 
-        ExecOut out = exec(format, mock, "runs", "view", "-i", "5dAZoXrcmZXRO4");
+        ExecOut out = exec(format, mock, "runs", "view", "-i", "5mDfiUtqyptDib");
 
         Workflow workflow = parseJson("{\n" +
                 "    \"id\": \"5mDfiUtqyptDib\",\n" +


### PR DESCRIPTION
## Description

Closes #371 

Changes the endpoint used by the view cmd allowing users with 'view' role to describe workflow launches as needed by the cmd implementation.

## Guidelines for testing
+ As user A in a workspace Wsp:
    - Create a pipeline and run it
    - Get the run ID
    - Give user B 'view' role for the workspace
+ As user B:
    - Confirm using web UI that workspace Wsp runs are visible
    - Configure tower access token for tw-cli
    - View run <runID> in Wsp using tw-cli:
```
$> ./tw runs view -i <runID> -w Org/Wsp
```
Expected output:
```

  Run at [Org / Wsp] workspace:


    General
    ---------------------+------------------------------------------
     ID                  | ggCxlvsF8Ao9I                            
     Operation ID        | 626f46be-1715-4e64-a20e-a3cd34818039     
     Run name            | pedantic_mcnulty                         
     Status              | SUCCEEDED                                
     Starting date       | Thu, 18 May 2023 09:47:13 GMT            
     Commit ID           | 1d71f857bb64af58716575d770ef74baf21313d1 
     Session ID          | ac254f00-d6d8-4d40-bf99-0ec5252ba8e5     
     Username            | jaime-munoz                              
     Workdir             | s3://jaime-testing/scratch/ggCxlvsF8Ao9I 
     Container           | quay.io/nextflow/bash                    
     Executors           | awsbatch                                 
     Compute Environment | deleted-12042873637099533                
     Nextflow Version    | 23.04.1                                  
     Labels              | No labels reported in workspace          


```

