### PR TITLE
enable g1gc for linux distribution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,7 @@ graalvmNative {
             configurationFileDirectories.from(file('conf'))
 
             if (System.env.getOrDefault("PLATFORM", "") == "linux-x86_64") {
-                buildArgs(['--static', '--libc=musl'])
+                buildArgs(['--static', '--libc=musl', '--gc=G1'])
             }
             buildArgs.add('--allow-incomplete-classpath')
             buildArgs.add('--report-unsupported-elements-at-runtime')


### PR DESCRIPTION
Tower-cli also has the virtual memory problem as wave-cli because of serial GC mentioned in this issue https://github.com/seqeralabs/wave-cli/issues/46.

To resolve this issue, this PR will enable g1gc