### PR TITLE
Update CLI usage docs page

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -227,7 +227,7 @@ $ tw launch my_rnaseq_nf_pipeline --params-file=my_rnaseq_nf_pipeline_params_2.y
 
 See [Nextflow configuration][nextflow-config] for more information.
 
-### Launch an unconfigured pipeline
+### Launch an unsaved pipeline
 
 The CLI can directly launch pipelines that have not been added to the Launchpad in a Seqera workspace by using the full pipeline repository URL:
 
@@ -250,7 +250,7 @@ $ tw launch https://github.com/nf-core/rnaseq --params-file=./custom_rnaseq_para
 Run `tw workspaces -h` to view supported workspace operations.
 Run `tw workspaces add -h` to view the required and optional fields for adding your workspace.
 
-Workspaces provide the context in which a user launches workflow executions, defines the available resources, and manages who can access those resources. Workspaces contain pipelines, runs, actions, datasets, compute environments, and credentials. Access permissions are controlled with participants, collaborators, and teams.
+Workspaces provide the context in which a user launches workflow executions, defines the available resources, and manages who can access those resources. Workspaces contain pipelines, runs, actions, datasets, compute environments, credentials, and secrets. Access permissions are controlled with participants, collaborators, and teams.
 
 See [User workspaces][user-workspaces] for more information.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -48,9 +48,9 @@ Seqera requires access credentials to interact with pipeline Git repositories. S
 
 #### Container registry credentials
 
-Configure credentials for the Nextflow Wave container service to authenticate to private and public container registries. See the Container registry credentials section in the [Seqera docs](https://docs.seqera.io/platform/latest/credentials/overview) for registry-specific instructions. 
+Configure credentials for the Nextflow Wave container service to authenticate to private and public container registries. See the **Container registry credentials** section under [Credentials](https://docs.seqera.io/platform/latest/credentials/overview) for registry-specific instructions. 
 
-Continer registry credentials are only used by the Wave container service. See [Wave containers](https://www.nextflow.io/docs/latest/wave.html) for more information.
+> **Note**: Container registry credentials are only used by the Wave container service. See [Wave containers](https://www.nextflow.io/docs/latest/wave.html) for more information.
 
 ### List credentials
 
@@ -84,7 +84,7 @@ Compute environments in Seqera define the execution platform where a pipeline wi
 ### Add a compute environment
 
 Run `tw compute-envs add -h` to view the list of supported platforms.
-Run `tw compute-envs add <provider> -h` to view the required and optional fields for your provider.
+Run `tw compute-envs add <platform> -h` to view the required and optional fields for your platform.
 
 You must add the credentials for your provider before creating your compute environment. 
 
@@ -155,9 +155,9 @@ $ tw pipelines add --name=my_rnaseq_nf_pipeline --params-file=my_rnaseq_nf_pipel
  New pipeline 'my_rnaseq_nf_pipeline' added at user workspace
 ```
 
-The optional `--params-file` parameter is used to pass a set of default parameters that will be associated with the pipeline in the Launchpad.
+The optional `--params-file` flag is used to pass a set of default parameters that will be associated with the pipeline in the Launchpad.
 
-> **Note**: The `params-file` must be a YAML or JSON file., using [Nextflow configuration file](https://www.nextflow.io/docs/latest/config.html#config-syntax) syntax.
+> **Note**: The `params-file` must be a YAML or JSON file using [Nextflow configuration file](https://www.nextflow.io/docs/latest/config.html#config-syntax) syntax.
 
 ### Import and export a pipeline
 
@@ -189,9 +189,9 @@ tw pipelines update --name=my_rnaseq_nf_pipeline --params-file=my_rnaseq_nf_pipe
 
 ### Launch a preconfigured pipeline
 
-When launching a pipeline from the Launchpad, if no custom parameters are passed via the CLI then the defaults set for the pipeline in the Launchpad will be used.
+If no custom parameters are passed via the CLI during launch, the defaults set for the pipeline in the Launchpad will be used.
 
-> **Note**: Platform CLI users are bound to the same user permissions that apply in the platform UI. Launch users can launch pre-configured pipelines in the workspaces they have access to, but they cannot add or run new pipelines.
+> **Note**: tw CLI users are bound to the same user permissions that apply in the Platform UI. Launch users can launch pre-configured pipelines in the workspaces they have access to, but they cannot add or run new pipelines.
 
 ```console
 $ tw launch my_rnaseq_nf_pipeline 
@@ -210,7 +210,7 @@ When using `--wait`, `tw` can exit with one of two exit codes:
 
 ### Launch a pipeline with custom parameters
 
-To specify custom parameters when launching a pipeline, specify a different `--params-file`:
+To specify custom parameters during pipeline launch, specify a custom `--params-file`:
 
 ```console
 $ tw launch my_rnaseq_nf_pipeline --params-file=my_rnaseq_nf_pipeline_params_2.yaml
@@ -219,6 +219,8 @@ $ tw launch my_rnaseq_nf_pipeline --params-file=my_rnaseq_nf_pipeline_params_2.y
 
     https://tower.nf/user/abhinav/watch/2XDXxX0vCX8xhx
 ```
+
+See [Nextflow configuration](https://www.nextflow.io/docs/latest/config.html#config-syntax) for more information.
 
 ### Launch an unconfigured pipeline
 
@@ -232,25 +234,23 @@ $ tw launch https://github.com/nf-core/rnaseq --params-file=./custom_rnaseq_para
     https://tower.nf/user/abhinav/watch/2XDXxX0vCX8xhx
 ```
 
-> **Note**: CLI users are bound to the same user permissions that apply in the Platform UI. Launch users can launch pre-configured pipelines in the workspaces they have access to, but they cannot add or run new pipelines.
-
-In the command above:
-
-- Pipeline level parameters are defined within the `custom_rnaseq_params.yaml` file
+- Pipeline parameters are defined within the `custom_rnaseq_params.yaml` file
 - Other parameters such as `--profile` and `--revision` can also be specified
-- A non-primary compute environment has been used to launch the pipeline
+- A non-primary compute environment has been used to launch the pipeline. Omit `--compute-env` to launch with the workspace default compute environment.
+
+> **Note**: CLI users are bound to the same user permissions that apply in the Platform UI. Launch users can launch pre-configured pipelines in the workspaces they have access to, but they cannot add or run new pipelines.
 
 ## Workspaces
 
 Workspaces provide the context in which a user launches workflow executions, defines the available resources, and manages who can access those resources. Workspaces contain pipelines, runs, actions, datasets, compute environments, and credentials. Access permissions are controlled with participants, collaborators, and teams.
 
-Comprehensive details about [Users and Workspaces](https://help.tower.nf/22.1/orgs-and-teams/overview/) are available in the Tower Usage docs.
+See [User workspaces](https://docs.seqera.io/platform/latest/orgs-and-teams/workspace-management) for more information.
 
 > **Note**: This section assumes that you already have access to an organization in Seqera Platform.
 
 ### Create a workspace
 
-In the example below, we create a shared workspace to be used for sharing pipelines with other private workspaces. Please refer to the Tower usage docs for detailed information about [shared Workspaces](https://help.tower.nf/22.1/orgs-and-teams/shared-workspaces/).
+In the example below, we create a shared workspace to be used for sharing pipelines with other private workspaces. See [Shared workspaces](https://docs.seqera.io/platform/latest/orgs-and-teams/shared-workspaces) for more information.
 
 ```console
 $ tw workspaces add --name=shared-workspace --full-name=shared-workspace-for-all  --org=my-tower-org --visibility=SHARED
@@ -258,7 +258,7 @@ $ tw workspaces add --name=shared-workspace --full-name=shared-workspace-for-all
   A 'SHARED' workspace 'shared-workspace' added for 'my-tower-org' organization
 ```
 
-> **Note**: By default, a Workspace is set to private when created.
+> **Note**: By default, a workspace is set to private when created.
 
 ### List workspaces
 
@@ -292,7 +292,7 @@ $ tw participants list
 
 To add a new _collaborator_ to the workspace, use the `add` subcommand. The default role assigned to a _collaborator_ is `Launch`.
 
-Please refer to the Tower usage docs for detailed information about [collaborators and members](https://help.tower.nf/22.1/orgs-and-teams/workspace-management/).
+See [Participant roles](https://docs.seqera.io/platform/latest/orgs-and-teams/workspace-management#participant-roles) for more information.
 
 ```console
 $ tw participants add --name=collaborator@mydomain.com --type=MEMBER                           

--- a/USAGE.md
+++ b/USAGE.md
@@ -86,7 +86,7 @@ Compute environments in Seqera define the execution platform where a pipeline ru
 Run `tw compute-envs add -h` to view the list of supported platforms.
 Run `tw compute-envs add <platform> -h` to view the required and optional fields for your platform.
 
-You must add the credentials for your provider before creating your compute environment. 
+You must add the credentials for your provider before creating your compute environment.
 
 ```console
 $ tw compute-envs add aws-batch forge --name=my_aws_ce --credentials=<my_aws_creds_1> --region=eu-west-1 --max-cpus=256 --work-dir=s3://<bucket name> --wait=AVAILABLE

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,6 +1,6 @@
-# Usage examples
+# tw CLI commands
 
-## View available commands
+> **Note**: The CLI performs operations in the user workspace context by default. Use the `TOWER_WORKSPACE_ID` environment variable or the `--workspace` parameter to specify an organization workspace ID.
 
 Use the `-h` or `--help` parameter to list the available commands and their associated options.
 
@@ -20,8 +20,6 @@ To launch pipelines in a Seqera workspace, you need [credentials](https://docs.s
 2. Pipeline repository Git providers
 3. (Optional) [Tower agent](https://github.com/seqeralabs/tower-agent) — used with HPC clusters
 4. (Optional) Container registries, such as docker.io
-
-> **Note**: The CLI performs operations in the user workspace context by default. Use the `TOWER_WORKSPACE_ID` environment variable or the `--workspace` parameter to specify an organization workspace ID.
 
 ### Add credentials
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -10,7 +10,7 @@ For help with a specific subcommand, run the command with `-h` or `--help` appen
 
 > **Tip**: Use `tw --output=json <command>` to dump and store Seqera Platform entities in JSON format.
 >
-> **Tip**: Use `tw --output=json <command> | jq -r '.[].<key>'`  to pipe the command to jq to retrieve specific values in the JSON output. For example, `tw --output=json workspaces list | jq -r '.workspaces[].orgId'` returns the organization ID for each workspace listed.
+> **Tip**: Use `tw --output=json <command> | jq -r '.[].<key>'`  to pipe the command to use jq to retrieve specific values in the JSON output. For example, `tw --output=json workspaces list | jq -r '.workspaces[].orgId'` returns the organization ID for each workspace listed.
 
 ## Credentials
 
@@ -25,6 +25,8 @@ To launch pipelines in a Seqera workspace, you need [credentials](https://docs.s
 
 Run `tw credentials add -h` to view a list of providers.
 Run `tw credentials add <provider> -h` to view the required fields for your provider.
+
+> **Note**: You can add multiple credentials from the same provider in the same workspace.
 
 #### Compute environment credentials
 
@@ -66,8 +68,6 @@ $ tw credentials list
      2x7xNsf2xkxxUIxXKxsTCx | ssh       | my_ssh_key                         | Thu, 8 Jul 2021 07:09:46 GMT  
      4xxxIeUx7xex1xqx1xxesk | github    | my_github_cred                     | Wed, 22 Jun 2022 09:18:05 GMT 
 ```
-
-> **Note**: You can add multiple credentials from the same provider in the same workspace.
 
 ### Delete credentials
 
@@ -145,6 +145,9 @@ $ tw compute-envs import --name=my_aws_ce_v1 ./my_aws_ce_v1.json
 
 Pipelines define pre-configured workflows in a workspace. A pipeline consists of a workflow repository, launch parameters, and a compute environment. 
 
+Run `tw pipelines -h` to view the list of supported operations.
+Run `tw pipelines add -h` to view the required and optional fields for adding your pipeline.
+
 ### Add a pipeline
 
 Add a pre-configured pipeline to the Launchpad:
@@ -186,6 +189,8 @@ tw pipelines update --name=my_rnaseq_nf_pipeline --params-file=my_rnaseq_nf_pipe
 ```
 
 ## Launch pipelines
+
+Run `tw launch -h` to view supported launch options.
 
 ### Launch a preconfigured pipeline
 
@@ -236,11 +241,14 @@ $ tw launch https://github.com/nf-core/rnaseq --params-file=./custom_rnaseq_para
 
 - Pipeline parameters are defined within the `custom_rnaseq_params.yaml` file
 - Other parameters such as `--profile` and `--revision` can also be specified
-- A non-primary compute environment has been used to launch the pipeline. Omit `--compute-env` to launch with the workspace default compute environment.
+- A non-primary compute environment can be used to launch the pipeline. Omit `--compute-env` to launch with the workspace default compute environment.
 
 > **Note**: CLI users are bound to the same user permissions that apply in the Platform UI. Launch users can launch pre-configured pipelines in the workspaces they have access to, but they cannot add or run new pipelines.
 
 ## Workspaces
+
+Run `tw workspaces -h` to view supported workspace operations.
+Run `tw workspaces add -h` to view the required and optional fields for adding your workspace.
 
 Workspaces provide the context in which a user launches workflow executions, defines the available resources, and manages who can access those resources. Workspaces contain pipelines, runs, actions, datasets, compute environments, and credentials. Access permissions are controlled with participants, collaborators, and teams.
 
@@ -275,6 +283,9 @@ $ tw workspaces list
 ```
 
 ## Participants
+
+Run `tw participants -h` to view supported participant operations. 
+Run `tw participants add -h` to view the required and optoinal fields for adding a participant. 
 
 ### List participants
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -14,11 +14,11 @@ For help with a specific subcommand, run the command with `-h` or `--help` appen
 
 ## Credentials
 
-To launch pipelines in a Seqera workspace, you need [credentials](https://docs.seqera.io/platform/latest/credentials/overview) for:
+To launch pipelines in a Seqera workspace, you need [credentials][credentials] for:
 
 1. Compute environments
 2. Pipeline repository Git providers
-3. (Optional) [Tower agent](https://github.com/seqeralabs/tower-agent) — used with HPC clusters
+3. (Optional) [Tower agent][tower-agent] — used with HPC clusters
 4. (Optional) Container registries, such as docker.io
 
 ### Add credentials
@@ -30,7 +30,7 @@ Run `tw credentials add <provider> -h` to view the required fields for your prov
 
 #### Compute environment credentials
 
-Seqera requires credentials to access your cloud compute environments. See the [compute environment page](https://docs.seqera.io/platform/latest/compute-envs/overview) for your cloud provider for more information.
+Seqera requires credentials to access your cloud compute environments. See the [compute environment page][compute-envs] for your cloud provider for more information.
 
   ```console
   $ tw credentials add aws --name=my_aws_creds --access-key=<aws access key> --secret-key=<aws secret key>
@@ -40,7 +40,7 @@ Seqera requires credentials to access your cloud compute environments. See the [
 
 #### Git credentials
 
-Seqera requires access credentials to interact with pipeline Git repositories. See [Git integration](https://docs.seqera.io/platform/latest/git/overview) for more information.
+Seqera requires access credentials to interact with pipeline Git repositories. See [Git integration][git-integration] for more information.
 
   ```console
   $ tw credentials add github -n=my_GH_creds -u=<GitHub username> -p=<GitHub access token>
@@ -50,9 +50,9 @@ Seqera requires access credentials to interact with pipeline Git repositories. S
 
 #### Container registry credentials
 
-Configure credentials for the Nextflow Wave container service to authenticate to private and public container registries. See the **Container registry credentials** section under [Credentials](https://docs.seqera.io/platform/latest/credentials/overview) for registry-specific instructions. 
+Configure credentials for the Nextflow Wave container service to authenticate to private and public container registries. See the **Container registry credentials** section under [Credentials][credentials] for registry-specific instructions. 
 
-> **Note**: Container registry credentials are only used by the Wave container service. See [Wave containers](https://www.nextflow.io/docs/latest/wave.html) for more information.
+> **Note**: Container registry credentials are only used by the Wave container service. See [Wave containers][wave-docs] for more information.
 
 ### List credentials
 
@@ -79,7 +79,7 @@ $ tw credentials delete --name=my_aws_creds
 
 ## Compute environments
 
-Compute environments in Seqera define the execution platform where a pipeline runs. A compute environment is composed of the credentials, configuration, and storage options related to a particular computing platform.  See [Seqera Platform compute environments](https://docs.seqera.io/platform/latest/compute-envs/overview) for more information on supported compute environments.
+Compute environments in Seqera define the execution platform where a pipeline runs. A compute environment is composed of the credentials, configuration, and storage options related to a particular computing platform.  See [Seqera Platform compute environments][compute-envs] for more information on supported compute environments.
 
 ### Add a compute environment
 
@@ -103,7 +103,7 @@ This command will:
 - Use an existing S3 bucket to store the Nextflow work directory (`--work-dir`)
 - Wait until the compute environment has been successfully created and is ready to use (`--wait`)
 
-See the [compute environment page](https://docs.seqera.io/platform/latest/compute-envs/overview) for your provider for detailed information on Batch Forge and manual compute environment creation.
+See the [compute environment page][compute-envs] for your provider for detailed information on Batch Forge and manual compute environment creation.
 
 ### Delete a compute environment
 
@@ -160,7 +160,7 @@ $ tw pipelines add --name=my_rnaseq_nf_pipeline --params-file=my_rnaseq_nf_pipel
 
 The optional `--params-file` flag is used to pass a set of default parameters that will be associated with the pipeline in the Launchpad.
 
-> **Note**: The `params-file` must be a YAML or JSON file using [Nextflow configuration file](https://www.nextflow.io/docs/latest/config.html#config-syntax) syntax.
+> **Note**: The `params-file` must be a YAML or JSON file using [Nextflow configuration file][nextflow-config] syntax.
 
 ### Import and export a pipeline
 
@@ -225,7 +225,7 @@ $ tw launch my_rnaseq_nf_pipeline --params-file=my_rnaseq_nf_pipeline_params_2.y
     https://tower.nf/user/abhinav/watch/2XDXxX0vCX8xhx
 ```
 
-See [Nextflow configuration](https://www.nextflow.io/docs/latest/config.html#config-syntax) for more information.
+See [Nextflow configuration][nextflow-config] for more information.
 
 ### Launch an unconfigured pipeline
 
@@ -240,7 +240,7 @@ $ tw launch https://github.com/nf-core/rnaseq --params-file=./custom_rnaseq_para
 ```
 
 - Pipeline parameters are defined within the `custom_rnaseq_params.yaml` file.
-- Other parameters such as `--profile` and `--revision` can also be specified
+- Other parameters such as `--profile` and `--revision` can also be specified.
 - A non-primary compute environment can be used to launch the pipeline. Omit `--compute-env` to launch with the workspace default compute environment.
 
 > **Note**: CLI users are bound to the same user permissions that apply in the Platform UI. Launch users can launch pre-configured pipelines in the workspaces they have access to, but they cannot add or run new pipelines.
@@ -252,13 +252,13 @@ Run `tw workspaces add -h` to view the required and optional fields for adding y
 
 Workspaces provide the context in which a user launches workflow executions, defines the available resources, and manages who can access those resources. Workspaces contain pipelines, runs, actions, datasets, compute environments, and credentials. Access permissions are controlled with participants, collaborators, and teams.
 
-See [User workspaces](https://docs.seqera.io/platform/latest/orgs-and-teams/workspace-management) for more information.
+See [User workspaces][user-workspaces] for more information.
 
 > **Note**: This section assumes that you already have access to an organization in Seqera Platform.
 
 ### Create a workspace
 
-In the example below, we create a shared workspace to be used for sharing pipelines with other private workspaces. See [Shared workspaces](https://docs.seqera.io/platform/latest/orgs-and-teams/shared-workspaces) for more information.
+In the example below, we create a shared workspace to be used for sharing pipelines with other private workspaces. See [Shared workspaces][shared-workspaces] for more information.
 
 ```console
 $ tw workspaces add --name=shared-workspace --full-name=shared-workspace-for-all  --org=my-tower-org --visibility=SHARED
@@ -303,7 +303,7 @@ $ tw participants list
 
 To add a new _collaborator_ to the workspace, use the `add` subcommand. The default role assigned to a _collaborator_ is `Launch`.
 
-See [Participant roles](https://docs.seqera.io/platform/latest/orgs-and-teams/workspace-management#participant-roles) for more information.
+See [Participant roles][participant-roles] for more information.
 
 ```console
 $ tw participants add --name=collaborator@mydomain.com --type=MEMBER                           
@@ -320,3 +320,13 @@ $ tw  participants update --name=collaborator@mydomain.com --type=COLLABORATOR -
 
   Participant 'collaborator@mydomain.com' has now role 'maintain' for workspace 'shared-workspace'
 ```
+
+[compute-envs]: https://docs.seqera.io/platform/latest/compute-envs/overview
+[credentials]: https://docs.seqera.io/platform/latest/credentials/overview
+[git-integration]: https://docs.seqera.io/platform/latest/git/overview
+[nextflow-config]: https://www.nextflow.io/docs/latest/config.html#config-syntax
+[participant-roles]: https://docs.seqera.io/platform/latest/orgs-and-teams/workspace-management#participant-roles
+[shared-workspaces]: https://docs.seqera.io/platform/latest/orgs-and-teams/shared-workspaces
+[tower-agent]: https://github.com/seqeralabs/tower-agent
+[user-workspaces]: https://docs.seqera.io/platform/latest/orgs-and-teams/workspace-management
+[wave-docs]: https://www.nextflow.io/docs/latest/wave.html

--- a/USAGE.md
+++ b/USAGE.md
@@ -239,7 +239,7 @@ $ tw launch https://github.com/nf-core/rnaseq --params-file=./custom_rnaseq_para
     https://tower.nf/user/abhinav/watch/2XDXxX0vCX8xhx
 ```
 
-- Pipeline parameters are defined within the `custom_rnaseq_params.yaml` file
+- Pipeline parameters are defined within the `custom_rnaseq_params.yaml` file.
 - Other parameters such as `--profile` and `--revision` can also be specified
 - A non-primary compute environment can be used to launch the pipeline. Omit `--compute-env` to launch with the workspace default compute environment.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -79,7 +79,7 @@ $ tw credentials delete --name=my_aws_creds
 
 ## Compute environments
 
-Compute environments in Seqera define the execution platform where a pipeline will run. A compute environment is composed of the credentials, configuration, and storage options related to a particular computing platform.  See [Seqera Platform compute environments](https://docs.seqera.io/platform/latest/compute-envs/overview) for more information on supported compute environments.
+Compute environments in Seqera define the execution platform where a pipeline runs. A compute environment is composed of the credentials, configuration, and storage options related to a particular computing platform.  See [Seqera Platform compute environments](https://docs.seqera.io/platform/latest/compute-envs/overview) for more information on supported compute environments.
 
 ### Add a compute environment
 


### PR DESCRIPTION
General updates to the CLI usage page, including:
- Updating Tower mentions
- --help command guidance for granular command info
- Improved examples
- Subsections for credentials
- Updates docs links