### PR TITLE
Match pipelines name exactly

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/AbstractPipelinesCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/AbstractPipelinesCmd.java
@@ -35,19 +35,25 @@ public abstract class AbstractPipelinesCmd extends AbstractApiCmd {
     public AbstractPipelinesCmd() {
     }
 
-    protected PipelineDbDto pipelineByName(Long workspaceId, String name) throws ApiException {
+    protected PipelineDbDto pipelineByName(Long workspaceId, String pipelineName, List<PipelineQueryAttribute> pipelineQueryAttributes) throws ApiException {
 
-        ListPipelinesResponse list = api().listPipelines(Collections.emptyList(), workspaceId, null, null, name, "all");
+        String exactName = quotePipelineName(pipelineName);
+
+        ListPipelinesResponse list = api().listPipelines(pipelineQueryAttributes, workspaceId, null, null, exactName, "all");
 
         if (list.getPipelines().isEmpty()) {
-            throw new PipelineNotFoundException(name, workspaceRef(workspaceId));
+            throw new PipelineNotFoundException(exactName, workspaceRef(workspaceId));
         }
 
         if (list.getPipelines().size() > 1) {
-            throw new MultiplePipelinesFoundException(name, workspaceRef(workspaceId));
+            throw new MultiplePipelinesFoundException(exactName, workspaceRef(workspaceId));
         }
 
         return list.getPipelines().get(0);
+    }
+
+    protected PipelineDbDto pipelineByName(Long workspaceId, String pipelineName) throws ApiException {
+        return pipelineByName(workspaceId, pipelineName, NO_PIPELINE_ATTRIBUTES);
     }
 
     protected PipelineDbDto fetchPipeline(PipelineRefOptions pipelineRefOptions, Long wspId, PipelineQueryAttribute... attributes) throws ApiException {
@@ -56,6 +62,21 @@ public abstract class AbstractPipelinesCmd extends AbstractApiCmd {
             pipelineId = pipelineByName(wspId, pipelineRefOptions.pipeline.pipelineName).getPipelineId();
         }
         return api().describePipeline(pipelineId, List.of(attributes), wspId, null).getPipeline();
+    }
+
+    private static String quotePipelineName(String pipelineName) {
+
+        if (pipelineName == null) return null;
+        if (pipelineName.isEmpty()) return "\"\"";
+
+        // replace '"' with '\"'
+        String escaped = pipelineName.replace("\"", "\\\"");
+
+        if (escaped.startsWith("\"") && escaped.endsWith("\"")) {
+            return escaped;
+        }
+
+        return "\"" + escaped + "\"";
     }
 
 }

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/AbstractPipelinesCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/AbstractPipelinesCmd.java
@@ -26,7 +26,6 @@ import io.seqera.tower.model.PipelineDbDto;
 import io.seqera.tower.model.PipelineQueryAttribute;
 import picocli.CommandLine.Command;
 
-import java.util.Collections;
 import java.util.List;
 
 @Command

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/AbstractPipelinesCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/AbstractPipelinesCmd.java
@@ -71,7 +71,7 @@ public abstract class AbstractPipelinesCmd extends AbstractApiCmd {
         // replace '"' with '\"'
         String escaped = pipelineName.replace("\"", "\\\"");
 
-        if (escaped.startsWith("\"") && escaped.endsWith("\"")) {
+        if (escaped.startsWith("\\\"") && escaped.endsWith("\\\"")) {
             return escaped;
         }
 

--- a/src/test/java/io/seqera/tower/cli/pipelines/PipelinesCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/pipelines/PipelinesCmdTest.java
@@ -76,7 +76,7 @@ class PipelinesCmdTest extends BaseCmdTest {
         mock.reset();
 
         mock.when(
-                request().withMethod("GET").withPath("/pipelines").withQueryStringParameter("search", "sleep_one_minute"), exactly(1)
+                request().withMethod("GET").withPath("/pipelines").withQueryStringParameter("search", "\"sleep_one_minute\""), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody("{\"pipelines\":[{\"pipelineId\":217997727159863,\"name\":\"sleep_one_minute\",\"description\":null,\"icon\":null,\"repository\":\"https://github.com/pditommaso/nf-sleep\",\"userId\":4,\"userName\":\"jordi\",\"userFirstName\":null,\"userLastName\":null,\"orgId\":null,\"orgName\":null,\"workspaceId\":null,\"workspaceName\":null,\"visibility\":null}],\"totalSize\":1}").withContentType(MediaType.APPLICATION_JSON)
         );
@@ -106,7 +106,7 @@ class PipelinesCmdTest extends BaseCmdTest {
         mock.reset();
 
         mock.when(
-                request().withMethod("GET").withPath("/pipelines").withQueryStringParameter("search", "sleep_one_minute"), exactly(1)
+                request().withMethod("GET").withPath("/pipelines").withQueryStringParameter("search", "\"sleep_one_minute\""), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody("{\"pipelines\":[{\"pipelineId\":217997727159863,\"name\":\"sleep_one_minute\",\"description\":null,\"icon\":null,\"repository\":\"https://github.com/pditommaso/nf-sleep\",\"userId\":4,\"userName\":\"jordi\",\"userFirstName\":null,\"userLastName\":null,\"orgId\":null,\"orgName\":null,\"workspaceId\":null,\"workspaceName\":null,\"visibility\":null}],\"totalSize\":1}").withContentType(MediaType.APPLICATION_JSON)
         );
@@ -148,7 +148,7 @@ class PipelinesCmdTest extends BaseCmdTest {
         mock.reset();
 
         mock.when(
-                request().withMethod("GET").withPath("/pipelines").withQueryStringParameter("search", "sleep_one_minute")
+                request().withMethod("GET").withPath("/pipelines").withQueryStringParameter("search", "\"sleep_one_minute\"")
         ).respond(
                 response().withStatusCode(200).withBody("{\"pipelines\":[{\"pipelineId\":217997727159863,\"name\":\"sleep_one_minute\",\"description\":null,\"icon\":null,\"repository\":\"https://github.com/pditommaso/nf-sleep\",\"userId\":4,\"userName\":\"jordi\",\"userFirstName\":null,\"userLastName\":null,\"orgId\":null,\"orgName\":null,\"workspaceId\":null,\"workspaceName\":null,\"visibility\":null}],\"totalSize\":1}").withContentType(MediaType.APPLICATION_JSON)
         );
@@ -187,7 +187,7 @@ class PipelinesCmdTest extends BaseCmdTest {
         mock.reset();
 
         mock.when(
-                request().withMethod("GET").withPath("/pipelines").withQueryStringParameter("search", "sleep_one_minute")
+                request().withMethod("GET").withPath("/pipelines").withQueryStringParameter("search", "\"sleep_one_minute\"")
         ).respond(
                 response().withStatusCode(200).withBody("{\"pipelines\":[{\"pipelineId\":217997727159863,\"name\":\"sleep_one_minute\",\"description\":null,\"icon\":null,\"repository\":\"https://github.com/pditommaso/nf-sleep\",\"userId\":4,\"userName\":\"jordi\",\"userFirstName\":null,\"userLastName\":null,\"orgId\":null,\"orgName\":null,\"workspaceId\":null,\"workspaceName\":null,\"visibility\":null}],\"totalSize\":1}").withContentType(MediaType.APPLICATION_JSON)
         );
@@ -339,7 +339,7 @@ class PipelinesCmdTest extends BaseCmdTest {
         mock.reset();
 
         mock.when(
-                request().withMethod("GET").withPath("/pipelines").withQueryStringParameter("search", "sleep"), exactly(1)
+                request().withMethod("GET").withPath("/pipelines").withQueryStringParameter("search", "\"sleep\""), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("pipelines_sleep")).withContentType(MediaType.APPLICATION_JSON)
         );
@@ -363,14 +363,14 @@ class PipelinesCmdTest extends BaseCmdTest {
         mock.reset();
 
         mock.when(
-                request().withMethod("GET").withPath("/pipelines").withQueryStringParameter("search", "sleep_all"), exactly(1)
+                request().withMethod("GET").withPath("/pipelines").withQueryStringParameter("search", "\"sleep_all\""), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody("{\"pipelines\":[],\"totalSize\":0}").withContentType(MediaType.APPLICATION_JSON)
         );
 
         ExecOut out = exec(mock, "pipelines", "delete", "-n", "sleep_all");
 
-        assertEquals(errorMessage(out.app, new PipelineNotFoundException("sleep_all", USER_WORKSPACE_NAME)), out.stdErr);
+        assertEquals(errorMessage(out.app, new PipelineNotFoundException("\"sleep_all\"", USER_WORKSPACE_NAME)), out.stdErr);
         assertEquals("", out.stdOut);
         assertEquals(1, out.exitCode);
     }
@@ -381,14 +381,14 @@ class PipelinesCmdTest extends BaseCmdTest {
         mock.reset();
 
         mock.when(
-                request().withMethod("GET").withPath("/pipelines").withQueryStringParameter("search", "hello"), exactly(1)
+                request().withMethod("GET").withPath("/pipelines").withQueryStringParameter("search", "\"hello\""), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("pipelines_multiple")).withContentType(MediaType.APPLICATION_JSON)
         );
 
         ExecOut out = exec(mock, "pipelines", "delete", "-n", "hello");
 
-        assertEquals(errorMessage(out.app, new MultiplePipelinesFoundException("hello", USER_WORKSPACE_NAME)), out.stdErr);
+        assertEquals(errorMessage(out.app, new MultiplePipelinesFoundException("\"hello\"", USER_WORKSPACE_NAME)), out.stdErr);
         assertEquals("", out.stdOut);
         assertEquals(1, out.exitCode);
     }
@@ -538,7 +538,7 @@ class PipelinesCmdTest extends BaseCmdTest {
         mock.reset();
 
         mock.when(
-                request().withMethod("GET").withPath("/pipelines").withQueryStringParameter("search", "sleep_one_minute").withQueryStringParameter("visibility", "all"), exactly(1)
+                request().withMethod("GET").withPath("/pipelines").withQueryStringParameter("search", "\"sleep_one_minute\"").withQueryStringParameter("visibility", "all"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody("{\"pipelines\":[{\"pipelineId\":213164477645856,\"name\":\"sleep_one_minute\",\"description\":null,\"icon\":null,\"repository\":\"https://github.com/pditommaso/nf-sleep\",\"userId\":1776,\"userName\":\"jordi10\",\"userFirstName\":null,\"userLastName\":null,\"orgId\":null,\"orgName\":null,\"workspaceId\":null,\"workspaceName\":null,\"visibility\":null,\"deleted\":false,\"lastUpdated\":\"2023-05-15T13:59:19Z\",\"optimized\":null,\"labels\":null,\"computeEnv\":null}],\"totalSize\":1}").withContentType(MediaType.APPLICATION_JSON)
         );
@@ -649,7 +649,7 @@ class PipelinesCmdTest extends BaseCmdTest {
         mock.reset();
 
         mock.when(
-                request().withMethod("GET").withPath("/pipelines").withQueryStringParameter("search", "sleep"), exactly(1)
+                request().withMethod("GET").withPath("/pipelines").withQueryStringParameter("search", "\"sleep\""), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("pipelines_sleep")).withContentType(MediaType.APPLICATION_JSON)
         );
@@ -866,7 +866,7 @@ class PipelinesCmdTest extends BaseCmdTest {
                 request().withMethod("GET")
                         .withPath("/pipelines")
                         .withQueryStringParameter("workspaceId", "69509535922157")
-                        .withQueryStringParameter("search", "cli_pipeline")
+                        .withQueryStringParameter("search", "\"cli_pipeline\"")
                         .withQueryStringParameter("visibility", "all"),
                 exactly(1)
         ).respond(
@@ -986,7 +986,7 @@ class PipelinesCmdTest extends BaseCmdTest {
                 request().withMethod("GET")
                         .withPath("/pipelines")
                         .withQueryStringParameter("workspaceId", "69509535922157")
-                        .withQueryStringParameter("search", "cli_pipeline")
+                        .withQueryStringParameter("search", "\"cli_pipeline\"")
                         .withQueryStringParameter("visibility", "all"),
                 exactly(1)
         ).respond(
@@ -1077,7 +1077,7 @@ class PipelinesCmdTest extends BaseCmdTest {
         mock.when(
                 request().withMethod("GET")
                         .withPath("/pipelines")
-                        .withQueryStringParameter("search", "lab1")
+                        .withQueryStringParameter("search", "\"lab1\"")
                         .withQueryStringParameter("visibility", "all"),
                 exactly(1)
         ).respond(

--- a/src/test/java/io/seqera/tower/cli/pipelines/PipelinesCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/pipelines/PipelinesCmdTest.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.seqera.tower.JSON;
 import io.seqera.tower.cli.BaseCmdTest;
 import io.seqera.tower.cli.commands.enums.OutputType;
-import io.seqera.tower.cli.commands.labels.LabelsSubcmdOptions;
 import io.seqera.tower.cli.exceptions.InvalidResponseException;
 import io.seqera.tower.cli.exceptions.MultiplePipelinesFoundException;
 import io.seqera.tower.cli.exceptions.NoComputeEnvironmentException;
@@ -872,15 +871,31 @@ class PipelinesCmdTest extends BaseCmdTest {
         ).respond(
                 response().withStatusCode(200)
                         .withContentType(MediaType.APPLICATION_JSON)
-                        .withBody(
-                                "{\n" +
-                                "\"pipelines\":[{\"pipelineId\":227906339448730,\"name\":\"cli_pipeline\",\"description\":null,\"icon\":null,\"repository\":\"https://github.com/nextflow-io/hello\",\"userId\":1,\"userName\":\"eliantor\",\n" +
-                                "\"userFirstName\":null,\"userLastName\":null,\"orgId\":109383401867759,\"orgName\":\"CliOrg\",\n" +
-                                "\"workspaceId\":69509535922157,\"workspaceName\":\"cli-wsp\",\"visibility\":\"PRIVATE\",\n" +
-                                "\"deleted\":false,\"lastUpdated\":\"2023-04-12T14:30:44.541301+02:00\",\"optimized\":null,\"labels\":null,\"computeEnv\":null}],\n" +
-                                "\"totalSize\":1" +
-                                "}"
-                        )
+                        .withBody("""
+                          {
+                            "pipelines":[{
+                                "pipelineId":227906339448730,
+                                "name":"cli_pipeline",
+                                "description":null,
+                                "icon":null,
+                                "repository":"https://github.com/nextflow-io/hello",
+                                "userId":1,
+                                "userName":"eliantor",
+                                "userFirstName":null,
+                                "userLastName":null,
+                                "orgId":109383401867759,
+                                "orgName":"CliOrg",
+                                "workspaceId":69509535922157,
+                                "workspaceName":"cli-wsp",
+                                "visibility":"PRIVATE",
+                                "deleted":false,
+                                "lastUpdated":"2023-04-12T14:30:44.541301+02:00",
+                                "optimized":null,
+                                "labels":null,
+                                "computeEnv":null
+                              }],
+                            "totalSize":1
+                          }""")
                 );
 
         mock.when(
@@ -890,7 +905,30 @@ class PipelinesCmdTest extends BaseCmdTest {
         ).respond(
                 response().withStatusCode(200)
                         .withContentType(MediaType.APPLICATION_JSON)
-                        .withBody("{\"pipeline\":{\"pipelineId\":227906339448730,\"name\":\"cli_pipeline\",\"description\":null,\"icon\":null,\"repository\":\"https://github.com/nf-core/rnaseq\",\"userId\":1776,\"userName\":\"jordi10\",\"userFirstName\":null,\"userLastName\":null,\"orgId\":null,\"orgName\":null,\"workspaceId\":null,\"workspaceName\":null,\"visibility\":null,\"deleted\":false,\"lastUpdated\":\"2023-05-15T11:53:49Z\",\"optimized\":null,\"labels\":null,\"computeEnv\":null}}")
+                        .withBody("""
+                          {
+                            "pipeline":{
+                              "pipelineId":227906339448730,
+                              "name":"cli_pipeline",
+                              "description":null,
+                              "icon":null,
+                              "repository":"https://github.com/nf-core/rnaseq",
+                              "userId":1776,
+                              "userName":"jordi10",
+                              "userFirstName":null,
+                              "userLastName":null,
+                              "orgId":null,
+                              "orgName":null,
+                              "workspaceId":null,
+                              "workspaceName":null,
+                              "visibility":null,
+                              "deleted":false,
+                              "lastUpdated":"2023-05-15T11:53:49Z",
+                              "optimized":null,
+                              "labels":null,
+                              "computeEnv":null
+                            }
+                        }""")
         );
 
         mock.when(
@@ -904,9 +942,20 @@ class PipelinesCmdTest extends BaseCmdTest {
         ).respond(
                 response().withStatusCode(200)
                         .withContentType(MediaType.APPLICATION_JSON)
-                        .withBody("" +
-                            "{\"labels\":[{\"id\":20504124310835,\"name\":\"test_label0\",\"value\":null,\"resource\":false,\"isDefault\":false}],\"totalSize\":1}" +
-                        "")
+                        .withBody("""
+                                {
+                                  "labels":[
+                                    {
+                                      "id":20504124310835,
+                                      "name":"test_label0",
+                                      "value":null,
+                                      "resource":false,
+                                      "isDefault":false
+                                    }
+                                  ],
+                                  "totalSize":1
+                                }
+                        """)
         );
         mock.when(
                 request().withMethod("GET").withPath("/labels")
@@ -919,9 +968,9 @@ class PipelinesCmdTest extends BaseCmdTest {
         ).respond(
                 response().withStatusCode(200)
                         .withContentType(MediaType.APPLICATION_JSON)
-                        .withBody("" +
-                            "{\"labels\":[],\"totalSize\":0}" +
-                        "")
+                        .withBody("""
+                                {"labels":[],"totalSize":0}
+                        """)
         );
         mock.when(
                 request().withMethod("POST")
@@ -992,14 +1041,31 @@ class PipelinesCmdTest extends BaseCmdTest {
         ).respond(
                 response().withStatusCode(200)
                         .withContentType(MediaType.APPLICATION_JSON)
-                        .withBody(
-                                "{\n" +
-                                "\"pipelines\":[{\"pipelineId\":227906339448730,\"name\":\"cli_pipeline\",\"description\":null,\"icon\":null,\"repository\":\"https://github.com/nextflow-io/hello\",\"userId\":1,\"userName\":\"eliantor\",\n" +
-                                "\"userFirstName\":null,\"userLastName\":null,\"orgId\":109383401867759,\"orgName\":\"CliOrg\",\n" +
-                                "\"workspaceId\":69509535922157,\"workspaceName\":\"cli-wsp\",\"visibility\":\"PRIVATE\",\n" +
-                                "\"deleted\":false,\"lastUpdated\":\"2023-04-12T14:30:44.541301+02:00\",\"optimized\":null,\"labels\":null,\"computeEnv\":null}],\n" +
-                                "\"totalSize\":1}"
-                        )
+                        .withBody("""
+                          {
+                            "pipelines":[{
+                              "pipelineId":227906339448730,
+                              "name":"cli_pipeline",
+                              "description":null,
+                              "icon":null,
+                              "repository":"https://github.com/nextflow-io/hello",
+                              "userId":1,
+                              "userName":"eliantor",
+                              "userFirstName":null,
+                              "userLastName":null,
+                              "orgId":109383401867759,
+                              "orgName":"CliOrg",
+                              "workspaceId":69509535922157,
+                              "workspaceName":"cli-wsp",
+                              "visibility":"PRIVATE",
+                              "deleted":false,
+                              "lastUpdated":"2023-04-12T14:30:44.541301+02:00",
+                              "optimized":null,
+                              "labels":null,
+                              "computeEnv":null
+                            }],
+                            "totalSize":1
+                        }""")
         );
 
         mock.when(
@@ -1009,7 +1075,30 @@ class PipelinesCmdTest extends BaseCmdTest {
         ).respond(
                 response().withStatusCode(200)
                         .withContentType(MediaType.APPLICATION_JSON)
-                        .withBody("{\"pipeline\":{\"pipelineId\":227906339448730,\"name\":\"cli_pipeline\",\"description\":null,\"icon\":null,\"repository\":\"https://github.com/nf-core/rnaseq\",\"userId\":1776,\"userName\":\"jordi10\",\"userFirstName\":null,\"userLastName\":null,\"orgId\":null,\"orgName\":null,\"workspaceId\":null,\"workspaceName\":null,\"visibility\":null,\"deleted\":false,\"lastUpdated\":\"2023-05-15T11:53:49Z\",\"optimized\":null,\"labels\":null,\"computeEnv\":null}}")
+                        .withBody("""
+                          {
+                            "pipeline":{
+                              "pipelineId":227906339448730,
+                              "name":"cli_pipeline",
+                              "description":null,
+                              "icon":null,
+                              "repository":"https://github.com/nf-core/rnaseq",
+                              "userId":1776,
+                              "userName":"jordi10",
+                              "userFirstName":null,
+                              "userLastName":null,
+                              "orgId":null,
+                              "orgName":null,
+                              "workspaceId":null,
+                              "workspaceName":null,
+                              "visibility":null,
+                              "deleted":false,
+                              "lastUpdated":"2023-05-15T11:53:49Z",
+                              "optimized":null,
+                              "labels":null,
+                              "computeEnv":null
+                            }
+                        }""")
         );
 
         mock.when(
@@ -1023,9 +1112,17 @@ class PipelinesCmdTest extends BaseCmdTest {
         ).respond(
                 response().withStatusCode(200)
                         .withContentType(MediaType.APPLICATION_JSON)
-                        .withBody("" +
-                            "{\"labels\":[{\"id\":20504124310835,\"name\":\"test_label0\",\"value\":null,\"resource\":false,\"isDefault\":false}],\"totalSize\":1}" +
-                        "")
+                        .withBody("""
+                          {
+                            "labels":[{
+                              "id":20504124310835,
+                              "name":"test_label0",
+                              "value":null,
+                              "resource":false,
+                              "isDefault":false
+                            }],
+                            "totalSize":1}
+                        """)
         );
         mock.when(
                 request().withMethod("GET").withPath("/labels")


### PR DESCRIPTION
## Description

Closes #360 

When searching a pipeline by name match the names exactly, not partially.

## Guidelines for testing

1.  Create a pipeline named `HelloWorld`
2. Create a second pipeline named `HelloWorldSecond`
3. When viewing pipelines by name the search matches the exact name and no "Multiple pipelines found" error is thrown.
```
$> ./tw pipelines view -n HelloWorld -w JaimeInc/Wsp

  Pipeline at [JaimeInc / Wsp] workspace:

    --------------+--------------------------------------
     ID           | 30153220095308                       
     Name         | HelloOptimization                    
     Description  |                                      
     Repository   | https://github.com/nextflow-io/hello 
     Compute env. | Org-batch-ce                         
     Labels       | owner=jaime                          

  Configuration:
....
```
4. When the name includes `"` characters they are escaped (and **the search should fail** because pipeline names can only contain aplhanumeric, dash and underscore)
```
$> ./tw pipelines view -n '"Hello"World"' -w JaimeInc/Wsp

 ERROR: Unknown pipeline '\"Hello\"Optimization\"' at [JaimeInc / Wsp] workspace

```