### PR TITLE
chore: changes default url to https://api.cloud.seqera.io

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -203,7 +203,7 @@ $ tw launch my_rnaseq_nf_pipeline
 
   Workflow 1XCXxX0vCX8xhx submitted at user workspace.
 
-    https://tower.nf/user/abhinav/watch/1XCXxX0vCX8xhx
+    https://cloud.seqera.io/user/abhinav/watch/1XCXxX0vCX8xhx
 ```
 
 When using `--wait`, `tw` can exit with one of two exit codes:
@@ -222,7 +222,7 @@ $ tw launch my_rnaseq_nf_pipeline --params-file=my_rnaseq_nf_pipeline_params_2.y
 
   Workflow 2XDXxX0vCX8xhx submitted at user workspace.
 
-    https://tower.nf/user/abhinav/watch/2XDXxX0vCX8xhx
+    https://cloud.seqera.io/user/abhinav/watch/2XDXxX0vCX8xhx
 ```
 
 See [Nextflow configuration][nextflow-config] for more information.
@@ -236,7 +236,7 @@ $ tw launch https://github.com/nf-core/rnaseq --params-file=./custom_rnaseq_para
 
   Workflow 2XDXxX0vCX8xhx submitted at user workspace.
 
-    https://tower.nf/user/abhinav/watch/2XDXxX0vCX8xhx
+    https://cloud.seqera.io/user/abhinav/watch/2XDXxX0vCX8xhx
 ```
 
 - Pipeline parameters are defined within the `custom_rnaseq_params.yaml` file.

--- a/src/main/java/io/seqera/tower/cli/Tower.java
+++ b/src/main/java/io/seqera/tower/cli/Tower.java
@@ -82,7 +82,7 @@ public class Tower extends AbstractCmd {
     @Option(names = {"-t", "--access-token"}, description = "Tower personal access token (TOWER_ACCESS_TOKEN).", defaultValue = "${TOWER_ACCESS_TOKEN}")
     public String token;
 
-    @Option(names = {"-u", "--url"}, description = "Tower server API endpoint URL (TOWER_API_ENDPOINT) [default: 'tower.nf'].", defaultValue = "${TOWER_API_ENDPOINT:-https://api.tower.nf}")
+    @Option(names = {"-u", "--url"}, description = "Tower server API endpoint URL (TOWER_API_ENDPOINT) [default: 'api.cloud.seqera.io'].", defaultValue = "${TOWER_API_ENDPOINT:-https://api.cloud.seqera.io}")
     public String url;
 
     @Option(names = {"-o", "--output"}, description = "Show output in defined format (only the 'json' option is available at the moment).", defaultValue = "${TOWER_CLI_OUTPUT_FORMAT:-console}")

--- a/src/test/resources/runcmd/info/service-info.json
+++ b/src/test/resources/runcmd/info/service-info.json
@@ -12,26 +12,26 @@
       "menus": [
         {
           "label": "Docs",
-          "url": "https://help.tower.nf"
+          "url": "https://docs.seqera.io/platform"
         },
         {
           "label": "Community",
-          "url": "https://cloud.tower.nf/community/"
+          "url": "https://community.seqera.io"
         },
         {
           "label": "Feedback",
-          "url": "https://github.com/seqeralabs/nf-tower/issues"
+          "url": "https://feedback.seqera.io"
         }
       ]
     },
     "heartbeatInterval": 3240,
     "userWorkspaceEnabled": true,
     "allowInstanceCredentials": false,
-    "landingUrl": "https://cloud.tower.nf",
-    "termsOfUseUrl": "https://cloud.tower.nf/legal",
-    "contentUrl": "https://user-data.tower.nf",
+    "landingUrl": "https://seqera.io",
+    "termsOfUseUrl": "https://seqera.io/legal/terms-of-use",
+    "contentUrl": "https://user-data.cloud.seqera.io",
     "analytics": {
-      "url": "https://analytics.tower.nf",
+      "url": "https://analytics.cloud.seqera.io",
       "siteId": 2
     },
     "allowLocalRepos": true,

--- a/src/test/resources/runcmd/runs/download.txt
+++ b/src/test/resources/runcmd/runs/download.txt
@@ -90,7 +90,7 @@ Uploading local `bin` scripts folder to s3://nextflow-ci/scratch/wzV8gF5Nh6QO8/t
 WARN: Process 'NFCORE_RNASEQ:RNASEQ:MULTIQC_TSV_FAIL_MAPPED' cannot be executed by 'awsbatch' executor -- Using 'local' executor instead
 WARN: Local executor only supports default file system -- Check work directory: s3://nextflow-ci/scratch/wzV8gF5Nh6QO8
 WARN: Process 'NFCORE_RNASEQ:RNASEQ:MULTIQC_TSV_STRAND_CHECK' cannot be executed by 'awsbatch' executor -- Using 'local' executor instead
-Monitor the execution with Nextflow Tower using this url https://tower.nf/orgs/seqeralabs/workspaces/verified-pipelines/watch/wzV8gF5Nh6QO8
+Monitor the execution with Nextflow Tower using this url https://cloud.seqera.io/orgs/seqeralabs/workspaces/verified-pipelines/watch/wzV8gF5Nh6QO8
 [9f/17b790] Submitted process > NFCORE_RNASEQ:RNASEQ:PREPARE_GENOME:UNTAR_SALMON_INDEX (salmon.tar.gz)
 [58/ed03ae] Submitted process > NFCORE_RNASEQ:RNASEQ:INPUT_CHECK:SAMPLESHEET_CHECK (samplesheet_test.csv)
 [a1/ff94c7] Submitted process > NFCORE_RNASEQ:RNASEQ:PREPARE_GENOME:GUNZIP_GTF (genes.gtf.gz)


### PR DESCRIPTION
This PR changes the default api endpoint from the legacy `api.tower.nf` to the new `api.cloud.seqera.io`

No regression on testing