### PR TITLE
fixes npe issue with --stats

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/runs/ViewCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/ViewCmd.java
@@ -33,6 +33,8 @@ import io.seqera.tower.model.ProgressData;
 import io.seqera.tower.model.Workflow;
 import io.seqera.tower.model.WorkflowLoad;
 import io.seqera.tower.model.WorkflowQueryAttribute;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 import java.util.ArrayList;
@@ -56,6 +58,7 @@ import static io.seqera.tower.cli.utils.FormatHelper.formatLabels;
 )
 public class ViewCmd extends AbstractRunsCmd {
 
+    private static final Logger log = LoggerFactory.getLogger(ViewCmd.class);
     @CommandLine.Option(names = {"-i", "--id"}, description = "Pipeline run identifier.", required = true)
     public String id;
 
@@ -144,7 +147,8 @@ public class ViewCmd extends AbstractRunsCmd {
 
             Map<String, Object> stats = new HashMap<>();
             if (opts.stats) {
-                stats.put("wallTime", TimeUnit.MILLISECONDS.toSeconds(workflow.getDuration()) / 60D);
+                if( workflow.getDuration() != null )
+                    stats.put("wallTime", TimeUnit.MILLISECONDS.toSeconds(workflow.getDuration()) / 60D);
                 if(progress.getWorkflowProgress() != null) {
                     stats.put("cpuTime", TimeUnit.MILLISECONDS.toMinutes(progress.getWorkflowProgress().getCpuTime()) / 60D);
                     stats.put("totalMemory", progress.getWorkflowProgress().getMemoryRss() / 1024 / 1024 / 1024D);


### PR DESCRIPTION
This PR will fix the issue of getting NPE when using --stats for failed or cancelled pipelines

error:
```
tw % ./tw runs view -i 35vHNSjgrDPftA -w "community/showcase" --stats           
java.lang.NullPointerException
        at io.seqera.tower.cli.commands.runs.ViewCmd.exec(ViewCmd.java:147)
        at io.seqera.tower.cli.commands.AbstractApiCmd.call(AbstractApiCmd.java:436)
        at io.seqera.tower.cli.commands.AbstractApiCmd.call(AbstractApiCmd.java:67)
        at picocli.CommandLine.executeUserObject(CommandLine.java:1953)
        at picocli.CommandLine.access$1300(CommandLine.java:145)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2358)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2352)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2314)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2179)
        at picocli.CommandLine$RunLast.execute(CommandLine.java:2316)
        at picocli.CommandLine.execute(CommandLine.java:2078)
        at io.seqera.tower.cli.Tower.main(Tower.java:101)
        at java.base@21.0.4/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)
```
