### PR TITLE
updated mac runner for intel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
 
   mac-image:
     name: MAC
-    runs-on: macos-12
+    runs-on: macos-latest-large
     timeout-minutes: 90
 
     steps:


### PR DESCRIPTION
mac-12 will be removed in November 2024, so updating it to latest
https://github.com/actions/runner-images/issues/10721