### PR TITLE
impr: small usability improvements

### DIFF
--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -1173,6 +1173,18 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"io.seqera.tower.cli.commands.datastudios.ParentDataStudioRefOptions",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"io.seqera.tower.cli.commands.datastudios.ParentDataStudioRefOptions$ParentDataStudioRef",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"io.seqera.tower.cli.commands.datastudios.StartAsNewCmd",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
@@ -1890,6 +1902,12 @@
   "queryAllDeclaredConstructors":true
 },
 {
+  "name":"io.seqera.tower.cli.responses.datastudios.DataStudioDeleted",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
   "name":"io.seqera.tower.cli.responses.datastudios.DataStudioStartSubmitted",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
@@ -1921,12 +1939,6 @@
 },
 {
   "name":"io.seqera.tower.cli.responses.datastudios.DataStudiosView",
-  "allDeclaredFields":true,
-  "queryAllDeclaredMethods":true,
-  "queryAllDeclaredConstructors":true
-},
-{
-  "name":"io.seqera.tower.cli.responses.datastudios.DataStudioDeleted",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true
@@ -3315,7 +3327,7 @@
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true,
-  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"getAllowInstanceCredentials","parameterTypes":[] }, {"name":"getAllowLocalRepos","parameterTypes":[] }, {"name":"getAnalytics","parameterTypes":[] }, {"name":"getApiVersion","parameterTypes":[] }, {"name":"getArm64Enabled","parameterTypes":[] }, {"name":"getAuthTypes","parameterTypes":[] }, {"name":"getCommitId","parameterTypes":[] }, {"name":"getContentMaxFileSize","parameterTypes":[] }, {"name":"getContentUrl","parameterTypes":[] }, {"name":"getDataExplorerAllowedWorkspaces","parameterTypes":[] }, {"name":"getEvalWorkspaceIds","parameterTypes":[] }, {"name":"getForgePrefix","parameterTypes":[] }, {"name":"getGroundswellAllowedWorkspaces","parameterTypes":[] }, {"name":"getGroundswellEnabled","parameterTypes":[] }, {"name":"getHeartbeatInterval","parameterTypes":[] }, {"name":"getLandingUrl","parameterTypes":[] }, {"name":"getLoginPath","parameterTypes":[] }, {"name":"getNavbar","parameterTypes":[] }, {"name":"getSeqeraCloud","parameterTypes":[] }, {"name":"getTermsOfUseUrl","parameterTypes":[] }, {"name":"getUserWorkspaceEnabled","parameterTypes":[] }, {"name":"getVersion","parameterTypes":[] }, {"name":"getWaveAllowedWorkspaces","parameterTypes":[] }, {"name":"getWaveEnabled","parameterTypes":[] }, {"name":"setAllowInstanceCredentials","parameterTypes":["java.lang.Boolean"] }, {"name":"setAllowLocalRepos","parameterTypes":["java.lang.Boolean"] }, {"name":"setAllowNextflowCliLogs","parameterTypes":["java.lang.Boolean"] }, {"name":"setAnalytics","parameterTypes":["io.seqera.tower.model.Analytics"] }, {"name":"setApiVersion","parameterTypes":["java.lang.String"] }, {"name":"setArm64Enabled","parameterTypes":["java.lang.Boolean"] }, {"name":"setAuthTypes","parameterTypes":["java.util.List"] }, {"name":"setCommitId","parameterTypes":["java.lang.String"] }, {"name":"setContactEmail","parameterTypes":["java.lang.String"] }, {"name":"setContentMaxFileSize","parameterTypes":["java.lang.Long"] }, {"name":"setContentUrl","parameterTypes":["java.lang.String"] }, {"name":"setDataExplorerAllowedWorkspaces","parameterTypes":["java.util.List"] }, {"name":"setEvalWorkspaceIds","parameterTypes":["java.util.List"] }, {"name":"setForgePrefix","parameterTypes":["java.lang.String"] }, {"name":"setGroundswellAllowedWorkspaces","parameterTypes":["java.util.List"] }, {"name":"setGroundswellEnabled","parameterTypes":["java.lang.Boolean"] }, {"name":"setHeartbeatInterval","parameterTypes":["java.lang.Integer"] }, {"name":"setLandingUrl","parameterTypes":["java.lang.String"] }, {"name":"setLoginPath","parameterTypes":["java.lang.String"] }, {"name":"setNavbar","parameterTypes":["io.seqera.tower.model.NavbarConfig"] }, {"name":"setSeqeraCloud","parameterTypes":["java.lang.Boolean"] }, {"name":"setTermsOfUseUrl","parameterTypes":["java.lang.String"] }, {"name":"setUserWorkspaceEnabled","parameterTypes":["java.lang.Boolean"] }, {"name":"setVersion","parameterTypes":["java.lang.String"] }, {"name":"setWaveAllowedWorkspaces","parameterTypes":["java.util.List"] }, {"name":"setWaveEnabled","parameterTypes":["java.lang.Boolean"] }]
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"getAllowInstanceCredentials","parameterTypes":[] }, {"name":"getAllowLocalRepos","parameterTypes":[] }, {"name":"getAnalytics","parameterTypes":[] }, {"name":"getApiVersion","parameterTypes":[] }, {"name":"getArm64Enabled","parameterTypes":[] }, {"name":"getAuthTypes","parameterTypes":[] }, {"name":"getCommitId","parameterTypes":[] }, {"name":"getContentMaxFileSize","parameterTypes":[] }, {"name":"getContentUrl","parameterTypes":[] }, {"name":"getDataExplorerAllowedWorkspaces","parameterTypes":[] }, {"name":"getEvalWorkspaceIds","parameterTypes":[] }, {"name":"getForgePrefix","parameterTypes":[] }, {"name":"getGroundswellAllowedWorkspaces","parameterTypes":[] }, {"name":"getGroundswellEnabled","parameterTypes":[] }, {"name":"getHeartbeatInterval","parameterTypes":[] }, {"name":"getLandingUrl","parameterTypes":[] }, {"name":"getLoginPath","parameterTypes":[] }, {"name":"getNavbar","parameterTypes":[] }, {"name":"getSeqeraCloud","parameterTypes":[] }, {"name":"getTermsOfUseUrl","parameterTypes":[] }, {"name":"getUserWorkspaceEnabled","parameterTypes":[] }, {"name":"getVersion","parameterTypes":[] }, {"name":"getWaveAllowedWorkspaces","parameterTypes":[] }, {"name":"getWaveEnabled","parameterTypes":[] }, {"name":"setAllowInstanceCredentials","parameterTypes":["java.lang.Boolean"] }, {"name":"setAllowLocalRepos","parameterTypes":["java.lang.Boolean"] }, {"name":"setAllowNextflowCliLogs","parameterTypes":["java.lang.Boolean"] }, {"name":"setAnalytics","parameterTypes":["io.seqera.tower.model.Analytics"] }, {"name":"setApiVersion","parameterTypes":["java.lang.String"] }, {"name":"setArm64Enabled","parameterTypes":["java.lang.Boolean"] }, {"name":"setAuthTypes","parameterTypes":["java.util.List"] }, {"name":"setCommitId","parameterTypes":["java.lang.String"] }, {"name":"setContactEmail","parameterTypes":["java.lang.String"] }, {"name":"setContentMaxFileSize","parameterTypes":["java.lang.Long"] }, {"name":"setContentUrl","parameterTypes":["java.lang.String"] }, {"name":"setDataExplorerAllowedWorkspaces","parameterTypes":["java.util.List"] }, {"name":"setEvalWorkspaceIds","parameterTypes":["java.util.List"] }, {"name":"setForgePrefix","parameterTypes":["java.lang.String"] }, {"name":"setGroundswellAllowedWorkspaces","parameterTypes":["java.util.List"] }, {"name":"setGroundswellEnabled","parameterTypes":["java.lang.Boolean"] }, {"name":"setHeartbeatInterval","parameterTypes":["java.lang.Integer"] }, {"name":"setLandingUrl","parameterTypes":["java.lang.String"] }, {"name":"setLoginPath","parameterTypes":["java.lang.String"] }, {"name":"setLogoutUrl_JsonNullable","parameterTypes":["org.openapitools.jackson.nullable.JsonNullable"] }, {"name":"setNavbar","parameterTypes":["io.seqera.tower.model.NavbarConfig"] }, {"name":"setSeqeraCloud","parameterTypes":["java.lang.Boolean"] }, {"name":"setTermsOfUseUrl","parameterTypes":["java.lang.String"] }, {"name":"setUserWorkspaceEnabled","parameterTypes":["java.lang.Boolean"] }, {"name":"setVersion","parameterTypes":["java.lang.String"] }, {"name":"setWaveAllowedWorkspaces","parameterTypes":["java.util.List"] }, {"name":"setWaveEnabled","parameterTypes":["java.lang.Boolean"] }]
 },
 {
   "name":"io.seqera.tower.model.ServiceInfoResponse",

--- a/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
@@ -243,6 +243,7 @@ public class LaunchCmd extends AbstractRootCmd {
                     WorkflowStatus.CANCELLED, WorkflowStatus.FAILED, WorkflowStatus.SUCCEEDED
             );
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             return exitCode;
         }
     }

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/add/AbstractAddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/add/AbstractAddCmd.java
@@ -89,6 +89,7 @@ public abstract class AbstractAddCmd extends AbstractApiCmd {
                     ComputeEnvStatus.AVAILABLE, ComputeEnvStatus.ERRORED, ComputeEnvStatus.INVALID
             );
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             return exitCode;
         }
     }

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/DataLinkService.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/DataLinkService.java
@@ -63,6 +63,7 @@ public class DataLinkService  {
                     DataLinksFetchStatus.DONE, DataLinksFetchStatus.ERROR
             );
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/io/seqera/tower/cli/commands/datastudios/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datastudios/AddCmd.java
@@ -19,6 +19,7 @@ package io.seqera.tower.cli.commands.datastudios;
 
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
+import io.seqera.tower.cli.exceptions.DataStudiosTemplateNotFoundException;
 import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.datastudios.DataStudiosCreated;
@@ -28,10 +29,13 @@ import io.seqera.tower.model.DataStudioCreateRequest;
 import io.seqera.tower.model.DataStudioCreateResponse;
 import io.seqera.tower.model.DataStudioDto;
 import io.seqera.tower.model.DataStudioStatus;
+import io.seqera.tower.model.DataStudioTemplate;
 import picocli.CommandLine;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @CommandLine.Command(
         name = "add",
@@ -71,6 +75,7 @@ public class AddCmd extends AbstractStudiosCmd{
         Long wspId = workspaceId(workspace.workspace);
 
         try {
+            checkIfTemplateIsAvailable(template, wspId);
             DataStudioCreateRequest request = prepareRequest();
             DataStudioCreateResponse response = api().createDataStudio(request, wspId, autoStart);
             DataStudioDto dataStudioDto = response.getStudio();
@@ -81,6 +86,16 @@ public class AddCmd extends AbstractStudiosCmd{
                 throw new TowerException(String.format("User not entitled to create studio at %s workspace", wspId));
             }
             throw e;
+        }
+    }
+
+    void checkIfTemplateIsAvailable(String template, Long workspaceId) throws ApiException {
+        List<DataStudioTemplate> availableTemplates = fetchDataStudioTemplates(workspaceId);
+        boolean validTemplate = availableTemplates.stream()
+                .anyMatch(t -> t.getRepository() != null && t.getRepository().equals(template));
+
+        if (!validTemplate) {
+            throw new DataStudiosTemplateNotFoundException(template, availableTemplates.stream().map(DataStudioTemplate::getRepository).collect(Collectors.toList()));
         }
     }
 

--- a/src/main/java/io/seqera/tower/cli/commands/datastudios/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datastudios/AddCmd.java
@@ -80,7 +80,7 @@ public class AddCmd extends AbstractStudiosCmd{
             DataStudioCreateResponse response = api().createDataStudio(request, wspId, autoStart);
             DataStudioDto dataStudioDto = response.getStudio();
             assert dataStudioDto != null;
-            return new DataStudiosCreated(dataStudioDto.getSessionId(), wspId, workspaceRef(wspId), autoStart);
+            return new DataStudiosCreated(dataStudioDto.getSessionId(), wspId, workspaceRef(wspId), baseWorkspaceUrl(wspId), autoStart);
         } catch (ApiException e) {
             if (e.getCode() == 403) {
                 throw new TowerException(String.format("User not entitled to create studio at %s workspace", wspId));

--- a/src/main/java/io/seqera/tower/cli/commands/datastudios/ParentDataStudioRefOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datastudios/ParentDataStudioRefOptions.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.commands.datastudios;
+
+import picocli.CommandLine;
+
+public class ParentDataStudioRefOptions {
+
+    @CommandLine.ArgGroup(multiplicity = "1")
+    public ParentDataStudioRefOptions.ParentDataStudioRef studio;
+
+    public static class ParentDataStudioRef {
+        @CommandLine.Option(names = {"-pid", "--parentId"}, description = "Parent DataStudio session ID.")
+        public String sessionId;
+
+        @CommandLine.Option(names = {"-pn", "--parentName"}, description = "Parent DataStudio name.")
+        public String name;
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/datastudios/StartAsNewCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datastudios/StartAsNewCmd.java
@@ -78,7 +78,7 @@ public class StartAsNewCmd extends AbstractStudiosCmd{
             DataStudioCreateResponse response = api().createDataStudio(request, wspId, autoStart);
             DataStudioDto dataStudioDto = response.getStudio();
             assert dataStudioDto != null;
-            return new DataStudiosCreated(dataStudioDto.getSessionId(), wspId, workspaceRef(wspId), autoStart);
+            return new DataStudiosCreated(dataStudioDto.getSessionId(), wspId, workspaceRef(wspId), baseWorkspaceUrl(wspId), autoStart);
         } catch (ApiException e) {
             if (e.getCode() == 403) {
                 throw new TowerException(String.format("User not entitled to create studio at %s workspace", wspId));

--- a/src/main/java/io/seqera/tower/cli/commands/datastudios/StartAsNewCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datastudios/StartAsNewCmd.java
@@ -40,8 +40,8 @@ import java.util.Objects;
 )
 public class StartAsNewCmd extends AbstractStudiosCmd{
 
-    @CommandLine.Option(names = {"-pid", "--parentId"}, description = "Parent DataStudio session ID.", required = true)
-    public String parentStudioSessionId;
+    @CommandLine.Mixin
+    public ParentDataStudioRefOptions parentDataStudioRefOptions;
 
     @CommandLine.Option(names = {"-n", "--name"}, description = "Data Studio name.", required = true)
     public String name;
@@ -66,6 +66,7 @@ public class StartAsNewCmd extends AbstractStudiosCmd{
         Long wspId = workspaceId(workspace.workspace);
 
         try {
+            String parentStudioSessionId = getParentDataStudioSessionId(parentDataStudioRefOptions, wspId);
             DataStudioDto parentDataStudio = api().describeDataStudio(parentStudioSessionId, wspId);
             if (parentDataStudio == null) {
                 throw new TowerException(String.format("Parent DataStudio %s not found at %s workspace", parentStudioSessionId, wspId));

--- a/src/main/java/io/seqera/tower/cli/commands/datastudios/TemplatesCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datastudios/TemplatesCmd.java
@@ -44,9 +44,7 @@ public class TemplatesCmd extends AbstractStudiosCmd {
         Long wspId = workspaceId(workspace.workspace);
 
         try {
-            DataStudioTemplatesListResponse response = api().listDataStudioTemplates(wspId,max,0);
-
-            return new DataStudiosTemplatesList(response.getTemplates());
+            return new DataStudiosTemplatesList(fetchDataStudioTemplates(wspId, max));
         } catch (ApiException e) {
             if (e.getCode() == 403) {
                 throw new TowerException("User not entitled to list studio templates");

--- a/src/main/java/io/seqera/tower/cli/exceptions/DataStudiosTemplateNotFoundException.java
+++ b/src/main/java/io/seqera/tower/cli/exceptions/DataStudiosTemplateNotFoundException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.exceptions;
+
+import java.util.List;
+
+public class DataStudiosTemplateNotFoundException extends TowerException {
+
+    public DataStudiosTemplateNotFoundException(String template, List<String> templatesAvailable) {
+        super(String.format("DataStudio template '%s' is not one of available templates '%s'", template, templatesAvailable));
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/responses/datastudios/DataStudiosCreated.java
+++ b/src/main/java/io/seqera/tower/cli/responses/datastudios/DataStudiosCreated.java
@@ -26,18 +26,21 @@ public class DataStudiosCreated extends Response {
     public final String workspaceRef;
     public final Long workspaceId;
     public final boolean autoStart;
+    public final String studioUrl;
 
-    public DataStudiosCreated(String sessionId, Long workspaceId, String workspaceRef, boolean autoStart) {
+
+    public DataStudiosCreated(String sessionId, Long workspaceId, String workspaceRef, String baseWorkspaceUrl, boolean autoStart) {
         this.sessionId = sessionId;
         this.workspaceRef = workspaceRef;
         this.workspaceId = workspaceId;
         this.autoStart = autoStart;
+        this.studioUrl = String.format("%s/studios/%s/connect", baseWorkspaceUrl, sessionId);
     }
 
     @Override
     public String toString() {
         if (autoStart){
-            return ansi(String.format("%n  @|yellow Data Studio %s CREATED at %s workspace and auto started.|@%n", sessionId, workspaceRef));
+            return ansi(String.format("%n  @|yellow Data Studio %s CREATED at %s workspace and auto started.|@%n%n    @|bold %s|@%n", sessionId, workspaceRef, studioUrl));
         } else {
             return ansi(String.format("%n  @|yellow Data Studio %s CREATED at %s workspace.|@%n", sessionId, workspaceRef));
         }

--- a/src/main/java/io/seqera/tower/cli/utils/TarFileHelper.java
+++ b/src/main/java/io/seqera/tower/cli/utils/TarFileHelper.java
@@ -173,6 +173,7 @@ public class TarFileHelper {
                     throw new TowerException("Timeout compressing logs");
                 }
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw new RuntimeException(e);
             }
 

--- a/src/test/java/io/seqera/tower/cli/datastudios/DataStudiosCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/datastudios/DataStudiosCmdTest.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -951,6 +950,14 @@ public class DataStudiosCmdTest extends BaseCmdTest {
         );
 
         mock.when(
+                request().withMethod("GET").withPath("/studios/templates")
+                        .withQueryStringParameter("workspaceId", "75887156211589")
+                        .withQueryStringParameter("max", "20"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("datastudios/datastudios_templates_response")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
                 request().withMethod("POST").withPath("/studios")
                         .withQueryStringParameter("workspaceId", "75887156211589")
                         .withQueryStringParameter("autostart", "false"), exactly(1)
@@ -960,7 +967,8 @@ public class DataStudiosCmdTest extends BaseCmdTest {
 
         ExecOut out = exec(format, mock, "studios", "add", "-n", "studio-a66d", "-w", "75887156211589", "-t" ,"cr.seqera.io/public/data-studio-vscode:1.93.1-snapshot", "-c", "7WgvfmcjAwp3Or75UphCJl");
 
-        assertOutput(format, out, new DataStudiosCreated("3e8370e7",75887156211589L, "[organization1 / workspace1]", false));
+        assertOutput(format, out, new DataStudiosCreated("3e8370e7",75887156211589L, "[organization1 / workspace1]",
+                "http://localhost:"+mock.getPort()+"/orgs/organization1/workspaces/workspace1", false));
     }
 
     @ParameterizedTest
@@ -1045,10 +1053,19 @@ public class DataStudiosCmdTest extends BaseCmdTest {
                 response().withStatusCode(200).withBody(loadResource("datastudios/datastudios_view_response")).withContentType(MediaType.APPLICATION_JSON)
         );
 
+        mock.when(
+                request().withMethod("GET").withPath("/studios/templates")
+                        .withQueryStringParameter("workspaceId", "75887156211589")
+                        .withQueryStringParameter("max", "20"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("datastudios/datastudios_templates_response")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
         ExecOut out = exec(format, mock, "studios", "add", "-n", "studio-a66d", "-w", "75887156211589", "-t" ,"cr.seqera.io/public/data-studio-vscode:1.93.1-snapshot",
                 "-c", "7WgvfmcjAwp3Or75UphCJl", "-a", "--wait", "running");
 
-        assertOutput(format, out, new DataStudiosCreated("3e8370e7",75887156211589L, "[organization1 / workspace1]", true));
+        assertOutput(format, out, new DataStudiosCreated("3e8370e7",75887156211589L, "[organization1 / workspace1]",
+                "http://localhost:"+mock.getPort()+"/orgs/organization1/workspaces/workspace1", true));
 
         // verify the API has been polled additionally for the status
         mock.verify(request().withMethod("GET").withPath("/studios/3e8370e7"), VerificationTimes.exactly(2));
@@ -1094,7 +1111,8 @@ public class DataStudiosCmdTest extends BaseCmdTest {
 
         ExecOut out = exec(format, mock, "studios", "start-as-new", "-pid", "3e8370e7", "-n", "child-studio-a66d", "-w", "75887156211589", "--cpu", "4");
 
-        assertOutput(format, out, new DataStudiosCreated("8aebf1b8",75887156211589L, "[organization1 / workspace1]", false));
+        assertOutput(format, out, new DataStudiosCreated("8aebf1b8",75887156211589L, "[organization1 / workspace1]",
+                "http://localhost:"+mock.getPort()+"/orgs/organization1/workspaces/workspace1", false));
 
 
         mock.when(
@@ -1196,7 +1214,8 @@ public class DataStudiosCmdTest extends BaseCmdTest {
 
         ExecOut out = exec(format, mock, "studios", "start-as-new", "-pn", "studio-a66d", "-n", "child-studio-a66d", "-w", "75887156211589", "--cpu", "4");
 
-        assertOutput(format, out, new DataStudiosCreated("8aebf1b8", 75887156211589L, "[organization1 / workspace1]", false));
+        assertOutput(format, out, new DataStudiosCreated("8aebf1b8", 75887156211589L, "[organization1 / workspace1]",
+                "http://localhost:"+mock.getPort()+"/orgs/organization1/workspaces/workspace1", false));
     }
 
     @ParameterizedTest

--- a/src/test/java/io/seqera/tower/cli/datastudios/DataStudiosCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/datastudios/DataStudiosCmdTest.java
@@ -20,6 +20,7 @@ package io.seqera.tower.cli.datastudios;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.seqera.tower.cli.BaseCmdTest;
 import io.seqera.tower.cli.commands.enums.OutputType;
+import io.seqera.tower.cli.exceptions.DataStudiosTemplateNotFoundException;
 import io.seqera.tower.cli.exceptions.MultipleDataLinksFoundException;
 import io.seqera.tower.cli.responses.datastudios.DataStudioDeleted;
 import io.seqera.tower.cli.responses.datastudios.DataStudioStartSubmitted;
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -961,6 +963,51 @@ public class DataStudiosCmdTest extends BaseCmdTest {
         assertOutput(format, out, new DataStudiosCreated("3e8370e7",75887156211589L, "[organization1 / workspace1]", false));
     }
 
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testAddThrowsDataStudiosTemplateNotFoundException(OutputType format, MockServerClient mock){
+
+        mock.when(
+                request().withMethod("GET").withPath("/user-info"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/user/1264/workspaces"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workspaces/workspaces_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/studios")
+                        .withQueryStringParameter("workspaceId", "75887156211589")
+                        .withQueryStringParameter("autostart", "false"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("datastudios/datastudios_created_response")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/studios/templates")
+                        .withQueryStringParameter("workspaceId", "75887156211589")
+                        .withQueryStringParameter("max", "20"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("datastudios/datastudios_templates_response")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(format, mock, "studios", "add", "-n", "studio-a66d", "-w", "75887156211589", "-t" ,"invalid-template-vs-code", "-c", "7WgvfmcjAwp3Or75UphCJl");
+
+        List<String> availableTemplate = List.of(
+                "cr.seqera.io/public/data-studio-jupyter:4.2.5-snapshot",
+                "cr.seqera.io/public/data-studio-rstudio:4.4.1-u1-snapshot",
+                "cr.seqera.io/public/data-studio-vscode:1.93.1-snapshot",
+                "cr.seqera.io/public/data-studio-xpra:6.2.0-r2-1-snapshot");
+
+        assertEquals(errorMessage(out.app, new DataStudiosTemplateNotFoundException("invalid-template-vs-code", availableTemplate)), out.stdErr);
+        assertEquals("", out.stdOut);
+        assertEquals(1, out.exitCode);
+    }
+
     // Only run this test in json output format, since extra stdout output is printed out to console with --wait flag
     @ParameterizedTest
     @EnumSource(value = OutputType.class, names = {"json"})
@@ -1101,6 +1148,55 @@ public class DataStudiosCmdTest extends BaseCmdTest {
                   "progress": []
                 }
                 """, DataStudioDto.class), "[organization1 / workspace1]"));
+    }
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testStartAsNewUsingParentName(OutputType format, MockServerClient mock) throws JsonProcessingException {
+
+        mock.when(
+                request().withMethod("GET").withPath("/user-info"), exactly(2)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/user/1264/workspaces"), exactly(2)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workspaces/workspaces_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/studios").withQueryStringParameter("workspaceId", "75887156211589"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("datastudios/datastudios_list_response")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/studios/3e8370e7").withQueryStringParameter("workspaceId", "75887156211589"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("datastudios/datastudios_view_response_studio_stopped")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/studios/3e8370e7/checkpoints")
+                        .withQueryStringParameter("workspaceId", "75887156211589")
+                        .withQueryStringParameter("max", "1"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"checkpoints\":[],\"totalSize\":0}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("POST").withPath("/studios")
+                        .withQueryStringParameter("workspaceId", "75887156211589")
+                        .withQueryStringParameter("autostart", "false"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("datastudios/datastudios_start_as_new_response")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(format, mock, "studios", "start-as-new", "-pn", "studio-a66d", "-n", "child-studio-a66d", "-w", "75887156211589", "--cpu", "4");
+
+        assertOutput(format, out, new DataStudiosCreated("8aebf1b8", 75887156211589L, "[organization1 / workspace1]", false));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Small improvements and follow-ups to the cli:

**1. when creating a new DataStudio validate the template that is provided:**
```
➜ ./gradlew run -q --args="--insecure studios add -n my-studi4 -w 22117901918827 -t wrong-template-vscode -c 2rZkbXfTkiJxTVz18OJs3i"

 ERROR: DataStudio template 'wrong-template-vscode' is not one of available templates 
 '[cr.seqera.io/public/data-studio-jupyter:4.2.5-snapshot, cr.seqera.io/public/data-studio-rstudio:4.4.1-u1-snapshot, cr.seqera.io/public/data-studio-vscode:1.93.1-snapshot, cr.seqera.io/public/data-studio-xpra:6.2.0-r2-1-snapshot]'
```

**2. when starting as new, allow for parent data studio name to be specified, not just ID:**
```
➜ ./gradlew run -q --args="--insecure studios start-as-new -pn studio-that-was-never-started -n my-child-studio -w 22117901918827"

  Data Studio 57a05dda CREATED at [aaa / bbb] workspace.
```

**3. when a studio is created with autostart, show the studio in the:**
```
➜ ./gradlew run -q --args="--insecure studios add -n my-studi4 -w 22117901918827 -t cr.seqera.io/public/data-studio-jupyter:4.2.5-snapshot -c 2rZkbXfTkiJxTVz18OJs3i -a"

  Data Studio 720ad0ca CREATED at [aaa / bbb] workspace and auto started.

    http://localhost:8000//orgs/aaa/workspaces/bbb/studios/720ad0ca/connect

➜ ./gradlew run -q --args="--insecure studios start-as-new -pn studio-that-was-never-started -n my-child-studio-2 -w 22117901918827 -a"                               

  Data Studio 39b8c805 CREATED at [aaa / bbb] workspace and auto started.

    http://localhost:8000//orgs/aaa/workspaces/bbb/studios/39b8c805/connect
```