### PR TITLE
feat: studios custom template option and extra validation

### DIFF
--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -1161,6 +1161,18 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"io.seqera.tower.cli.commands.datastudios.DataStudioTemplateOptions",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"io.seqera.tower.cli.commands.datastudios.DataStudioTemplateOptions$DataStudioTemplate",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"io.seqera.tower.cli.commands.datastudios.DeleteCmd",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,

--- a/src/main/java/io/seqera/tower/cli/commands/datastudios/DataStudioTemplateOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datastudios/DataStudioTemplateOptions.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.commands.datastudios;
+
+import picocli.CommandLine;
+
+public class DataStudioTemplateOptions {
+
+    @CommandLine.ArgGroup(multiplicity = "1")
+    public DataStudioTemplate template;
+
+    public static class DataStudioTemplate {
+        @CommandLine.Option(names = {"-t", "--template"}, description = "Container image template to be used for Data Studio. Available templates can be listed with 'studios templates' command")
+        public String standardTemplate;
+
+        @CommandLine.Option(names = {"-ct", "--custom-template"}, description = "Custom container image template to be used for Data Studio")
+        public String customTemplate;
+    }
+
+    public String getTemplate() {
+        return template.standardTemplate != null ? template.standardTemplate : template.customTemplate;
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/exceptions/DataStudiosCustomTemplateWithCondaException.java
+++ b/src/main/java/io/seqera/tower/cli/exceptions/DataStudiosCustomTemplateWithCondaException.java
@@ -17,11 +17,9 @@
 
 package io.seqera.tower.cli.exceptions;
 
-import java.util.List;
+public class DataStudiosCustomTemplateWithCondaException extends TowerException {
 
-public class DataStudiosTemplateNotFoundException extends TowerException {
-
-    public DataStudiosTemplateNotFoundException(String template, List<String> templatesAvailable) {
-        super(String.format("DataStudio template provided '%s', is not one of the Platform's available templates '%s'.", template, templatesAvailable));
+    public DataStudiosCustomTemplateWithCondaException() {
+        super(String.format("DataStudio template provided is a custom template and cannot be used together with conda environment option."));
     }
 }


### PR DESCRIPTION
Fixes that came out of the validation task: https://seqera.atlassian.net/browse/PLAT-1338

- **add** - template vs --custom-template, (white space removal)
- **start-as-new** double check yaml file works with available templates, and does not work with custom templates (mutually exclusive --custom-template and conda env)

```
➜ ./gradlew run -q --args="--insecure studios add -n medve -w 22117901918827 -c 2rZkbXfTkiJxTVz18OJs3i -ct alma --conda-env-yml /Users/eend/a.yml"

 ERROR: DataStudio template provided is a custom template and cannot be used together with conda environment option.

```

```
➜  ./gradlew run -q --args="--insecure studios add -n medve -w 22117901918827 -c 2rZkbXfTkiJxTVz18OJs3i -t alma -ct korte"
Error: --template=<standardTemplate>, --custom-template=<customTemplate> are mutually exclusive (specify only one)

```