### PR TITLE
PLAT-1418 - Add command to retrieve data studio checkpoints

### DIFF
--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -1131,6 +1131,12 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"io.seqera.tower.cli.commands.datastudios.CheckpointsCmd",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"io.seqera.tower.cli.commands.datastudios.DataLinkRefOptions",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
@@ -1932,6 +1938,12 @@
   "queryAllDeclaredConstructors":true
 },
 {
+  "name":"io.seqera.tower.cli.responses.datastudios.DataStudioCheckpointsList",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
   "name":"io.seqera.tower.cli.responses.datastudios.DataStudiosTemplatesList",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
@@ -2716,7 +2728,7 @@
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true,
-  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setAuthor","parameterTypes":["io.seqera.tower.model.StudioUser"] }, {"name":"setDateCreated","parameterTypes":["java.time.OffsetDateTime"] }, {"name":"setDateSaved","parameterTypes":["java.time.OffsetDateTime"] }, {"name":"setId","parameterTypes":["java.lang.Long"] }, {"name":"setName","parameterTypes":["java.lang.String"] }]
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setAuthor","parameterTypes":["io.seqera.tower.model.StudioUser"] }, {"name":"setDateCreated","parameterTypes":["java.time.OffsetDateTime"] }, {"name":"setDateSaved","parameterTypes":["java.time.OffsetDateTime"] }, {"name":"setId","parameterTypes":["java.lang.Long"] }, {"name":"setName","parameterTypes":["java.lang.String"] }, {"name":"getAuthor","parameterTypes":[] }, {"name":"getDateCreated","parameterTypes":[] }, {"name":"getDateSaved","parameterTypes":[] }, {"name":"getId","parameterTypes":[] }, {"name":"getName","parameterTypes":[] }]
 },
 {
   "name":"io.seqera.tower.model.DataStudioComputeEnvDto",

--- a/src/main/java/io/seqera/tower/cli/commands/DataStudiosCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/DataStudiosCmd.java
@@ -18,6 +18,7 @@
 package io.seqera.tower.cli.commands;
 
 import io.seqera.tower.cli.commands.datastudios.AddCmd;
+import io.seqera.tower.cli.commands.datastudios.CheckpointsCmd;
 import io.seqera.tower.cli.commands.datastudios.DeleteCmd;
 import io.seqera.tower.cli.commands.datastudios.ListCmd;
 import io.seqera.tower.cli.commands.datastudios.StartAsNewCmd;
@@ -36,6 +37,7 @@ import picocli.CommandLine;
                 StartCmd.class,
                 AddCmd.class,
                 TemplatesCmd.class,
+                CheckpointsCmd.class,
                 StartAsNewCmd.class,
                 StopCmd.class,
                 DeleteCmd.class,

--- a/src/main/java/io/seqera/tower/cli/commands/datastudios/CheckpointsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datastudios/CheckpointsCmd.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.commands.datastudios;
+
+import io.seqera.tower.ApiException;
+import io.seqera.tower.cli.commands.global.PaginationOptions;
+import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
+import io.seqera.tower.cli.exceptions.TowerException;
+import io.seqera.tower.cli.exceptions.WorkspaceNotFoundException;
+import io.seqera.tower.cli.responses.Response;
+import io.seqera.tower.cli.responses.datastudios.DataStudioCheckpointsList;
+import io.seqera.tower.cli.responses.datastudios.DataStudiosList;
+import io.seqera.tower.cli.utils.PaginationInfo;
+import io.seqera.tower.model.DataStudioListCheckpointsResponse;
+import io.seqera.tower.model.DataStudioListResponse;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+import java.io.IOException;
+
+@Command(
+        name = "checkpoints",
+        description = "List checkpoints for a data studios."
+)
+public class CheckpointsCmd extends AbstractStudiosCmd {
+
+    private static final Integer DATA_STUDIO_LIST_MAX_ALLOWED_CHECKPOINTS = 50;
+
+    @CommandLine.Mixin
+    public WorkspaceOptionalOptions workspace;
+
+    @CommandLine.Mixin
+    public DataStudioRefOptions dataStudioRefOptions;
+
+    @CommandLine.Option(names = {"-f", "--filter"}, description = "Optional filter criteria, allowing free text search on name " +
+            "and keywords: `after: YYYY-MM-DD`, `before: YYYY-MM-DD` and `author`. Example keyword usage: -f author:my-name")
+    public String filter;
+
+    @CommandLine.Mixin
+    PaginationOptions paginationOptions;
+
+    @Override
+    protected Response exec() throws ApiException, IOException {
+        Long wspId = workspaceId(workspace.workspace);
+        Integer max = PaginationOptions.getMax(paginationOptions) > DATA_STUDIO_LIST_MAX_ALLOWED_CHECKPOINTS
+                ? DATA_STUDIO_LIST_MAX_ALLOWED_CHECKPOINTS
+                : PaginationOptions.getMax(paginationOptions);
+        Integer offset = PaginationOptions.getOffset(paginationOptions, max);
+
+        String sessionId = getSessionId(dataStudioRefOptions, wspId);
+
+        DataStudioListCheckpointsResponse response;
+
+        try {
+           response = api().listDataStudioCheckpoints(sessionId, wspId, filter, max, offset);
+        } catch (ApiException e) {
+            if (e.getCode() == 404){
+                throw new WorkspaceNotFoundException(wspId);
+            }
+            if (e.getCode() == 403) {
+                throw new TowerException(String.format("User not entitled to %s workspace", wspId));
+            }
+            throw e;
+        }
+
+        return new DataStudioCheckpointsList(dataStudioRefOptions.getDataStudioIdentifier() ,workspaceRef(wspId), response.getCheckpoints(), PaginationInfo.from(paginationOptions, response.getTotalSize()));
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/responses/datastudios/DataStudioCheckpointsList.java
+++ b/src/main/java/io/seqera/tower/cli/responses/datastudios/DataStudioCheckpointsList.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.responses.datastudios;
+
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.seqera.tower.cli.responses.Response;
+import io.seqera.tower.cli.utils.PaginationInfo;
+import io.seqera.tower.cli.utils.TableList;
+import io.seqera.tower.model.DataStudioCheckpointDto;
+import io.seqera.tower.model.StudioUser;
+
+import static io.seqera.tower.cli.utils.FormatHelper.formatTime;
+
+public class DataStudioCheckpointsList extends Response {
+
+    public final String userSuppliedStudioIdentifier;
+    public final String workspaceRef;
+    public final List<DataStudioCheckpointDto> checkpoints;
+
+    @JsonIgnore
+    @Nullable
+    private final PaginationInfo paginationInfo;
+
+    public DataStudioCheckpointsList(String userSuppliedStudioIdentifier, String workspaceRef, List<DataStudioCheckpointDto> checkpoints, @Nullable PaginationInfo paginationInfo) {
+        this.userSuppliedStudioIdentifier = userSuppliedStudioIdentifier;
+        this.workspaceRef = workspaceRef;
+        this.checkpoints = checkpoints;
+        this.paginationInfo = paginationInfo;
+    }
+
+    @Override
+    public void toString(PrintWriter out) {
+
+        out.println(ansi(String.format("%n  @|bold Checkpoints at data studio %s at %s workspace:|@%n", userSuppliedStudioIdentifier, workspaceRef)));
+
+        if (checkpoints.isEmpty()) {
+            out.println(ansi("    @|yellow No checkpoints found|@"));
+            return;
+        }
+
+        List<String> descriptions = new ArrayList<>(List.of("ID", "Name", "Author", "Date Created", "Date Saved"));
+
+        TableList table = new TableList(out, descriptions.size(), descriptions.toArray(new String[descriptions.size()])).sortBy(0);
+        table.setPrefix("    ");
+
+        checkpoints.forEach(checkpoint -> {
+            StudioUser user = checkpoint.getAuthor();
+
+            List<String> rows = new ArrayList<>(List.of(
+                    checkpoint.getId() == null ? "" : checkpoint.getId().toString(),
+                    checkpoint.getName() == null ? "" : checkpoint.getName(),
+                    user == null ? "" : user.getUserName(),
+                    formatTime(checkpoint.getDateCreated()),
+                    formatTime(checkpoint.getDateSaved())
+            ));
+            table.addRow(rows.toArray(new String[rows.size()]));
+        });
+
+        table.print();
+
+        PaginationInfo.addFooter(out, paginationInfo);
+
+        out.println("");
+    }
+
+}

--- a/src/main/java/io/seqera/tower/cli/responses/datastudios/DataStudiosView.java
+++ b/src/main/java/io/seqera/tower/cli/responses/datastudios/DataStudiosView.java
@@ -52,13 +52,13 @@ public class DataStudiosView extends Response {
         table.addRow("SessionID", dataStudio.getSessionId());
         table.addRow("Name", dataStudio.getName());
         table.addRow("Status", formatDataStudioStatus(statusInfo == null ? null : statusInfo.getStatus()));
-        table.addRow("Status Last Update", statusInfo == null ? "NA" : formatTime(statusInfo.getLastUpdate()));
+        table.addRow("Status last update", statusInfo == null ? "NA" : formatTime(statusInfo.getLastUpdate()));
         table.addRow("Studio URL", dataStudio.getStudioUrl());
         table.addRow("Description", dataStudio.getDescription());
         table.addRow("Created on", formatTime(dataStudio.getDateCreated()));
         table.addRow("Created by", studioUser == null ? "NA" : String.format("%s | %s",studioUser.getUserName(), studioUser.getEmail()));
         table.addRow("Template", dataStudio.getTemplate() == null ? "NA" : dataStudio.getTemplate().getRepository());
-        table.addRow("Mounted Data", dataStudio.getMountedDataLinks() == null ? "NA" : dataStudio.getMountedDataLinks()
+        table.addRow("Mounted data", dataStudio.getMountedDataLinks() == null ? "NA" : dataStudio.getMountedDataLinks()
                 .stream().map(DataLinkDto::getResourceRef).collect(java.util.stream.Collectors.joining(", ")));
         table.addRow("Compute environment", dataStudio.getComputeEnv() == null ? "NA" : dataStudio.getComputeEnv().getName());
         table.addRow("Region", dataStudio.getComputeEnv() == null ? "NA" : dataStudio.getComputeEnv().getRegion());

--- a/src/test/java/io/seqera/tower/cli/datastudios/DataStudiosCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/datastudios/DataStudiosCmdTest.java
@@ -22,6 +22,7 @@ import io.seqera.tower.cli.BaseCmdTest;
 import io.seqera.tower.cli.commands.enums.OutputType;
 import io.seqera.tower.cli.exceptions.DataStudiosTemplateNotFoundException;
 import io.seqera.tower.cli.exceptions.MultipleDataLinksFoundException;
+import io.seqera.tower.cli.responses.datastudios.DataStudioCheckpointsList;
 import io.seqera.tower.cli.responses.datastudios.DataStudioDeleted;
 import io.seqera.tower.cli.responses.datastudios.DataStudioStartSubmitted;
 import io.seqera.tower.cli.responses.datastudios.DataStudiosCreated;
@@ -30,6 +31,7 @@ import io.seqera.tower.cli.responses.datastudios.DataStudiosList;
 import io.seqera.tower.cli.responses.datastudios.DataStudiosTemplatesList;
 import io.seqera.tower.cli.responses.datastudios.DataStudiosView;
 import io.seqera.tower.cli.utils.PaginationInfo;
+import io.seqera.tower.model.DataStudioCheckpointDto;
 import io.seqera.tower.model.DataStudioDto;
 import io.seqera.tower.model.DataStudioTemplatesListResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -1326,6 +1328,57 @@ public class DataStudiosCmdTest extends BaseCmdTest {
         ExecOut out = exec(format, mock, "studios", "delete", "-w", "75887156211589", "-i" ,"3e8370e7");
 
         assertOutput(format, out, new DataStudioDeleted("3e8370e7", "[organization1 / workspace1]"));
+    }
+
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testCheckpoints(OutputType format, MockServerClient mock) throws JsonProcessingException {
+        mock.when(
+                request().withMethod("GET").withPath("/user-info"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/user/1264/workspaces"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workspaces/workspaces_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/studios/3e8370e7/checkpoints").withQueryStringParameter("workspaceId", "75887156211589"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("datastudios/datastudios_checkpoints_list_response")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(format, mock, "studios", "checkpoints", "-w", "75887156211589", "-i", "3e8370e7");
+
+        assertOutput(format, out, new DataStudioCheckpointsList("3e8370e7", "[organization1 / workspace1]", Arrays.asList(parseJson("""
+                            {
+                               "id": 2,
+                               "name": "studio-a66d_2",
+                               "dateSaved": "2025-01-30T09:34:33Z",
+                               "dateCreated": "2025-01-30T09:29:31Z",
+                               "author": {
+                                 "id": 100,
+                                 "userName": "johnny-bravo"
+                               }
+                            }
+                            """, DataStudioCheckpointDto.class),
+                parseJson("""
+                            {
+                              "id": 1,
+                              "name": "studio-a66d_1",
+                              "dateSaved": "2025-01-28T14:05:07Z",
+                              "dateCreated": "2025-01-28T12:49:06Z",
+                              "author": {
+                                "id": 100,
+                                "userName": "johnny-bravo"
+                              }
+                            }
+                            """, DataStudioCheckpointDto.class)
+        ), null));
     }
 
 }

--- a/src/test/resources/runcmd/datastudios/datastudios_checkpoints_list_response.json
+++ b/src/test/resources/runcmd/datastudios/datastudios_checkpoints_list_response.json
@@ -1,0 +1,25 @@
+{
+  "checkpoints": [
+    {
+      "id": 2,
+      "name": "studio-a66d_2",
+      "dateSaved": "2025-01-30T09:34:33Z",
+      "dateCreated": "2025-01-30T09:29:31Z",
+      "author": {
+        "id": 100,
+        "userName": "johnny-bravo"
+      }
+    },
+    {
+      "id": 1,
+      "name": "studio-a66d_1",
+      "dateSaved": "2025-01-28T14:05:07Z",
+      "dateCreated": "2025-01-28T12:49:06Z",
+      "author": {
+        "id": 100,
+        "userName": "johnny-bravo"
+      }
+    }
+  ],
+  "totalSize": 2
+}


### PR DESCRIPTION
Relates to: https://seqera.atlassian.net/browse/PLAT-1418

```
$ ./tw studios checkpoints -w data-studios/data-studios -n studio-ef6b

  Checkpoints at data studio studio-ef6b at [data-studios / data-studios] workspace:

     ID  | Name                   | Author         | Date Created                  | Date Saved
    -----+------------------------+----------------+-------------------------------+-------------------------------
     158 | studio-ef6b_1737635204 | georgi-hristov | Thu, 23 Jan 2025 12:26:44 GMT | Thu, 23 Jan 2025 12:31:48 GMT
     159 | studio-ef6b_1737635574 | georgi-hristov | Thu, 23 Jan 2025 12:32:54 GMT | Thu, 23 Jan 2025 12:38:07 GMT
     160 | studio-ef6b_1737636023 | georgi-hristov | Thu, 23 Jan 2025 12:40:23 GMT | Thu, 23 Jan 2025 12:44:01 GMT
     161 | studio-ef6b_1737636325 | georgi-hristov | Thu, 23 Jan 2025 12:45:25 GMT | Thu, 23 Jan 2025 13:01:57 GMT
     162 | studio-ef6b_1737639347 | georgi-hristov | Thu, 23 Jan 2025 13:35:47 GMT | Thu, 23 Jan 2025 14:12:26 GMT
     163 | studio-ef6b_1737643087 | georgi-hristov | Thu, 23 Jan 2025 14:38:07 GMT | Thu, 23 Jan 2025 15:05:03 GMT
     165 | studio-ef6b_1737651629 | georgi-hristov | Thu, 23 Jan 2025 17:00:29 GMT | Thu, 23 Jan 2025 17:05:44 GMT
     168 | studio-ef6b_1737651957 | georgi-hristov | Thu, 23 Jan 2025 17:05:57 GMT | Fri, 24 Jan 2025 03:17:52 GMT
```