### PR TITLE
PLAT-1418 - Workaround fix for mount-data options showing as mandatry in the --help, while they are optional

### DIFF
--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -1920,6 +1920,12 @@
   "queryAllDeclaredConstructors":true
 },
 {
+  "name":"io.seqera.tower.cli.responses.datastudios.DataStudioCheckpointsList",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
   "name":"io.seqera.tower.cli.responses.datastudios.DataStudioDeleted",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
@@ -1945,12 +1951,6 @@
 },
 {
   "name":"io.seqera.tower.cli.responses.datastudios.DataStudiosList",
-  "allDeclaredFields":true,
-  "queryAllDeclaredMethods":true,
-  "queryAllDeclaredConstructors":true
-},
-{
-  "name":"io.seqera.tower.cli.responses.datastudios.DataStudioCheckpointsList",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true
@@ -2740,7 +2740,7 @@
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true,
-  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setAuthor","parameterTypes":["io.seqera.tower.model.StudioUser"] }, {"name":"setDateCreated","parameterTypes":["java.time.OffsetDateTime"] }, {"name":"setDateSaved","parameterTypes":["java.time.OffsetDateTime"] }, {"name":"setId","parameterTypes":["java.lang.Long"] }, {"name":"setName","parameterTypes":["java.lang.String"] }, {"name":"getAuthor","parameterTypes":[] }, {"name":"getDateCreated","parameterTypes":[] }, {"name":"getDateSaved","parameterTypes":[] }, {"name":"getId","parameterTypes":[] }, {"name":"getName","parameterTypes":[] }]
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"getAuthor","parameterTypes":[] }, {"name":"getDateCreated","parameterTypes":[] }, {"name":"getDateSaved","parameterTypes":[] }, {"name":"getId","parameterTypes":[] }, {"name":"getName","parameterTypes":[] }, {"name":"setAuthor","parameterTypes":["io.seqera.tower.model.StudioUser"] }, {"name":"setDateCreated","parameterTypes":["java.time.OffsetDateTime"] }, {"name":"setDateSaved","parameterTypes":["java.time.OffsetDateTime"] }, {"name":"setId","parameterTypes":["java.lang.Long"] }, {"name":"setName","parameterTypes":["java.lang.String"] }]
 },
 {
   "name":"io.seqera.tower.model.DataStudioComputeEnvDto",

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/DataLinkService.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/DataLinkService.java
@@ -91,8 +91,8 @@ public class DataLinkService  {
 
     public List<String> getDataLinkIds(DataLinkRefOptions.DataLinkRef dataLinkRef, Long wspId) {
         // if DataLink IDs are supplied - use those directly
-        if (dataLinkRef.mountDataIds != null) {
-            return dataLinkRef.mountDataIds;
+        if (dataLinkRef.getMountDataIds() != null) {
+            return dataLinkRef.getMountDataIds();
         }
 
         // Check and wait if DataLinks are still being fetched
@@ -103,14 +103,14 @@ public class DataLinkService  {
 
         List<String> dataLinkIds = new ArrayList<>();
 
-        if (dataLinkRef.mountDataNames != null) {
-            dataLinkIds = dataLinkRef.mountDataNames.stream()
+        if (dataLinkRef.getMountDataNames() != null) {
+            dataLinkIds = dataLinkRef.getMountDataNames().stream()
                     .map(name -> getDataLinkIdByName(wspId, name))
                     .collect(Collectors.toList());
         }
 
-        if (dataLinkRef.mountDataResourceRefs != null) {
-            dataLinkIds = dataLinkRef.mountDataResourceRefs.stream()
+        if (dataLinkRef.getMountDataResourceRefs() != null) {
+            dataLinkIds = dataLinkRef.getMountDataResourceRefs().stream()
                     .map(resourceRef -> getDataLinkIdByResourceRef(wspId, resourceRef))
                     .collect(Collectors.toList());
         }

--- a/src/main/java/io/seqera/tower/cli/commands/datastudios/DataLinkRefOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datastudios/DataLinkRefOptions.java
@@ -58,8 +58,8 @@ public class DataLinkRefOptions {
             boolean resourceRefsProvided = mountDataResourceRefs != null;
             boolean idsProvided = mountDataIds != null;
 
-            // XOR function + check that not all 3 are provided covers that exactly 1 is provided
-            boolean valid = (namesProvided ^ resourceRefsProvided ^ idsProvided) && !(namesProvided && resourceRefsProvided && idsProvided);
+            // check that exactly 1 is provided
+            boolean valid = (namesProvided ? 1 : 0) + (resourceRefsProvided ? 1 : 0) + (idsProvided ? 1 : 0) == 1;
 
             if (!valid) {
                 throw new TowerRuntimeException("Error: --mount-data=<mountDataNames>, --mount-data-ids=<mountDataIds>, --mount-data-resource-refs=<mountDataResourceRefs> are mutually exclusive (specify only one)");

--- a/src/main/java/io/seqera/tower/cli/commands/datastudios/DataLinkRefOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datastudios/DataLinkRefOptions.java
@@ -19,22 +19,52 @@ package io.seqera.tower.cli.commands.datastudios;
 
 import java.util.List;
 
+import io.seqera.tower.cli.exceptions.TowerRuntimeException;
 import picocli.CommandLine;
 
 public class DataLinkRefOptions {
 
-    @CommandLine.ArgGroup
+    // TODO: The use of the validate option is a work around to an existing Picocli issue. Please refer to https://github.com/seqeralabs/tower-cli/pull/72#issuecomment-952588876
+    @CommandLine.ArgGroup(validate = false, heading = "Option to mount data by passing in one of the below options:\n")
     public DataLinkRef dataLinkRef;
 
     public static class DataLinkRef {
         @CommandLine.Option(names = {"--mount-data"}, description = "Optional configuration override for 'mountData' setting (comma separate list of data-link names)", split = ",")
-        public List<String> mountDataNames;
+        private List<String> mountDataNames;
 
         @CommandLine.Option(names = {"--mount-data-ids"}, description = "Optional configuration override for 'mountData' setting (comma separate list of data-link Ids)", split = ",")
-        public List<String> mountDataIds;
+        private List<String> mountDataIds;
 
         @CommandLine.Option(names = {"--mount-data-resource-refs"}, description = "Optional configuration override for 'mountData' setting (comma separate list of data-link resource refs)", split = ",")
-        public List<String> mountDataResourceRefs;
+        private List<String> mountDataResourceRefs;
+
+        public List<String> getMountDataNames() {
+            validate();
+            return mountDataNames;
+        }
+
+        public List<String> getMountDataIds() {
+            validate();
+            return mountDataIds;
+        }
+
+        public List<String> getMountDataResourceRefs() {
+            validate();
+            return mountDataResourceRefs;
+        }
+
+        private void validate() {
+            boolean namesProvided = mountDataNames != null;
+            boolean resourceRefsProvided = mountDataResourceRefs != null;
+            boolean idsProvided = mountDataIds != null;
+
+            // XOR function + check that not all 3 are provided covers that exactly 1 is provided
+            boolean valid = (namesProvided ^ resourceRefsProvided ^ idsProvided) && !(namesProvided && resourceRefsProvided && idsProvided);
+
+            if (!valid) {
+                throw new TowerRuntimeException("Error: --mount-data=<mountDataNames>, --mount-data-ids=<mountDataIds>, --mount-data-resource-refs=<mountDataResourceRefs> are mutually exclusive (specify only one)");
+            }
+        }
     }
 
 }

--- a/src/main/java/io/seqera/tower/cli/responses/datastudios/DataStudioStartSubmitted.java
+++ b/src/main/java/io/seqera/tower/cli/responses/datastudios/DataStudioStartSubmitted.java
@@ -42,7 +42,7 @@ public class DataStudioStartSubmitted extends Response {
     @Override
     public String toString() {
         String isSuccess = jobSubmitted ? "successfully submitted" : "failed to submit";
-        return ansi(String.format("%n  @|yellow Data Studio %s START %s at %s workspace.|@%n%n    @|bold %s|@%n", userSuppliedStudioIdentifier, isSuccess, workspaceRef, studioUrl));
+        return ansi(String.format("%n  @|yellow Data Studio %s START %s at %s workspace.|@%n%n  To connect to this data studio session, copy and paste the following URL in your browser:%n%n    @|bold %s|@%n", userSuppliedStudioIdentifier, isSuccess, workspaceRef, studioUrl));
     }
 
 }

--- a/src/main/java/io/seqera/tower/cli/responses/datastudios/DataStudiosCreated.java
+++ b/src/main/java/io/seqera/tower/cli/responses/datastudios/DataStudiosCreated.java
@@ -40,7 +40,7 @@ public class DataStudiosCreated extends Response {
     @Override
     public String toString() {
         if (autoStart){
-            return ansi(String.format("%n  @|yellow Data Studio %s CREATED at %s workspace and auto started.|@%n%n    @|bold %s|@%n", sessionId, workspaceRef, studioUrl));
+            return ansi(String.format("%n  @|yellow Data Studio %s CREATED at %s workspace and auto started.|@%n%n  To connect to this data studio session, copy and paste the following URL in your browser:%n%n    @|bold %s|@%n", sessionId, workspaceRef, studioUrl));
         } else {
             return ansi(String.format("%n  @|yellow Data Studio %s CREATED at %s workspace.|@%n", sessionId, workspaceRef));
         }


### PR DESCRIPTION
Relates to : https://seqera.atlassian.net/browse/PLAT-1418

A known bug in the picocli framework causes even optional params that are grouped together to appear as mandatory in the --help section (as denoted by the `*`).

This causes the options to mount data to appear as mandatory, while they are optional.
```
Usage: tw studios start [OPTIONS]

Start a data studio.

Options:
  -w, --workspace=<workspace>       Workspace numeric identifier (TOWER_WORKSPACE_ID as default) or workspace reference as OrganizationName/WorkspaceName
* -i, --id=<sessionId>              DataStudio session ID.
* -n, --name=<dataStudioName>       DataStudio name.
*     --mount-data=<mountDataNames>[,<mountDataNames>...]
                                    Optional configuration override for 'mountData' setting (comma separate list of data-link names)
*     --mount-data-ids=<mountDataIds>[,<mountDataIds>...]
                                    Optional configuration override for 'mountData' setting (comma separate list of data-link Ids)
*     --mount-data-resource-refs=<mountDataResourceRefs>[,<mountDataResourceRefs>...]
                                    Optional configuration override for 'mountData' setting (comma separate list of data-link resource refs)
      --gpu=<gpu>                   Optional configuration override for 'gpu' setting (Integer representing number of cores)
      --cpu=<cpu>                   Optional configuration override for 'cpu' setting (Integer representing number of cores)
      --memory=<memory>             Optional configuration override for 'memory' setting (Integer representing memory in MBs)
      --wait=<wait>                 Wait until given status or fail. Valid options: starting, running, stopping, stopped, errored, building, buildFailed.
      --description=<description>   Optional configuration override for 'description'.
  -h, --help                        Show this help message and exit.
  -V, --version                     Print version information and exit.
$
```

A workaround (already used in the tower-cli for the [PaginationOptions that experience the same issue ](https://github.com/seqeralabs/tower-cli/pull/72#issuecomment-952588876)) is to add the (validation=false) option and implement our own validation.

After change:

```
Usage: tw studios start [OPTIONS]

Start a data studio.

Options:
  -w, --workspace=<workspace>       Workspace numeric identifier (TOWER_WORKSPACE_ID as default) or workspace reference as OrganizationName/WorkspaceName
* -i, --id=<sessionId>              DataStudio session ID.
* -n, --name=<dataStudioName>       DataStudio name.
      --gpu=<gpu>                   Optional configuration override for 'gpu' setting (Integer representing number of cores)
      --cpu=<cpu>                   Optional configuration override for 'cpu' setting (Integer representing number of cores)
      --memory=<memory>             Optional configuration override for 'memory' setting (Integer representing memory in MBs)
      --wait=<wait>                 Wait until given status or fail. Valid options: starting, running, stopping, stopped, errored, building, buildFailed.
      --description=<description>   Optional configuration override for 'description'.
  -h, --help                        Show this help message and exit.
  -V, --version                     Print version information and exit.
Option to mount data by passing in one of the below options:
      --mount-data=<mountDataNames>[,<mountDataNames>...]
                                    Optional configuration override for 'mountData' setting (comma separate list of data-link names)
      --mount-data-ids=<mountDataIds>[,<mountDataIds>...]
                                    Optional configuration override for 'mountData' setting (comma separate list of data-link Ids)
      --mount-data-resource-refs=<mountDataResourceRefs>[,<mountDataResourceRefs>...]
                                    Optional configuration override for 'mountData' setting (comma separate list of data-link resource refs)
```

Trying to supply more than one of the params still throws error:

```
$ ./tw studios start -w data-studios/data-studios -n studio-ef6b --mount-data adrian-navarro-test --mount-data-ids blabla

 ERROR: --mount-data=<mountDataNames>, --mount-data-ids=<mountDataIds>, --mount-data-resource-refs=<mountDataResourceRefs> are mutually exclusive (specify only one)
```