### PR TITLE
Format the description of a studio to remove line breaks to increase readability

### DIFF
--- a/src/main/java/io/seqera/tower/cli/responses/studios/StudiosList.java
+++ b/src/main/java/io/seqera/tower/cli/responses/studios/StudiosList.java
@@ -30,6 +30,7 @@ import io.seqera.tower.model.DataStudioDto;
 import io.seqera.tower.model.DataStudioStatusInfo;
 import io.seqera.tower.model.StudioUser;
 
+import static io.seqera.tower.cli.utils.FormatHelper.formatDescription;
 import static io.seqera.tower.cli.utils.FormatHelper.formatStudioStatus;
 
 public class StudiosList extends Response {
@@ -67,10 +68,10 @@ public class StudiosList extends Response {
             DataStudioStatusInfo statusInfo = studio.getStatusInfo();
             StudioUser user = studio.getUser();
             List<String> rows = new ArrayList<>(List.of(
-                    studio.getSessionId() == null ? "" : studio.getSessionId(),
-                    studio.getName() == null ? "" : studio.getName(),
-                    studio.getDescription() == null ? "" : studio.getDescription(),
-                    user == null ? "" : user.getUserName(),
+                    studio.getSessionId() == null ? "NA" : studio.getSessionId(),
+                    studio.getName() == null ? "NA" : studio.getName(),
+                    formatDescription(studio.getDescription(), 100),
+                    user == null ? "NA" : user.getUserName(),
                     formatStudioStatus(statusInfo == null ? null : statusInfo.getStatus())
             ));
 

--- a/src/main/java/io/seqera/tower/cli/responses/studios/StudiosView.java
+++ b/src/main/java/io/seqera/tower/cli/responses/studios/StudiosView.java
@@ -27,6 +27,7 @@ import io.seqera.tower.model.StudioUser;
 
 import java.io.PrintWriter;
 
+import static io.seqera.tower.cli.utils.FormatHelper.formatDescription;
 import static io.seqera.tower.cli.utils.FormatHelper.formatStudioStatus;
 import static io.seqera.tower.cli.utils.FormatHelper.formatTime;
 
@@ -54,7 +55,7 @@ public class StudiosView extends Response {
         table.addRow("Status", formatStudioStatus(statusInfo == null ? null : statusInfo.getStatus()));
         table.addRow("Status last update", statusInfo == null ? "NA" : formatTime(statusInfo.getLastUpdate()));
         table.addRow("Studio URL", studio.getStudioUrl());
-        table.addRow("Description", studio.getDescription());
+        table.addRow("Description", formatDescription(studio.getDescription(), 100));
         table.addRow("Created on", formatTime(studio.getDateCreated()));
         table.addRow("Created by", studioUser == null ? "NA" : String.format("%s | %s",studioUser.getUserName(), studioUser.getEmail()));
         table.addRow("Template", studio.getTemplate() == null ? "NA" : studio.getTemplate().getRepository());

--- a/src/main/java/io/seqera/tower/cli/utils/FormatHelper.java
+++ b/src/main/java/io/seqera/tower/cli/utils/FormatHelper.java
@@ -334,4 +334,19 @@ public class FormatHelper {
         .collect(Collectors.joining(","));
     }
 
+    public static String formatDescription(String description) {
+        return formatDescription(description, 2048);
+    }
+
+    public static String formatDescription(String description, int maxLength) {
+        if (description == null) {
+            return "NA";
+        }
+
+        // remove line breaks
+        var text = description.replace("\n", " ").replace("\r", " ");
+        // cap the description length if too long
+        return text.length() > maxLength ? text.substring(0, maxLength) + "..." : text;
+    }
+
 }

--- a/src/main/java/io/seqera/tower/cli/utils/FormatHelper.java
+++ b/src/main/java/io/seqera/tower/cli/utils/FormatHelper.java
@@ -344,7 +344,7 @@ public class FormatHelper {
         }
 
         // remove line breaks
-        var text = description.replace("\n", " ").replace("\r", " ");
+        var text = description.trim().replace("\n", " ").replace("\r", " ");
         // cap the description length if too long
         return text.length() > maxLength ? text.substring(0, maxLength) + "..." : text;
     }


### PR DESCRIPTION
Noticed while doing some testing that for Studios where the description had a line break or was too long, it resulted in the table output being formatted wrong - this PR sanitises the description a bit to avoid badly formatted output and improve readability.

Before:
```
./tw studios list -w data-studios/data-studios

 Studios at [data-studios / data-studios] workspace:

     ID       | Name                      | Description                                                              | User               | Status
    ----------+---------------------------+--------------------------------------------------------------------------+--------------------+-------------
     abec0e2c | studio-c9f5               | test mount

Started from studio jboxman-test-012725b                     | jason-boxman       | STOPPED
     5dc53d96 | my_name_with_underscore   | NA                                                                       | endre-sukosd       | STOPPED
     93cf086d | studio-c3f6               | NA                                                                       | georgi-hristov     | ERRORED
     aa3ab09d | my-fresh-studio           | NA                                                                       | georgi-hristov     | ERRORED
```

After:
```
./tw studios list -w data-studios/data-studios

Studios at [data-studios / data-studios] workspace:

     ID       | Name                      | Description                                                              | User               | Status
    ----------+---------------------------+--------------------------------------------------------------------------+--------------------+-------------
     abec0e2c | studio-c9f5               | test mount Started from studio jboxman-test-012725b                      | jason-boxman       | STOPPED
     5dc53d96 | my_name_with_underscore   | NA                                                                       | endre-sukosd       | STOPPED
     93cf086d | studio-c3f6               | NA                                                                       | georgi-hristov     | ERRORED
     aa3ab09d | my-fresh-studio           | NA                                                                       | georgi-hristov     | ERRORED
     77677145 | gost-refactor-jupyter     | NA                                                                       | weronika-sosnowska | STOPPED
```
In line with how it is presented on the Frontend as well:
<img width="485" alt="image" src="https://github.com/user-attachments/assets/1151aa40-abd7-402e-b126-318fcc7cb40c" />

Studio with long description capped:
```
Studios at [data-studios / data-studios] workspace:

     ID       | Name                      | Description                                                                                             | User               | Status
    ----------+---------------------------+---------------------------------------------------------------------------------------------------------+--------------------+-------------
     8dbe08fa | studio-33a2               | Lorem ipsum odor amet, consectetuer adipiscing elit. Est lacinia proin habitasse suspendisse nascetu... | georgi-hristov     | RUNNING
     abec0e2c | studio-c9f5               | test mount Started from studio jboxman-test-012725b                                                     | jason-boxman       | STOPPED
     5dc53d96 | my_name_with_underscore   | NA                                                                                                      | endre-sukosd       | STOPPED
     93cf086d | studio-c3f6               | NA                                                                                                      | georgi-hristov     | ERRORED
```