### PR TITLE
Make autoStart option consistent with the other options

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/studios/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/studios/AddCmd.java
@@ -66,7 +66,7 @@ public class AddCmd extends AbstractStudiosCmd{
     @CommandLine.Mixin
     public StudioConfigurationOptions studioConfigOptions;
 
-    @CommandLine.Option(names = {"-a", "--autoStart"}, description = "Create Studio and start it immediately, defaults to false.", defaultValue = "false")
+    @CommandLine.Option(names = {"-a", "--auto-start"}, description = "Create Studio and start it immediately, defaults to false.", defaultValue = "false")
     public Boolean autoStart;
 
     @CommandLine.Option(names = {"--wait"}, description = "Wait until Studio is in RUNNING status. Valid options: ${COMPLETION-CANDIDATES}.")

--- a/src/main/java/io/seqera/tower/cli/commands/studios/StartAsNewCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/studios/StartAsNewCmd.java
@@ -58,7 +58,7 @@ public class StartAsNewCmd extends AbstractStudiosCmd{
     @CommandLine.Mixin
     public StudioConfigurationOptions studioConfigOptions;
 
-    @CommandLine.Option(names = {"-a", "--autoStart"}, description = "Create Studio and start it immediately, defaults to false.", defaultValue = "false")
+    @CommandLine.Option(names = {"-a", "--auto-start"}, description = "Create Studio and start it immediately, defaults to false.", defaultValue = "false")
     public Boolean autoStart;
 
     @CommandLine.Option(names = {"--wait"}, description = "Wait until Studio is in RUNNING status. Valid options: ${COMPLETION-CANDIDATES}.")


### PR DESCRIPTION
There are options following the `--mount-data` standard, and then `--autoStart`. This PR makes the latter consistent with the other options (`--auto-start`).