### PR TITLE
[PLAT-1567] - Studio rename start-as-new command to add-as-new to reflect better the functionality.

### DIFF
--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -1544,6 +1544,12 @@
   "queryAllDeclaredMethods":true
 },
 {
+  "name":"io.seqera.tower.cli.commands.studios.AddAsNewCmd",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"io.seqera.tower.cli.commands.studios.AddCmd",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
@@ -1587,12 +1593,6 @@
 },
 {
   "name":"io.seqera.tower.cli.commands.studios.ParentStudioRefOptions$ParentStudioRef",
-  "allDeclaredFields":true,
-  "queryAllDeclaredMethods":true,
-  "methods":[{"name":"<init>","parameterTypes":[] }]
-},
-{
-  "name":"io.seqera.tower.cli.commands.studios.StartAsNewCmd",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "methods":[{"name":"<init>","parameterTypes":[] }]

--- a/src/main/java/io/seqera/tower/cli/commands/StudiosCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/StudiosCmd.java
@@ -21,7 +21,7 @@ import io.seqera.tower.cli.commands.studios.AddCmd;
 import io.seqera.tower.cli.commands.studios.CheckpointsCmd;
 import io.seqera.tower.cli.commands.studios.DeleteCmd;
 import io.seqera.tower.cli.commands.studios.ListCmd;
-import io.seqera.tower.cli.commands.studios.StartAsNewCmd;
+import io.seqera.tower.cli.commands.studios.AddAsNewCmd;
 import io.seqera.tower.cli.commands.studios.StartCmd;
 import io.seqera.tower.cli.commands.studios.TemplatesCmd;
 import io.seqera.tower.cli.commands.studios.StopCmd;
@@ -38,7 +38,7 @@ import picocli.CommandLine;
                 AddCmd.class,
                 TemplatesCmd.class,
                 CheckpointsCmd.class,
-                StartAsNewCmd.class,
+                AddAsNewCmd.class,
                 StopCmd.class,
                 DeleteCmd.class,
         }

--- a/src/main/java/io/seqera/tower/cli/commands/studios/AddAsNewCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/studios/AddAsNewCmd.java
@@ -35,10 +35,10 @@ import picocli.CommandLine;
 import java.util.Objects;
 
 @CommandLine.Command(
-        name = "start-as-new",
-        description = "Start a new studio from an existing one."
+        name = "add-as-new",
+        description = "Add a new studio from an existing one."
 )
-public class StartAsNewCmd extends AbstractStudiosCmd{
+public class AddAsNewCmd extends AbstractStudiosCmd{
 
     @CommandLine.Mixin
     public ParentStudioRefOptions parentStudioRefOptions;

--- a/src/main/java/io/seqera/tower/cli/commands/studios/ParentStudioRefOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/studios/ParentStudioRefOptions.java
@@ -25,10 +25,10 @@ public class ParentStudioRefOptions {
     public ParentStudioRef studio;
 
     public static class ParentStudioRef {
-        @CommandLine.Option(names = {"-pid", "--parentId"}, description = "Parent Studio session ID.")
+        @CommandLine.Option(names = {"-pid", "--parent-id"}, description = "Parent Studio session ID.")
         public String sessionId;
 
-        @CommandLine.Option(names = {"-pn", "--parentName"}, description = "Parent Studio name.")
+        @CommandLine.Option(names = {"-pn", "--parent-name"}, description = "Parent Studio name.")
         public String name;
     }
 }

--- a/src/test/java/io/seqera/tower/cli/studios/StudiosCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/studios/StudiosCmdTest.java
@@ -1200,7 +1200,7 @@ public class StudiosCmdTest extends BaseCmdTest {
 
     @ParameterizedTest
     @EnumSource(OutputType.class)
-    void testStartAsNew(OutputType format, MockServerClient mock) throws JsonProcessingException {
+    void testAddAsNew(OutputType format, MockServerClient mock) throws JsonProcessingException {
 
         mock.when(
                 request().withMethod("GET").withPath("/user-info"), exactly(2)
@@ -1236,7 +1236,7 @@ public class StudiosCmdTest extends BaseCmdTest {
                 response().withStatusCode(200).withBody(loadResource("studios/studios_start_as_new_response")).withContentType(MediaType.APPLICATION_JSON)
         );
 
-        ExecOut out = exec(format, mock, "studios", "start-as-new", "-pid", "3e8370e7", "-n", "child-studio-a66d", "-w", "75887156211589", "--cpu", "4");
+        ExecOut out = exec(format, mock, "studios", "add-as-new", "-pid", "3e8370e7", "-n", "child-studio-a66d", "-w", "75887156211589", "--cpu", "4");
 
         assertOutput(format, out, new StudiosCreated("8aebf1b8",75887156211589L, "[organization1 / workspace1]",
                 "http://localhost:"+mock.getPort()+"/orgs/organization1/workspaces/workspace1", false));
@@ -1297,7 +1297,7 @@ public class StudiosCmdTest extends BaseCmdTest {
 
     @ParameterizedTest
     @EnumSource(OutputType.class)
-    void testStartAsNewUsingParentName(OutputType format, MockServerClient mock) {
+    void testAddAsNewUsingParentName(OutputType format, MockServerClient mock) {
 
         mock.when(
                 request().withMethod("GET").withPath("/user-info"), exactly(2)
@@ -1339,7 +1339,7 @@ public class StudiosCmdTest extends BaseCmdTest {
                 response().withStatusCode(200).withBody(loadResource("studios/studios_start_as_new_response")).withContentType(MediaType.APPLICATION_JSON)
         );
 
-        ExecOut out = exec(format, mock, "studios", "start-as-new", "-pn", "studio-a66d", "-n", "child-studio-a66d", "-w", "75887156211589", "--cpu", "4");
+        ExecOut out = exec(format, mock, "studios", "add-as-new", "-pn", "studio-a66d", "-n", "child-studio-a66d", "-w", "75887156211589", "--cpu", "4");
 
         assertOutput(format, out, new StudiosCreated("8aebf1b8", 75887156211589L, "[organization1 / workspace1]",
                 "http://localhost:"+mock.getPort()+"/orgs/organization1/workspaces/workspace1", false));
@@ -1347,7 +1347,7 @@ public class StudiosCmdTest extends BaseCmdTest {
 
     @ParameterizedTest
     @EnumSource(OutputType.class)
-    void testStartAsNewUsingParentCheckpointId(OutputType format, MockServerClient mock) {
+    void testAddAsNewUsingParentCheckpointId(OutputType format, MockServerClient mock) {
 
         mock.when(
                 request().withMethod("GET").withPath("/user-info"), exactly(2)
@@ -1387,7 +1387,7 @@ public class StudiosCmdTest extends BaseCmdTest {
                 response().withStatusCode(200).withBody(loadResource("studios/studios_start_as_new_response")).withContentType(MediaType.APPLICATION_JSON)
         );
 
-        ExecOut out = exec(format, mock, "studios", "start-as-new", "-pn", "studio-a66d", "-n", "child-studio-a66d", "-w", "75887156211589", "--parent-checkpoint-id", "1");
+        ExecOut out = exec(format, mock, "studios", "add-as-new", "-pn", "studio-a66d", "-n", "child-studio-a66d", "-w", "75887156211589", "--parent-checkpoint-id", "1");
 
         assertOutput(format, out, new StudiosCreated("8aebf1b8", 75887156211589L, "[organization1 / workspace1]",
                 "http://localhost:"+mock.getPort()+"/orgs/organization1/workspaces/workspace1", false));
@@ -1395,7 +1395,7 @@ public class StudiosCmdTest extends BaseCmdTest {
 
     @ParameterizedTest
     @EnumSource(OutputType.class)
-    void testStartAsNewThrowsInvalidDataStudioParentCheckpointException(OutputType format, MockServerClient mock) {
+    void testAddAsNewThrowsInvalidDataStudioParentCheckpointException(OutputType format, MockServerClient mock) {
 
         mock.when(
                 request().withMethod("GET").withPath("/user-info"), exactly(2)
@@ -1437,7 +1437,7 @@ public class StudiosCmdTest extends BaseCmdTest {
                 response().withStatusCode(200).withBody(loadResource("studios/studios_start_as_new_response")).withContentType(MediaType.APPLICATION_JSON)
         );
 
-        ExecOut out = exec(format, mock, "studios", "start-as-new", "-pn", "studio-a66d", "-n", "child-studio-a66d", "-w", "75887156211589", "--parent-checkpoint-id", "1111");
+        ExecOut out = exec(format, mock, "studios", "add-as-new", "--parent-name", "studio-a66d", "-n", "child-studio-a66d", "-w", "75887156211589", "--parent-checkpoint-id", "1111");
 
         assertEquals(errorMessage(out.app, new InvalidDataStudioParentCheckpointException("1111")), out.stdErr);
         assertEquals("", out.stdOut);


### PR DESCRIPTION
Add-as-new
```
./tw studios add-as-new -w data-studios/data-studios --name copied-studio --parent-name feb17_multi_session

  Studio 6a74520a CREATED at [data-studios / data-studios] workspace.
```
Add-as-new with --auto-start
```
./tw studios add-as-new -w data-studios/data-studios --name copied-studio-2 --parent-name feb17_multi_session --auto-start

  Studio 3744dc10 CREATED at [data-studios / data-studios] workspace and auto started.

  To connect to this studio session, copy and paste the following URL in your browser:

    https://dev-tower.net/orgs/data-studios/workspaces/data-studios/studios/3744dc10/connect
```

Also rename --parenId to --parent-id and --parentName to --parent-name to standardized option format.