### PR TITLE
chore:(CI) Use Github action credentials vs service account.   

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         run: ./gradlew cleanTest test
         env:
           GITHUB_USERNAME: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GH_SEQERA_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Tests reports
         uses: actions/upload-artifact@v4
@@ -58,7 +58,7 @@ jobs:
         run: ./gradlew nativeCompile
         env:
           GITHUB_USERNAME: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GH_SEQERA_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PLATFORM: linux-x86_64
 
       - name: Upload linux native image artifact
@@ -72,7 +72,7 @@ jobs:
         env:
           TOWER_CLI: build/native/nativeCompile/tw
           GITHUB_USERNAME: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GH_SEQERA_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Binary tests reports
         uses: actions/upload-artifact@v4
@@ -105,7 +105,7 @@ jobs:
         run: ./gradlew cleanTest test
         env:
           GITHUB_USERNAME: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GH_SEQERA_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Tests reports
         uses: actions/upload-artifact@v4
@@ -118,7 +118,7 @@ jobs:
         run: ./gradlew nativeCompile
         env:
           GITHUB_USERNAME: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GH_SEQERA_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PLATFORM: osx-x86_64
       - name: Codesign binary
         if: "contains(github.event.head_commit.message, '[release]') && github.event.ref=='refs/heads/master'"
@@ -159,7 +159,7 @@ jobs:
         env:
           TOWER_CLI: build/native/nativeCompile/tw
           GITHUB_USERNAME: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GH_SEQERA_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Binary tests reports
         uses: actions/upload-artifact@v4
@@ -200,7 +200,7 @@ jobs:
         run: ./gradlew cleanTest test
         env:
           GITHUB_USERNAME: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GH_SEQERA_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Tests reports
         uses: actions/upload-artifact@v4
@@ -213,7 +213,7 @@ jobs:
         run: ./gradlew nativeCompile
         env:
           GITHUB_USERNAME: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GH_SEQERA_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PLATFORM: osx-arm64
       - name: Codesign binary
         if: "contains(github.event.head_commit.message, '[release]') && github.event.ref=='refs/heads/master'"
@@ -254,7 +254,7 @@ jobs:
         env:
           TOWER_CLI: build/native/nativeCompile/tw
           GITHUB_USERNAME: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GH_SEQERA_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Binary tests reports
         uses: actions/upload-artifact@v4
@@ -287,7 +287,7 @@ jobs:
         run: ./gradlew cleanTest test
         env:
           GITHUB_USERNAME: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GH_SEQERA_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Tests reports
         uses: actions/upload-artifact@v4
@@ -300,7 +300,7 @@ jobs:
         run: ./gradlew nativeCompile
         env:
           GITHUB_USERNAME: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GH_SEQERA_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PLATFORM: windows-x86_64
 
       - name: Upload Windows native image artifact
@@ -314,7 +314,7 @@ jobs:
         env:
           TOWER_CLI: build/native/nativeCompile/tw.exe
           GITHUB_USERNAME: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GH_SEQERA_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Binary tests reports
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The following removes the use of the `GH_SEQERA_TOKEN` as it's not required for relevant build steps as artifacts originate from a public repository. 