### PR TITLE
fix: nullpointerexception when running runs dump for a nextflow -with-tower run

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/runs/DumpCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/DumpCmd.java
@@ -193,7 +193,7 @@ public class DumpCmd extends AbstractRunsCmd {
         String launchId = workflow.getLaunchId();
         Launch launch = (launchId == null) ? null : launchById(workspaceId, launchId);
 
-        return JsonHelper.prettyJson(launch);
+        return (launch == null) ? "" : JsonHelper.prettyJson(launch);
     }
 
     private String collectWorkflowMetrics(Long workspaceId) throws ApiException, JsonProcessingException {
@@ -265,9 +265,12 @@ public class DumpCmd extends AbstractRunsCmd {
             throw new TowerException("Unknown workflow");
         }
 
-        File nextflowLog = workflowsApi().downloadWorkflowLog(workflow.getId(), String.format("nf-%s.log", workflow.getId()), workspaceId);
-
-        return nextflowLog;
+        try {
+            File nextflowLog = workflowsApi().downloadWorkflowLog(workflow.getId(), String.format("nf-%s.log", workflow.getId()), workspaceId);
+            return nextflowLog;
+        } catch(Exception e) {
+            return null;
+        }
     }
 
     private void addTaskLog(TarFileHelper.TarFileAppender tar, Long taskId, String logName, Long workspaceId, String workflowId) throws ApiException, IOException {

--- a/src/main/java/io/seqera/tower/cli/commands/runs/DumpCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/DumpCmd.java
@@ -112,7 +112,10 @@ public class DumpCmd extends AbstractRunsCmd {
             tar.add("workflow-launch.json", collectWorkflowLaunch(wspId));
             tar.add("workflow-metrics.json", collectWorkflowMetrics(wspId));
             tar.add("workflow-tasks.json", collectWorkflowTasks(wspId));
-            tar.add("nextflow.log", collectNfLog(wspId));
+            var nfLog = collectNfLog(wspId);
+            if (nfLog != null) {
+                tar.add("nextflow.log", nfLog);
+            }
             collectWorkflowTaskLogs(tar, wspId); // tasks/{taskId}/.command.[out,err,log], .fusion.log
 
         } // blocks until data is written to tar file, or timeout

--- a/src/main/java/io/seqera/tower/cli/commands/runs/DumpCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/DumpCmd.java
@@ -109,21 +109,24 @@ public class DumpCmd extends AbstractRunsCmd {
             tar.add("workflow.json", collectWorkflowInfo(wspId));
             tar.add("workflow-metadata.json", collectWorkflowMetadata(wspId));
             tar.add("workflow-load.json", collectWorkflowLoad(wspId));
-            var aa = collectWorkflowLaunch(wspId);
-            if (aa != null) {
-                tar.add("workflow-launch.json", collectWorkflowLaunch(wspId));
+
+            var wfLaunch = collectWorkflowLaunch(wspId);
+            if (wfLaunch != null) {
+                tar.add("workflow-launch.json", wfLaunch);
             } else {
                 progress.println(ansi("\t- No data collected, skipping")); // nextflow-run workflows doesn't upload launch
             }
+
             tar.add("workflow-metrics.json", collectWorkflowMetrics(wspId));
             tar.add("workflow-tasks.json", collectWorkflowTasks(wspId));
+
             var nfLog = collectNfLog(wspId);
             if (nfLog != null) {
                 tar.add("nextflow.log", nfLog);
             } else {
                 progress.println(ansi("\t- No data collected, skipping")); // nextflow-run workflows doesn't upload log
-
             }
+
             collectWorkflowTaskLogs(tar, wspId); // tasks/{taskId}/.command.[out,err,log], .fusion.log
 
         } // blocks until data is written to tar file, or timeout


### PR DESCRIPTION
## Original issue repro steps:
- Run a workflow directly from `nextflow` using the `-with-tower` arg
- Run `tw run dump -i {workflowId} -o outfile.tar.gz`
- Current version throws a nullpointerexception. This should fix it.

## Description

This pull request introduces enhancements to error handling and default value management in the `DumpCmd` class. The changes ensure the code handles null values and exceptions gracefully, improving robustness and preventing potential runtime errors.

### Error Handling Improvements:
* [`src/main/java/io/seqera/tower/cli/commands/runs/DumpCmd.java`](diffhunk://#diff-3508a39924a4586ec204298466287aa2d84b10cde3cc575fccd0b6967add0716L196-R196): Updated `collectWorkflowLaunch` method to return an empty string (`""`) instead of `null` when the `launch` object is null, avoiding potential null pointer issues.
* [`src/main/java/io/seqera/tower/cli/commands/runs/DumpCmd.java`](diffhunk://#diff-3508a39924a4586ec204298466287aa2d84b10cde3cc575fccd0b6967add0716R268-R273): Added a try-catch block in the `collectNfLog` method to return `null` if an exception occurs while downloading the workflow log, preventing unhandled exceptions.