### PR TITLE
add data-links cmd for uploading files/directories

### DIFF
--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -2909,6 +2909,7 @@
 },
 {
   "name":"io.seqera.tower.model.DataLinkFinishMultiPartUploadRequest",
+  "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true,
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"addTagsItem","parameterTypes":["io.seqera.tower.model.UploadEtag"] }, {"name":"equals","parameterTypes":["java.lang.Object"] }, {"name":"fileName","parameterTypes":["java.lang.String"] }, {"name":"getFileName","parameterTypes":[] }, {"name":"getTags","parameterTypes":[] }, {"name":"getUploadId","parameterTypes":[] }, {"name":"getWithError","parameterTypes":[] }, {"name":"hashCode","parameterTypes":[] }, {"name":"setFileName","parameterTypes":["java.lang.String"] }, {"name":"setTags","parameterTypes":["java.util.List"] }, {"name":"setUploadId","parameterTypes":["java.lang.String"] }, {"name":"setWithError","parameterTypes":["java.lang.Boolean"] }, {"name":"tags","parameterTypes":["java.util.List"] }, {"name":"toIndentedString","parameterTypes":["java.lang.Object"] }, {"name":"toString","parameterTypes":[] }, {"name":"uploadId","parameterTypes":["java.lang.String"] }, {"name":"withError","parameterTypes":["java.lang.Boolean"] }]
@@ -4257,6 +4258,7 @@
 },
 {
   "name":"io.seqera.tower.model.UploadEtag",
+  "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true,
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"eTag","parameterTypes":["java.lang.String"] }, {"name":"equals","parameterTypes":["java.lang.Object"] }, {"name":"getPartNumber","parameterTypes":[] }, {"name":"geteTag","parameterTypes":[] }, {"name":"hashCode","parameterTypes":[] }, {"name":"partNumber","parameterTypes":["java.lang.Integer"] }, {"name":"setPartNumber","parameterTypes":["java.lang.Integer"] }, {"name":"seteTag","parameterTypes":["java.lang.String"] }, {"name":"toIndentedString","parameterTypes":["java.lang.Object"] }, {"name":"toString","parameterTypes":[] }]

--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -1050,6 +1050,12 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"io.seqera.tower.cli.commands.data.links.UploadCmd",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"io.seqera.tower.cli.commands.data.studios.AbstractStudiosCmd",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true
@@ -1900,13 +1906,13 @@
   "queryAllDeclaredConstructors":true
 },
 {
-  "name":"io.seqera.tower.cli.responses.data.DataLinkFileDownloadResult",
+  "name":"io.seqera.tower.cli.responses.data.DataLinkFileTransferResult",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true
 },
 {
-  "name":"io.seqera.tower.cli.responses.data.DataLinkFileDownloadResult$SimplePathInfo",
+  "name":"io.seqera.tower.cli.responses.data.DataLinkFileTransferResult$SimplePathInfo",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true

--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -111,6 +111,10 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"com.sun.crypto.provider.HmacCore$HmacSHA384",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"com.sun.crypto.provider.TlsKeyMaterialGenerator",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
@@ -2521,6 +2525,7 @@
 },
 {
   "name":"io.seqera.tower.model.AzureEntraKeys",
+  "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true,
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"clientId","parameterTypes":["java.lang.String"] }, {"name":"clientSecret","parameterTypes":["java.lang.String"] }, {"name":"equals","parameterTypes":["java.lang.Object"] }, {"name":"getClientId","parameterTypes":[] }, {"name":"getClientSecret","parameterTypes":[] }, {"name":"getDiscriminator","parameterTypes":[] }, {"name":"getTenantId","parameterTypes":[] }, {"name":"hashCode","parameterTypes":[] }, {"name":"setClientId","parameterTypes":["java.lang.String"] }, {"name":"setClientSecret","parameterTypes":["java.lang.String"] }, {"name":"setTenantId","parameterTypes":["java.lang.String"] }, {"name":"tenantId","parameterTypes":["java.lang.String"] }, {"name":"toIndentedString","parameterTypes":["java.lang.Object"] }, {"name":"toString","parameterTypes":[] }]
@@ -2851,6 +2856,7 @@
 },
 {
   "name":"io.seqera.tower.model.DataLinkContentTreeListResponse",
+  "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true,
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"addItemsItem","parameterTypes":["io.seqera.tower.model.DataLinkSimpleItem"] }, {"name":"equals","parameterTypes":["java.lang.Object"] }, {"name":"getItems","parameterTypes":[] }, {"name":"hashCode","parameterTypes":[] }, {"name":"items","parameterTypes":["java.util.List"] }, {"name":"setItems","parameterTypes":["java.util.List"] }, {"name":"toIndentedString","parameterTypes":["java.lang.Object"] }, {"name":"toString","parameterTypes":[] }]
@@ -2929,12 +2935,14 @@
 },
 {
   "name":"io.seqera.tower.model.DataLinkMultiPartUploadRequest",
+  "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true,
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"contentLength","parameterTypes":["java.lang.Long"] }, {"name":"contentType","parameterTypes":["java.lang.String"] }, {"name":"equals","parameterTypes":["java.lang.Object"] }, {"name":"fileName","parameterTypes":["java.lang.String"] }, {"name":"getContentLength","parameterTypes":[] }, {"name":"getContentType","parameterTypes":[] }, {"name":"getFileName","parameterTypes":[] }, {"name":"hashCode","parameterTypes":[] }, {"name":"setContentLength","parameterTypes":["java.lang.Long"] }, {"name":"setContentType","parameterTypes":["java.lang.String"] }, {"name":"setFileName","parameterTypes":["java.lang.String"] }, {"name":"toIndentedString","parameterTypes":["java.lang.Object"] }, {"name":"toString","parameterTypes":[] }]
 },
 {
   "name":"io.seqera.tower.model.DataLinkMultiPartUploadResponse",
+  "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true,
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"addUploadUrlsItem","parameterTypes":["java.lang.String"] }, {"name":"equals","parameterTypes":["java.lang.Object"] }, {"name":"getUploadId","parameterTypes":[] }, {"name":"getUploadUrls","parameterTypes":[] }, {"name":"hashCode","parameterTypes":[] }, {"name":"setUploadId","parameterTypes":["java.lang.String"] }, {"name":"setUploadUrls","parameterTypes":["java.util.List"] }, {"name":"toIndentedString","parameterTypes":["java.lang.Object"] }, {"name":"toString","parameterTypes":[] }, {"name":"uploadId","parameterTypes":["java.lang.String"] }, {"name":"uploadUrls","parameterTypes":["java.util.List"] }]
@@ -2955,6 +2963,7 @@
 },
 {
   "name":"io.seqera.tower.model.DataLinkSimpleItem",
+  "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true,
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"equals","parameterTypes":["java.lang.Object"] }, {"name":"getPath","parameterTypes":[] }, {"name":"getSize","parameterTypes":[] }, {"name":"hashCode","parameterTypes":[] }, {"name":"path","parameterTypes":["java.lang.String"] }, {"name":"setPath","parameterTypes":["java.lang.String"] }, {"name":"setSize","parameterTypes":["java.lang.Long"] }, {"name":"size","parameterTypes":["java.lang.Long"] }, {"name":"toIndentedString","parameterTypes":["java.lang.Object"] }, {"name":"toString","parameterTypes":[] }]
@@ -4759,6 +4768,9 @@
   "methods":[{"name":"getEncoding","parameterTypes":[] }, {"name":"getLanguage","parameterTypes":[] }, {"name":"getLanguageString","parameterTypes":[] }, {"name":"getMediaType","parameterTypes":[] }]
 },
 {
+  "name":"jdk.internal.misc.Unsafe"
+},
+{
   "name":"long[]"
 },
 {
@@ -5157,6 +5169,10 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"sun.security.rsa.RSASignature$SHA384withRSA",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"sun.security.rsa.RSASignature$SHA512withRSA",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
@@ -5216,6 +5232,10 @@
 },
 {
   "name":"sun.security.x509.NetscapeCertTypeExtension",
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"sun.security.x509.OCSPNoCheckExtension",
   "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
 },
 {

--- a/conf/resource-config.json
+++ b/conf/resource-config.json
@@ -51,6 +51,8 @@
   }, {
     "pattern":"java.base:\\Qsun/net/idn/uidna.spp\\E"
   }, {
+    "pattern":"java.base:\\Qsun/net/www/content-types.properties\\E"
+  }, {
     "pattern":"java.base:\\Qsun/text/resources/LineBreakIteratorData\\E"
   }]},
   "bundles":[{

--- a/conf/resource-config.json
+++ b/conf/resource-config.json
@@ -11,6 +11,8 @@
   }, {
     "pattern":"\\QMETA-INF/services/java.nio.channels.spi.SelectorProvider\\E"
   }, {
+    "pattern":"\\QMETA-INF/services/java.nio.file.spi.FileTypeDetector\\E"
+  }, {
     "pattern":"\\QMETA-INF/services/java.time.zone.ZoneRulesProvider\\E"
   }, {
     "pattern":"\\QMETA-INF/services/java.util.spi.ResourceBundleControlProvider\\E"
@@ -57,10 +59,10 @@
   }]},
   "bundles":[{
     "name":"org.glassfish.jersey.client.internal.localization",
-    "locales":["und"]
+    "locales":["", "und"]
   }, {
     "name":"org.glassfish.jersey.internal.localization",
-    "locales":["und"]
+    "locales":["", "und"]
   }, {
     "name":"org.glassfish.jersey.media.multipart.internal.localization"
   }]

--- a/src/main/java/io/seqera/tower/cli/commands/DataLinksCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/DataLinksCmd.java
@@ -23,18 +23,20 @@ import io.seqera.tower.cli.commands.data.links.DownloadCmd;
 import io.seqera.tower.cli.commands.data.links.ListCmd;
 import io.seqera.tower.cli.commands.data.links.UpdateCmd;
 import io.seqera.tower.cli.commands.data.links.BrowseCmd;
+import io.seqera.tower.cli.commands.data.links.UploadCmd;
 import picocli.CommandLine;
 
 @CommandLine.Command(
         name = "data-links",
-        description = "Manage data links.",
+        description = "Manage data-links.",
         subcommands = {
                 ListCmd.class,
                 AddCmd.class,
                 DeleteCmd.class,
                 UpdateCmd.class,
                 BrowseCmd.class,
-                DownloadCmd.class
+                DownloadCmd.class,
+                UploadCmd.class
         }
 )
 public class DataLinksCmd extends AbstractRootCmd {

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/AbstractDataLinksCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/AbstractDataLinksCmd.java
@@ -19,6 +19,7 @@ package io.seqera.tower.cli.commands.data.links;
 
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.AbstractApiCmd;
+import io.seqera.tower.model.DataLinkDto;
 
 public class AbstractDataLinksCmd extends AbstractApiCmd {
 
@@ -27,7 +28,15 @@ public class AbstractDataLinksCmd extends AbstractApiCmd {
     }
 
     protected String getDataLinkId(DataLinkRefOptions dataLinkRefOptions, Long wspId, String credId) throws ApiException {
+        // if DataLink ID is supplied - use that directly
+        if (dataLinkRefOptions.dataLinkRef.dataLinkId != null) {
+            return dataLinkRefOptions.dataLinkRef.dataLinkId;
+        }
+        return getDataLink(dataLinkRefOptions, wspId, credId).getId();
+    }
+
+    protected DataLinkDto getDataLink(DataLinkRefOptions dataLinkRefOptions, Long wspId, String credId) throws ApiException  {
         DataLinkService dataLinkService = new DataLinkService(dataLinksApi(), app());
-        return dataLinkService.getDataLinkId(dataLinkRefOptions.dataLinkRef, wspId, credId);
+        return dataLinkService.getDataLink(dataLinkRefOptions.dataLinkRef, wspId, credId);
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/AddCmd.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 
 @CommandLine.Command(
         name = "add",
-        description = "Add custom data link."
+        description = "Add custom data-link."
 )
 public class AddCmd extends AbstractApiCmd {
 

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/BrowseCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/BrowseCmd.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 
 @CommandLine.Command(
         name = "browse",
-        description = "Browse content of data link."
+        description = "Browse content of data-link."
 )
 public class BrowseCmd extends AbstractDataLinksCmd {
 

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/DeleteCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/DeleteCmd.java
@@ -18,7 +18,6 @@
 package io.seqera.tower.cli.commands.data.links;
 
 import io.seqera.tower.ApiException;
-import io.seqera.tower.cli.commands.AbstractApiCmd;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.data.DataLinkDeleted;
@@ -28,7 +27,7 @@ import java.io.IOException;
 
 @CommandLine.Command(
         name = "delete",
-        description = "Delete custom data link."
+        description = "Delete custom data-link."
 )
 public class DeleteCmd extends AbstractDataLinksCmd {
 

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/DownloadCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/DownloadCmd.java
@@ -46,7 +46,7 @@ import java.util.List;
 
 @CommandLine.Command(
         name = "download",
-        description = "Download content of data link."
+        description = "Download content of data-link."
 )
 public class DownloadCmd extends AbstractDataLinksCmd {
 

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/DownloadCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/DownloadCmd.java
@@ -21,7 +21,7 @@ import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.enums.OutputType;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
 import io.seqera.tower.cli.responses.Response;
-import io.seqera.tower.cli.responses.data.DataLinkFileDownloadResult;
+import io.seqera.tower.cli.responses.data.DataLinkFileTransferResult;
 import io.seqera.tower.cli.utils.progress.ProgressInputStream;
 import io.seqera.tower.cli.utils.progress.ProgressTracker;
 import io.seqera.tower.model.DataLinkContentTreeListResponse;
@@ -72,7 +72,7 @@ public class DownloadCmd extends AbstractDataLinksCmd {
 
         String id = getDataLinkId(dataLinkRefOptions, wspId, credId);
 
-        List<DataLinkFileDownloadResult.SimplePathInfo> pathInfo = new ArrayList<>();
+        List<DataLinkFileTransferResult.SimplePathInfo> pathInfo = new ArrayList<>();
         for (String path : paths) {
             DataLinkContentTreeListResponse browseTreeResponse = dataLinksApi().exploreDataLinkTree(id, wspId, credId, List.of(path));
 
@@ -86,7 +86,7 @@ public class DownloadCmd extends AbstractDataLinksCmd {
 
                 downloadFile(path, id, credId, wspId, targetPath);
 
-                pathInfo.add(new DataLinkFileDownloadResult.SimplePathInfo(DataLinkItemType.FILE, path, 1));
+                pathInfo.add(new DataLinkFileTransferResult.SimplePathInfo(DataLinkItemType.FILE, path, 1));
             }
             else {
                 // Download each file for that prefix
@@ -99,12 +99,12 @@ public class DownloadCmd extends AbstractDataLinksCmd {
 
                     downloadFile(item.getPath(), id, credId, wspId, targetPath);
                 }
-                pathInfo.add(new DataLinkFileDownloadResult.SimplePathInfo(DataLinkItemType.FOLDER, path, browseTreeResponse.getItems().size()));
+                pathInfo.add(new DataLinkFileTransferResult.SimplePathInfo(DataLinkItemType.FOLDER, path, browseTreeResponse.getItems().size()));
             }
 
         }
 
-        return new DataLinkFileDownloadResult(pathInfo);
+        return DataLinkFileTransferResult.donwloaded(pathInfo);
     }
 
     private void downloadFile(String path, String id, String credId, Long wspId, Path targetPath) throws ApiException, IOException, InterruptedException {

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/DownloadCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/DownloadCmd.java
@@ -62,7 +62,7 @@ public class DownloadCmd extends AbstractDataLinksCmd {
     @CommandLine.Option(names = {"-o", "--output-dir"}, description = "Output directory.")
     public String outputDir;
 
-    @CommandLine.Parameters(arity = "1..*", description = "Paths to files to download")
+    @CommandLine.Parameters(arity = "1..*", description = "Paths to files or directories to download.")
     private List<String> paths;
 
     @Override

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/ListCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/ListCmd.java
@@ -18,7 +18,6 @@
 package io.seqera.tower.cli.commands.data.links;
 
 import io.seqera.tower.ApiException;
-import io.seqera.tower.cli.commands.AbstractApiCmd;
 import io.seqera.tower.cli.commands.global.PaginationOptions;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
 import io.seqera.tower.cli.responses.Response;
@@ -34,7 +33,7 @@ import java.util.List;
 
 @Command(
         name = "list",
-        description = "List data links."
+        description = "List data-links."
 )
 public class ListCmd extends AbstractDataLinksCmd {
 

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/UpdateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/UpdateCmd.java
@@ -31,7 +31,7 @@ import java.util.Objects;
 
 @CommandLine.Command(
         name = "update",
-        description = "Update custom data link."
+        description = "Update custom data-link."
 )
 public class UpdateCmd extends AbstractApiCmd {
     @CommandLine.Mixin

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/UploadCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/UploadCmd.java
@@ -29,6 +29,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.enums.OutputType;
@@ -38,10 +39,12 @@ import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.data.DataLinkFileTransferResult;
 import io.seqera.tower.cli.utils.progress.ProgressTracker;
 import io.seqera.tower.cli.utils.progress.ProgressTrackingBodyPublisher;
+import io.seqera.tower.model.DataLinkDto;
 import io.seqera.tower.model.DataLinkFinishMultiPartUploadRequest;
 import io.seqera.tower.model.DataLinkItemType;
 import io.seqera.tower.model.DataLinkMultiPartUploadRequest;
 import io.seqera.tower.model.DataLinkMultiPartUploadResponse;
+import io.seqera.tower.model.DataLinkProvider;
 import io.seqera.tower.model.UploadEtag;
 import picocli.CommandLine;
 
@@ -52,6 +55,8 @@ import picocli.CommandLine;
 public class UploadCmd extends AbstractDataLinksCmd {
 
     static final Integer MULTI_UPLOAD_PART_SIZE_IN_BYTES = 250 * 1024 * 1024; // 250 MB - synced w
+    static final long MAX_FILE_SIZE = 5L * 1024L * 1024L * 1024L * 1024L; // 5 TB
+    static final Integer MAX_FILES_TO_UPLOAD = 300;
 
     @CommandLine.Mixin
     public WorkspaceOptionalOptions workspace;
@@ -70,10 +75,14 @@ public class UploadCmd extends AbstractDataLinksCmd {
 
     @Override
     protected Response exec() throws ApiException, IOException, InterruptedException {
+        checkFilesValidForUpload();
+
         Long wspId = workspaceId(workspace.workspace);
         String credId = credentialsRef != null ? credentialsByRef(null, wspId, credentialsRef) : null;
 
-        String id = getDataLinkId(dataLinkRefOptions, wspId, credId);
+        DataLinkDto dataLink = getDataLink(dataLinkRefOptions, wspId, credId);
+        String id = dataLink.getId();
+        DataLinkProvider provider = dataLink.getProvider();
 
         List<DataLinkFileTransferResult.SimplePathInfo> pathInfo = new ArrayList<>();
 
@@ -81,10 +90,10 @@ public class UploadCmd extends AbstractDataLinksCmd {
             File file = new File(path);
             if (file.isDirectory()) {
                 String basePrefix = file.getName() + "/";
-                int fileCount = uploadDirectory(file, file, basePrefix, id, credId, wspId);
+                int fileCount = uploadDirectory(file, file, basePrefix, id, credId, wspId, provider);
                 pathInfo.add(new DataLinkFileTransferResult.SimplePathInfo(DataLinkItemType.FOLDER, path, fileCount));
             } else {
-                uploadFile(file, file.getName(), id, credId, wspId);
+                uploadFile(file, file.getName(), id, credId, wspId, provider);
                 pathInfo.add(new DataLinkFileTransferResult.SimplePathInfo(DataLinkItemType.FILE, path, 1));
             }
         }
@@ -92,25 +101,25 @@ public class UploadCmd extends AbstractDataLinksCmd {
         return DataLinkFileTransferResult.uploaded(pathInfo);
     }
 
-    private int uploadDirectory(File baseDir, File currentDir, String basePrefix, String id, String credId, Long wspId) throws ApiException, IOException, InterruptedException {
+    private int uploadDirectory(File baseDir, File currentDir, String basePrefix, String id, String credId, Long wspId, DataLinkProvider provider) throws ApiException, IOException, InterruptedException {
         File[] files = currentDir.listFiles();
         if (files == null) return 0;
 
         int totalFiles = 0;
         for (File file : files) {
             if (file.isDirectory()) {
-                totalFiles += uploadDirectory(baseDir, file, basePrefix, id, credId, wspId);
+                totalFiles += uploadDirectory(baseDir, file, basePrefix, id, credId, wspId, provider);
             } else {
                 String relativePath = baseDir.toPath().relativize(file.toPath()).toString();
                 String fullKey = basePrefix + relativePath;
-                uploadFile(file, fullKey, id, credId, wspId);
+                uploadFile(file, fullKey, id, credId, wspId, provider);
                 totalFiles++;
             }
         }
         return totalFiles;
     }
 
-    private void uploadFile(File file, String relativeKey, String id, String credId, Long wspId) throws ApiException, IOException, InterruptedException {
+    private void uploadFile(File file, String relativeKey, String id, String credId, Long wspId, DataLinkProvider provider) throws ApiException, IOException, InterruptedException {
         if (!file.exists()) {
             throw new IOException("File not found: " + file.getPath());
         }
@@ -128,8 +137,6 @@ public class UploadCmd extends AbstractDataLinksCmd {
 
         // Get upload URL
         DataLinkMultiPartUploadRequest uploadRequest = new DataLinkMultiPartUploadRequest();
-        // If output directory is specified, prepend it to the relative key
-//        String finalKey = outputDir != null ? outputDir + "/" + relativeKey : relativeKey;
         uploadRequest.setFileName(relativeKey);
         uploadRequest.setContentLength(contentLength);
         uploadRequest.setContentType(mimeType);
@@ -143,13 +150,29 @@ public class UploadCmd extends AbstractDataLinksCmd {
 
         ProgressTracker tracker = new ProgressTracker(app().getOut(), showProgress, contentLength);
 
+        switch (provider) {
+            case AWS:
+                uploadFileToAws(file, relativeKey, id, credId, wspId, urlResponse, tracker);
+                break;
+            case GOOGLE:
+                uploadFileToGoogle(file, urlResponse, tracker);
+                break;
+            case AZURE:
+                uploadFileToAzure(file, urlResponse, tracker);
+                break;
+            default:
+                throw new TowerRuntimeException("Unsupported data-link provider: " + provider);
+        }
+    }
+
+    private void uploadFileToAws(File file, String relativeKey, String id, String credId, Long wspId, DataLinkMultiPartUploadResponse urlResponse, ProgressTracker tracker) throws ApiException {
         int index = 0;
         boolean withError = false;
         List<UploadEtag> tags = new ArrayList<>();
+
         try (HttpClient client = HttpClient.newHttpClient()) {
             for (String url : urlResponse.getUploadUrls()) {
-
-                byte[] chunk = getFileChunk(file, index);
+                byte[] chunk = getChunk(file, index);
 
                 HttpRequest request = HttpRequest.newBuilder()
                         .uri(URI.create(url))
@@ -171,17 +194,16 @@ public class UploadCmd extends AbstractDataLinksCmd {
                     uploadEtag.partNumber(index+1);
                     tags.add(uploadEtag);
                 }
-                else   {
-                    throw new TowerRuntimeException("Failed to upload file: Possible CORS issue");
+                else {
+                    throw new TowerRuntimeException("Possible CORS issue");
                 }
                 index++;
             }
-
         } catch (Exception e) {
             withError = true;
             throw new TowerRuntimeException("Failed to upload file: " + e.getMessage(), e);
         } finally {
-            // Step 3: Finalize the upload
+            // Finalize the upload
             DataLinkFinishMultiPartUploadRequest finishMultiPartUploadRequest = new DataLinkFinishMultiPartUploadRequest();
             finishMultiPartUploadRequest.setFileName(relativeKey);
             finishMultiPartUploadRequest.setUploadId(urlResponse.getUploadId());
@@ -192,12 +214,128 @@ public class UploadCmd extends AbstractDataLinksCmd {
                 dataLinksApi().finishDataLinkUpload1(id, outputDir, finishMultiPartUploadRequest, credId, wspId);
             } else {
                 dataLinksApi().finishDataLinkUpload(id, finishMultiPartUploadRequest, credId, wspId);
-
             }
         }
     }
 
-    private byte[] getFileChunk(File file, int index) {
+    private void uploadFileToGoogle(File file, DataLinkMultiPartUploadResponse urlResponse, ProgressTracker tracker) throws ApiException {
+        String url = urlResponse.getUploadUrls().get(0);
+        long fileSize = file.length();
+        long nextByteToRead = 0;
+
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            while (nextByteToRead < fileSize) {
+                long end = Math.min(nextByteToRead + MULTI_UPLOAD_PART_SIZE_IN_BYTES, fileSize);
+                byte[] chunk = getChunk(file, (int)(nextByteToRead / MULTI_UPLOAD_PART_SIZE_IN_BYTES));
+
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create(url))
+                        .PUT(new ProgressTrackingBodyPublisher(chunk, tracker))
+                        .header("Content-Range", String.format("bytes %d-%d/%d", nextByteToRead, Math.max(0, end - 1), fileSize))
+                        .build();
+
+                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+                if (response.statusCode() == 308) {
+                    // Resume upload from the last byte received by the server
+                    String range = response.headers().firstValue("range").orElse("");
+                    if (!range.isEmpty()) {
+                        long lastByte = Long.parseLong(range.substring(range.lastIndexOf('-') + 1));
+                        nextByteToRead = lastByte + 1;
+                    }
+                } else if (response.statusCode() != 200) {
+                    // Cancel the upload by sending a DELETE request
+                    HttpRequest deleteRequest = HttpRequest.newBuilder()
+                            .uri(URI.create(url))
+                            .DELETE()
+                            .build();
+                    client.send(deleteRequest, HttpResponse.BodyHandlers.discarding());
+                    throw new IOException("Failed to upload file: HTTP " + response.statusCode());
+                } else {
+                    break; // Upload completed successfully
+                }
+            }
+        } catch (Exception e) {
+            throw new TowerRuntimeException("Failed to upload file: " + e.getMessage(), e);
+        }
+    }
+
+    private void uploadFileToAzure(File file, DataLinkMultiPartUploadResponse urlResponse, ProgressTracker tracker) throws ApiException {
+        List<String> urls = urlResponse.getUploadUrls();
+
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            // Upload chunks
+            for (int i = 0; i < urls.size(); i++) {
+                String url = urls.get(i);
+
+                byte[] chunk = getChunk(file, i);
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create(url))
+                        .PUT(new ProgressTrackingBodyPublisher(chunk, tracker))
+                        .build();
+
+                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+                if (response.statusCode() != 201) {
+                    throw new IOException("Failed to upload chunk: HTTP " + response.statusCode());
+                }
+            }
+
+            // Finalize the upload by sending list of block IDs
+            finalizeAzureUpload(urls, client);
+
+        } catch (Exception e) {
+            throw new TowerRuntimeException("Failed to upload file: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Finalize the Azure upload sending the list of block IDs to Azure, so it can merge all the chunks received in a single file.
+     *
+     * @param urls The list of urls generated for the Azure upload, required to obtain the list of block IDs
+     */
+    private void finalizeAzureUpload(List<String> urls, HttpClient client) throws IOException, InterruptedException {
+        String finalizeUrl = getFinalizeUrl(urls.get(0));
+        List<String> blockIds = urls.stream()
+                .map(this::extractBlockId)
+                .collect(Collectors.toList());
+
+        String blockList = buildBlockList(blockIds);
+
+        HttpRequest finalizeRequest = HttpRequest.newBuilder()
+                .uri(URI.create(finalizeUrl))
+                .PUT(HttpRequest.BodyPublishers.ofString(blockList))
+                .build();
+
+        HttpResponse<String> response = client.send(finalizeRequest, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() != 201) {
+            throw new IOException("Failed to finalize Azure upload: HTTP " + response.statusCode());
+        }
+    }
+
+    private String extractBlockId(String url) {
+        String blockIdSubstring = "blockid=";
+        int start = url.indexOf(blockIdSubstring) + blockIdSubstring.length();
+        int end = url.indexOf('&', start);
+        return end > start ? url.substring(start, end) : url.substring(start);
+    }
+
+    private String getFinalizeUrl(String initialUrl) {
+        return initialUrl.replaceAll("(blockid=[^&]*&)", "")
+                        .replaceAll("(comp=[^&]*)", "comp=blocklist");
+    }
+
+    private String buildBlockList(List<String> blockIds) {
+        StringBuilder xml = new StringBuilder("<?xml version=\"1.0\" encoding=\"utf-8\"?><BlockList>");
+        for (String id : blockIds) {
+            xml.append("<Uncommitted>").append(id).append("</Uncommitted>");
+        }
+        xml.append("</BlockList>");
+        return xml.toString();
+    }
+
+    private byte[] getChunk(File file, int index) {
         try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
             long start = (long) index * MULTI_UPLOAD_PART_SIZE_IN_BYTES;
             long end = Math.min(start + MULTI_UPLOAD_PART_SIZE_IN_BYTES, file.length());
@@ -211,5 +349,41 @@ public class UploadCmd extends AbstractDataLinksCmd {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    private void checkFilesValidForUpload() {
+        // Check total number of files across all paths
+        int totalFiles = 0;
+        for (String path : paths) {
+            File file = new File(path);
+            if (file.isDirectory()) {
+                totalFiles += countFilesInDirectoryAndCheckFileSize(file);
+            } else {
+                totalFiles++;
+            }
+
+            if (totalFiles > MAX_FILES_TO_UPLOAD) {
+                throw new TowerRuntimeException("Cannot upload more than " + MAX_FILES_TO_UPLOAD + " files at once. " +
+                        "Found at least " + totalFiles + " files at provided paths. Please reduce number of files to upload in single batch to " + MAX_FILES_TO_UPLOAD + ".");
+            }
+        }
+    }
+
+    private int countFilesInDirectoryAndCheckFileSize(File directory) {
+        File[] files = directory.listFiles();
+        if (files == null) return 0;
+
+        int count = 0;
+        for (File file : files) {
+            if (file.isDirectory()) {
+                count += countFilesInDirectoryAndCheckFileSize(file);
+            } else {
+                count++;
+                if (file.length() > MAX_FILE_SIZE) {
+                    throw new TowerRuntimeException("File " + file.getPath() + " exceeds maximum size of 5 TB to upload.");
+                }
+            }
+        }
+        return count;
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/UploadCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/UploadCmd.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.commands.data.links;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import io.seqera.tower.ApiException;
+import io.seqera.tower.cli.commands.enums.OutputType;
+import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
+import io.seqera.tower.cli.exceptions.TowerRuntimeException;
+import io.seqera.tower.cli.responses.Response;
+import io.seqera.tower.cli.responses.data.DataLinkFileTransferResult;
+import io.seqera.tower.cli.utils.progress.ProgressTracker;
+import io.seqera.tower.cli.utils.progress.ProgressTrackingBodyPublisher;
+import io.seqera.tower.model.DataLinkFinishMultiPartUploadRequest;
+import io.seqera.tower.model.DataLinkItemType;
+import io.seqera.tower.model.DataLinkMultiPartUploadRequest;
+import io.seqera.tower.model.DataLinkMultiPartUploadResponse;
+import io.seqera.tower.model.UploadEtag;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+        name = "upload",
+        description = "Upload content to data link."
+)
+public class UploadCmd extends AbstractDataLinksCmd {
+
+    static final Integer MULTI_UPLOAD_PART_SIZE_IN_BYTES = 250 * 1024 * 1024; // 250 MB - synced w
+
+    @CommandLine.Mixin
+    public WorkspaceOptionalOptions workspace;
+
+    @CommandLine.Mixin
+    public DataLinkRefOptions dataLinkRefOptions;
+
+    @CommandLine.Option(names = {"-c", "--credentials"}, description = "Credentials identifier.", required = true)
+    public String credentialsRef;
+
+    @CommandLine.Option(names = {"-o", "--output-dir"}, description = "Output directory.")
+    public String outputDir;
+
+    @CommandLine.Parameters(arity = "1..*", description = "Paths to files or directories to upload")
+    private List<String> paths;
+
+    @Override
+    protected Response exec() throws ApiException, IOException, InterruptedException {
+        Long wspId = workspaceId(workspace.workspace);
+        String credId = credentialsRef != null ? credentialsByRef(null, wspId, credentialsRef) : null;
+
+        String id = getDataLinkId(dataLinkRefOptions, wspId, credId);
+
+        List<DataLinkFileTransferResult.SimplePathInfo> pathInfo = new ArrayList<>();
+
+        for (String path : paths) {
+            File file = new File(path);
+            if (file.isDirectory()) {
+                String basePrefix = file.getName() + "/";
+                int fileCount = uploadDirectory(file, file, basePrefix, id, credId, wspId);
+                pathInfo.add(new DataLinkFileTransferResult.SimplePathInfo(DataLinkItemType.FOLDER, path, fileCount));
+            } else {
+                uploadFile(file, file.getName(), id, credId, wspId);
+                pathInfo.add(new DataLinkFileTransferResult.SimplePathInfo(DataLinkItemType.FILE, path, 1));
+            }
+        }
+
+        return DataLinkFileTransferResult.uploaded(pathInfo);
+    }
+
+    private int uploadDirectory(File baseDir, File currentDir, String basePrefix, String id, String credId, Long wspId) throws ApiException, IOException, InterruptedException {
+        File[] files = currentDir.listFiles();
+        if (files == null) return 0;
+
+        int totalFiles = 0;
+        for (File file : files) {
+            if (file.isDirectory()) {
+                totalFiles += uploadDirectory(baseDir, file, basePrefix, id, credId, wspId);
+            } else {
+                String relativePath = baseDir.toPath().relativize(file.toPath()).toString();
+                String fullKey = basePrefix + relativePath;
+                uploadFile(file, fullKey, id, credId, wspId);
+                totalFiles++;
+            }
+        }
+        return totalFiles;
+    }
+
+    private void uploadFile(File file, String relativeKey, String id, String credId, Long wspId) throws ApiException, IOException, InterruptedException {
+        if (!file.exists()) {
+            throw new IOException("File not found: " + file.getPath());
+        }
+
+        String mimeType = Files.probeContentType(file.toPath()); // Detect MIME type
+        if (mimeType == null) {
+            mimeType = "application/octet-stream";
+        }
+        long contentLength = file.length();
+
+        boolean showProgress = app().output != OutputType.json;
+        if (showProgress) {
+            app().getOut().println("Uploading file: " + file.getPath());
+        }
+
+        // Get upload URL
+        DataLinkMultiPartUploadRequest uploadRequest = new DataLinkMultiPartUploadRequest();
+        // If output directory is specified, prepend it to the relative key
+//        String finalKey = outputDir != null ? outputDir + "/" + relativeKey : relativeKey;
+        uploadRequest.setFileName(relativeKey);
+        uploadRequest.setContentLength(contentLength);
+        uploadRequest.setContentType(mimeType);
+
+        DataLinkMultiPartUploadResponse urlResponse;
+        if (outputDir != null) {
+            urlResponse = dataLinksApi().generateDataLinkUploadUrl1(id, outputDir, uploadRequest, credId, wspId, null);
+        } else {
+            urlResponse = dataLinksApi().generateDataLinkUploadUrl(id, uploadRequest, credId, wspId, null);
+        }
+
+        ProgressTracker tracker = new ProgressTracker(app().getOut(), showProgress, contentLength);
+
+        int index = 0;
+        boolean withError = false;
+        List<UploadEtag> tags = new ArrayList<>();
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            for (String url : urlResponse.getUploadUrls()) {
+
+                byte[] chunk = getFileChunk(file, index);
+
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create(url))
+                        .PUT(new ProgressTrackingBodyPublisher(chunk, tracker))
+                        .build();
+
+                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+                if (response.statusCode() != 200) {
+                    withError = true;
+                    throw new IOException("Failed to upload file: HTTP " + response.statusCode());
+                }
+
+                Optional<String> etag = response.headers().firstValue("ETag");
+
+                if (etag.isPresent()) {
+                    UploadEtag uploadEtag = new UploadEtag();
+                    uploadEtag.eTag(etag.get());
+                    uploadEtag.partNumber(index+1);
+                    tags.add(uploadEtag);
+                }
+                else   {
+                    throw new TowerRuntimeException("Failed to upload file: Possible CORS issue");
+                }
+                index++;
+            }
+
+        } catch (Exception e) {
+            withError = true;
+            throw new TowerRuntimeException("Failed to upload file: " + e.getMessage(), e);
+        } finally {
+            // Step 3: Finalize the upload
+            DataLinkFinishMultiPartUploadRequest finishMultiPartUploadRequest = new DataLinkFinishMultiPartUploadRequest();
+            finishMultiPartUploadRequest.setFileName(relativeKey);
+            finishMultiPartUploadRequest.setUploadId(urlResponse.getUploadId());
+            finishMultiPartUploadRequest.setWithError(withError);
+            finishMultiPartUploadRequest.setTags(tags);
+
+            if (outputDir != null) {
+                dataLinksApi().finishDataLinkUpload1(id, outputDir, finishMultiPartUploadRequest, credId, wspId);
+            } else {
+                dataLinksApi().finishDataLinkUpload(id, finishMultiPartUploadRequest, credId, wspId);
+
+            }
+        }
+    }
+
+    private byte[] getFileChunk(File file, int index) {
+        try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
+            long start = (long) index * MULTI_UPLOAD_PART_SIZE_IN_BYTES;
+            long end = Math.min(start + MULTI_UPLOAD_PART_SIZE_IN_BYTES, file.length());
+            int length = (int) (end - start);
+
+            byte[] buffer = new byte[length];
+            raf.seek(start);
+            raf.readFully(buffer);
+
+            return buffer;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/UploadCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/UploadCmd.java
@@ -19,43 +19,36 @@ package io.seqera.tower.cli.commands.data.links;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.io.UncheckedIOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 import io.seqera.tower.ApiException;
+import io.seqera.tower.cli.commands.data.links.upload.CloudProviderUploader;
 import io.seqera.tower.cli.commands.enums.OutputType;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
 import io.seqera.tower.cli.exceptions.TowerRuntimeException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.data.DataLinkFileTransferResult;
 import io.seqera.tower.cli.utils.progress.ProgressTracker;
-import io.seqera.tower.cli.utils.progress.ProgressTrackingBodyPublisher;
 import io.seqera.tower.model.DataLinkDto;
-import io.seqera.tower.model.DataLinkFinishMultiPartUploadRequest;
 import io.seqera.tower.model.DataLinkItemType;
 import io.seqera.tower.model.DataLinkMultiPartUploadRequest;
 import io.seqera.tower.model.DataLinkMultiPartUploadResponse;
 import io.seqera.tower.model.DataLinkProvider;
-import io.seqera.tower.model.UploadEtag;
+import io.seqera.tower.cli.commands.data.links.upload.AwsUploader;
+import io.seqera.tower.cli.commands.data.links.upload.GoogleUploader;
+import io.seqera.tower.cli.commands.data.links.upload.AzureUploader;
 import picocli.CommandLine;
 
 @CommandLine.Command(
         name = "upload",
-        description = "Upload content to data link."
+        description = "Upload content to data-link."
 )
 public class UploadCmd extends AbstractDataLinksCmd {
 
-    static final Integer MULTI_UPLOAD_PART_SIZE_IN_BYTES = 250 * 1024 * 1024; // 250 MB - synced w
     static final long MAX_FILE_SIZE = 5L * 1024L * 1024L * 1024L * 1024L; // 5 TB
+
     static final Integer MAX_FILES_TO_UPLOAD = 300;
 
     @CommandLine.Mixin
@@ -119,7 +112,7 @@ public class UploadCmd extends AbstractDataLinksCmd {
         return totalFiles;
     }
 
-    private void uploadFile(File file, String relativeKey, String id, String credId, Long wspId, DataLinkProvider provider) throws ApiException, IOException, InterruptedException {
+    private void uploadFile(File file, String relativeKey, String id, String credId, Long wspId, DataLinkProvider provider) throws ApiException, IOException {
         if (!file.exists()) {
             throw new IOException("File not found: " + file.getPath());
         }
@@ -150,204 +143,20 @@ public class UploadCmd extends AbstractDataLinksCmd {
 
         ProgressTracker tracker = new ProgressTracker(app().getOut(), showProgress, contentLength);
 
+        CloudProviderUploader uploader = createUploadStrategy(provider, id, credId, wspId, outputDir, relativeKey);
+        uploader.uploadFile(file, urlResponse, tracker);
+    }
+
+    private CloudProviderUploader createUploadStrategy(DataLinkProvider provider, String id, String credId, Long wspId, String outputDir, String relativeKey) throws ApiException {
         switch (provider) {
             case AWS:
-                uploadFileToAws(file, relativeKey, id, credId, wspId, urlResponse, tracker);
-                break;
+                return new AwsUploader(id, credId, wspId, outputDir, relativeKey, dataLinksApi());
             case GOOGLE:
-                uploadFileToGoogle(file, urlResponse, tracker);
-                break;
+                return new GoogleUploader();
             case AZURE:
-                uploadFileToAzure(file, urlResponse, tracker);
-                break;
+                return new AzureUploader();
             default:
                 throw new TowerRuntimeException("Unsupported data-link provider: " + provider);
-        }
-    }
-
-    private void uploadFileToAws(File file, String relativeKey, String id, String credId, Long wspId, DataLinkMultiPartUploadResponse urlResponse, ProgressTracker tracker) throws ApiException {
-        int index = 0;
-        boolean withError = false;
-        List<UploadEtag> tags = new ArrayList<>();
-
-        try (HttpClient client = HttpClient.newHttpClient()) {
-            for (String url : urlResponse.getUploadUrls()) {
-                byte[] chunk = getChunk(file, index);
-
-                HttpRequest request = HttpRequest.newBuilder()
-                        .uri(URI.create(url))
-                        .PUT(new ProgressTrackingBodyPublisher(chunk, tracker))
-                        .build();
-
-                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-
-                if (response.statusCode() != 200) {
-                    withError = true;
-                    throw new IOException("Failed to upload file: HTTP " + response.statusCode());
-                }
-
-                Optional<String> etag = response.headers().firstValue("ETag");
-
-                if (etag.isPresent()) {
-                    UploadEtag uploadEtag = new UploadEtag();
-                    uploadEtag.eTag(etag.get());
-                    uploadEtag.partNumber(index+1);
-                    tags.add(uploadEtag);
-                }
-                else {
-                    throw new TowerRuntimeException("Possible CORS issue");
-                }
-                index++;
-            }
-        } catch (Exception e) {
-            withError = true;
-            throw new TowerRuntimeException("Failed to upload file: " + e.getMessage(), e);
-        } finally {
-            // Finalize the upload
-            DataLinkFinishMultiPartUploadRequest finishMultiPartUploadRequest = new DataLinkFinishMultiPartUploadRequest();
-            finishMultiPartUploadRequest.setFileName(relativeKey);
-            finishMultiPartUploadRequest.setUploadId(urlResponse.getUploadId());
-            finishMultiPartUploadRequest.setWithError(withError);
-            finishMultiPartUploadRequest.setTags(tags);
-
-            if (outputDir != null) {
-                dataLinksApi().finishDataLinkUpload1(id, outputDir, finishMultiPartUploadRequest, credId, wspId);
-            } else {
-                dataLinksApi().finishDataLinkUpload(id, finishMultiPartUploadRequest, credId, wspId);
-            }
-        }
-    }
-
-    private void uploadFileToGoogle(File file, DataLinkMultiPartUploadResponse urlResponse, ProgressTracker tracker) throws ApiException {
-        String url = urlResponse.getUploadUrls().get(0);
-        long fileSize = file.length();
-        long nextByteToRead = 0;
-
-        try (HttpClient client = HttpClient.newHttpClient()) {
-            while (nextByteToRead < fileSize) {
-                long end = Math.min(nextByteToRead + MULTI_UPLOAD_PART_SIZE_IN_BYTES, fileSize);
-                byte[] chunk = getChunk(file, (int)(nextByteToRead / MULTI_UPLOAD_PART_SIZE_IN_BYTES));
-
-                HttpRequest request = HttpRequest.newBuilder()
-                        .uri(URI.create(url))
-                        .PUT(new ProgressTrackingBodyPublisher(chunk, tracker))
-                        .header("Content-Range", String.format("bytes %d-%d/%d", nextByteToRead, Math.max(0, end - 1), fileSize))
-                        .build();
-
-                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-
-                if (response.statusCode() == 308) {
-                    // Resume upload from the last byte received by the server
-                    String range = response.headers().firstValue("range").orElse("");
-                    if (!range.isEmpty()) {
-                        long lastByte = Long.parseLong(range.substring(range.lastIndexOf('-') + 1));
-                        nextByteToRead = lastByte + 1;
-                    }
-                } else if (response.statusCode() != 200) {
-                    // Cancel the upload by sending a DELETE request
-                    HttpRequest deleteRequest = HttpRequest.newBuilder()
-                            .uri(URI.create(url))
-                            .DELETE()
-                            .build();
-                    client.send(deleteRequest, HttpResponse.BodyHandlers.discarding());
-                    throw new IOException("Failed to upload file: HTTP " + response.statusCode());
-                } else {
-                    break; // Upload completed successfully
-                }
-            }
-        } catch (Exception e) {
-            throw new TowerRuntimeException("Failed to upload file: " + e.getMessage(), e);
-        }
-    }
-
-    private void uploadFileToAzure(File file, DataLinkMultiPartUploadResponse urlResponse, ProgressTracker tracker) throws ApiException {
-        List<String> urls = urlResponse.getUploadUrls();
-
-        try (HttpClient client = HttpClient.newHttpClient()) {
-            // Upload chunks
-            for (int i = 0; i < urls.size(); i++) {
-                String url = urls.get(i);
-
-                byte[] chunk = getChunk(file, i);
-                HttpRequest request = HttpRequest.newBuilder()
-                        .uri(URI.create(url))
-                        .PUT(new ProgressTrackingBodyPublisher(chunk, tracker))
-                        .build();
-
-                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-
-                if (response.statusCode() != 201) {
-                    throw new IOException("Failed to upload chunk: HTTP " + response.statusCode());
-                }
-            }
-
-            // Finalize the upload by sending list of block IDs
-            finalizeAzureUpload(urls, client);
-
-        } catch (Exception e) {
-            throw new TowerRuntimeException("Failed to upload file: " + e.getMessage(), e);
-        }
-    }
-
-    /**
-     * Finalize the Azure upload sending the list of block IDs to Azure, so it can merge all the chunks received in a single file.
-     *
-     * @param urls The list of urls generated for the Azure upload, required to obtain the list of block IDs
-     */
-    private void finalizeAzureUpload(List<String> urls, HttpClient client) throws IOException, InterruptedException {
-        String finalizeUrl = getFinalizeUrl(urls.get(0));
-        List<String> blockIds = urls.stream()
-                .map(this::extractBlockId)
-                .collect(Collectors.toList());
-
-        String blockList = buildBlockList(blockIds);
-
-        HttpRequest finalizeRequest = HttpRequest.newBuilder()
-                .uri(URI.create(finalizeUrl))
-                .PUT(HttpRequest.BodyPublishers.ofString(blockList))
-                .build();
-
-        HttpResponse<String> response = client.send(finalizeRequest, HttpResponse.BodyHandlers.ofString());
-
-        if (response.statusCode() != 201) {
-            throw new IOException("Failed to finalize Azure upload: HTTP " + response.statusCode());
-        }
-    }
-
-    private String extractBlockId(String url) {
-        String blockIdSubstring = "blockid=";
-        int start = url.indexOf(blockIdSubstring) + blockIdSubstring.length();
-        int end = url.indexOf('&', start);
-        return end > start ? url.substring(start, end) : url.substring(start);
-    }
-
-    private String getFinalizeUrl(String initialUrl) {
-        return initialUrl.replaceAll("(blockid=[^&]*&)", "")
-                        .replaceAll("(comp=[^&]*)", "comp=blocklist");
-    }
-
-    private String buildBlockList(List<String> blockIds) {
-        StringBuilder xml = new StringBuilder("<?xml version=\"1.0\" encoding=\"utf-8\"?><BlockList>");
-        for (String id : blockIds) {
-            xml.append("<Uncommitted>").append(id).append("</Uncommitted>");
-        }
-        xml.append("</BlockList>");
-        return xml.toString();
-    }
-
-    private byte[] getChunk(File file, int index) {
-        try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
-            long start = (long) index * MULTI_UPLOAD_PART_SIZE_IN_BYTES;
-            long end = Math.min(start + MULTI_UPLOAD_PART_SIZE_IN_BYTES, file.length());
-            int length = (int) (end - start);
-
-            byte[] buffer = new byte[length];
-            raf.seek(start);
-            raf.readFully(buffer);
-
-            return buffer;
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
         }
     }
 
@@ -360,6 +169,9 @@ public class UploadCmd extends AbstractDataLinksCmd {
                 totalFiles += countFilesInDirectoryAndCheckFileSize(file);
             } else {
                 totalFiles++;
+                if (file.length() > MAX_FILE_SIZE) {
+                    throw new TowerRuntimeException("File " + file.getPath() + " exceeds maximum size of 5 TB to upload.");
+                }
             }
 
             if (totalFiles > MAX_FILES_TO_UPLOAD) {

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/UploadCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/UploadCmd.java
@@ -63,7 +63,7 @@ public class UploadCmd extends AbstractDataLinksCmd {
     @CommandLine.Option(names = {"-o", "--output-dir"}, description = "Output directory.")
     public String outputDir;
 
-    @CommandLine.Parameters(arity = "1..*", description = "Paths to files or directories to upload")
+    @CommandLine.Parameters(arity = "1..*", description = "Paths to files or directories to upload.")
     private List<String> paths;
 
     @Override

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/upload/AbstractProviderUploader.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/upload/AbstractProviderUploader.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.commands.data.links.upload;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.io.UncheckedIOException;
+
+public abstract class AbstractProviderUploader implements CloudProviderUploader {
+
+    static final Integer MULTI_UPLOAD_PART_SIZE_IN_BYTES = 250 * 1024 * 1024; // 250 MB
+
+    protected byte[] getChunk(File file, int index) {
+        try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
+            long start = (long) index * MULTI_UPLOAD_PART_SIZE_IN_BYTES;
+            long end = Math.min(start + MULTI_UPLOAD_PART_SIZE_IN_BYTES, file.length());
+            int length = (int) (end - start);
+
+            byte[] buffer = new byte[length];
+            raf.seek(start);
+            raf.readFully(buffer);
+
+            return buffer;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+} 

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/upload/AwsUploader.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/upload/AwsUploader.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.commands.data.links.upload;
+
+import io.seqera.tower.ApiException;
+import io.seqera.tower.api.DataLinksApi;
+import io.seqera.tower.cli.exceptions.TowerRuntimeException;
+import io.seqera.tower.cli.utils.progress.ProgressTracker;
+import io.seqera.tower.cli.utils.progress.ProgressTrackingBodyPublisher;
+import io.seqera.tower.model.DataLinkFinishMultiPartUploadRequest;
+import io.seqera.tower.model.DataLinkMultiPartUploadResponse;
+import io.seqera.tower.model.UploadEtag;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class AwsUploader extends AbstractProviderUploader {
+
+    private final String id;
+    private final String credId;
+    private final Long wspId;
+    private final String outputDir;
+    private final String relativeKey;
+    private final DataLinksApi dataLinksApi;
+
+    public AwsUploader(String id, String credId, Long wspId, String outputDir, String relativeKey, DataLinksApi dataLinksApi) {
+        this.id = id;
+        this.credId = credId;
+        this.wspId = wspId;
+        this.outputDir = outputDir;
+        this.relativeKey = relativeKey;
+        this.dataLinksApi = dataLinksApi;
+    }
+
+    @Override
+    public void uploadFile(File file, DataLinkMultiPartUploadResponse urlResponse, ProgressTracker tracker) throws ApiException {
+        int index = 0;
+        boolean withError = false;
+        List<UploadEtag> tags = new ArrayList<>();
+
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            for (String url : urlResponse.getUploadUrls()) {
+                byte[] chunk = getChunk(file, index);
+
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create(url))
+                        .PUT(new ProgressTrackingBodyPublisher(chunk, tracker))
+                        .build();
+
+                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+                if (response.statusCode() != 200) {
+                    withError = true;
+                    throw new IOException("Failed to upload file: HTTP " + response.statusCode());
+                }
+
+                Optional<String> etag = response.headers().firstValue("ETag");
+
+                if (etag.isPresent()) {
+                    UploadEtag uploadEtag = new UploadEtag();
+                    uploadEtag.eTag(etag.get());
+                    uploadEtag.partNumber(index+1);
+                    tags.add(uploadEtag);
+                }
+                else {
+                    throw new TowerRuntimeException("Failed to upload file: Possible CORS issue");
+                }
+                index++;
+            }
+        } catch (Exception e) {
+            withError = true;
+            throw new TowerRuntimeException("Failed to upload file: " + e.getMessage(), e);
+        } finally {
+            // Finalize the upload
+            DataLinkFinishMultiPartUploadRequest finishMultiPartUploadRequest = new DataLinkFinishMultiPartUploadRequest();
+            finishMultiPartUploadRequest.setFileName(relativeKey);
+            finishMultiPartUploadRequest.setUploadId(urlResponse.getUploadId());
+            finishMultiPartUploadRequest.setWithError(withError);
+            finishMultiPartUploadRequest.setTags(tags);
+
+            if (outputDir != null) {
+                dataLinksApi.finishDataLinkUpload1(id, outputDir, finishMultiPartUploadRequest, credId, wspId);
+            } else {
+                dataLinksApi.finishDataLinkUpload(id, finishMultiPartUploadRequest, credId, wspId);
+            }
+        }
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/upload/AzureUploader.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/upload/AzureUploader.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.commands.data.links.upload;
+
+import io.seqera.tower.cli.exceptions.TowerRuntimeException;
+import io.seqera.tower.cli.utils.progress.ProgressTracker;
+import io.seqera.tower.cli.utils.progress.ProgressTrackingBodyPublisher;
+import io.seqera.tower.model.DataLinkMultiPartUploadResponse;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AzureUploader extends AbstractProviderUploader {
+
+    @Override
+    public void uploadFile(File file, DataLinkMultiPartUploadResponse urlResponse, ProgressTracker tracker) {
+        List<String> urls = urlResponse.getUploadUrls();
+
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            // Upload chunks
+            for (int i = 0; i < urls.size(); i++) {
+                String url = urls.get(i);
+                byte[] chunk = getChunk(file, i);
+
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create(url))
+                        .PUT(new ProgressTrackingBodyPublisher(chunk, tracker))
+                        .build();
+
+                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+                if (response.statusCode() != 201) {
+                    throw new IOException("Failed to upload chunk: HTTP " + response.statusCode());
+                }
+            }
+
+            // Finalize the upload by sending list of block IDs
+            finalizeAzureUpload(urls, client);
+
+        } catch (Exception e) {
+            throw new TowerRuntimeException("Failed to upload file: " + e.getMessage(), e);
+        }
+    }
+
+    private void finalizeAzureUpload(List<String> urls, HttpClient client) throws IOException, InterruptedException {
+        String finalizeUrl = getFinalizeUrl(urls.get(0));
+        List<String> blockIds = urls.stream()
+                .map(this::extractBlockId)
+                .collect(Collectors.toList());
+
+        String blockList = buildBlockList(blockIds);
+
+        HttpRequest finalizeRequest = HttpRequest.newBuilder()
+                .uri(URI.create(finalizeUrl))
+                .PUT(HttpRequest.BodyPublishers.ofString(blockList))
+                .build();
+
+        HttpResponse<String> response = client.send(finalizeRequest, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() != 201) {
+            throw new IOException("Failed to finalize Azure upload: HTTP " + response.statusCode());
+        }
+    }
+
+    private String extractBlockId(String url) {
+        String blockIdSubstring = "blockid=";
+        int start = url.indexOf(blockIdSubstring) + blockIdSubstring.length();
+        int end = url.indexOf('&', start);
+        return end > start ? url.substring(start, end) : url.substring(start);
+    }
+
+    private String getFinalizeUrl(String initialUrl) {
+        return initialUrl.replaceAll("(blockid=[^&]*&)", "")
+                        .replaceAll("(comp=[^&]*)", "comp=blocklist");
+    }
+
+    private String buildBlockList(List<String> blockIds) {
+        StringBuilder xml = new StringBuilder("<?xml version=\"1.0\" encoding=\"utf-8\"?><BlockList>");
+        for (String id : blockIds) {
+            xml.append("<Uncommitted>").append(id).append("</Uncommitted>");
+        }
+        xml.append("</BlockList>");
+        return xml.toString();
+    }
+} 

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/upload/CloudProviderUploader.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/upload/CloudProviderUploader.java
@@ -28,9 +28,17 @@ public interface CloudProviderUploader {
      * Upload a file using the provider-specific strategy
      *
      * @param file The file to upload
-     * @param urlResponse The upload URLs and metadata from the server
+     * @param urlResponse The upload URLs and metadata from Platform
      * @param tracker Progress tracker for upload status
      * @throws ApiException If there's an error communicating with the API
      */
     void uploadFile(File file, DataLinkMultiPartUploadResponse urlResponse, ProgressTracker tracker) throws ApiException;
-} 
+
+    /**
+     * Abort upload of a file using the provider-specific strategy
+     *
+     * @param urlResponse The upload URLs and metadata from Platform
+     * @throws ApiException If there's an error communicating with the API
+     */
+    void abortUpload(DataLinkMultiPartUploadResponse urlResponse) throws ApiException;
+}

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/upload/CloudProviderUploader.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/upload/CloudProviderUploader.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.commands.data.links.upload;
+
+import io.seqera.tower.ApiException;
+import io.seqera.tower.cli.utils.progress.ProgressTracker;
+import io.seqera.tower.model.DataLinkMultiPartUploadResponse;
+
+import java.io.File;
+
+public interface CloudProviderUploader {
+    /**
+     * Upload a file using the provider-specific strategy
+     *
+     * @param file The file to upload
+     * @param urlResponse The upload URLs and metadata from the server
+     * @param tracker Progress tracker for upload status
+     * @throws ApiException If there's an error communicating with the API
+     */
+    void uploadFile(File file, DataLinkMultiPartUploadResponse urlResponse, ProgressTracker tracker) throws ApiException;
+} 

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/upload/GoogleUploader.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/upload/GoogleUploader.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.commands.data.links.upload;
+
+import io.seqera.tower.ApiException;
+import io.seqera.tower.cli.exceptions.TowerRuntimeException;
+import io.seqera.tower.cli.utils.progress.ProgressTracker;
+import io.seqera.tower.cli.utils.progress.ProgressTrackingBodyPublisher;
+import io.seqera.tower.model.DataLinkMultiPartUploadResponse;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public class GoogleUploader extends AbstractProviderUploader {
+
+    @Override
+    public void uploadFile(File file, DataLinkMultiPartUploadResponse urlResponse, ProgressTracker tracker) {
+        String url = urlResponse.getUploadUrls().get(0);
+        long fileSize = file.length();
+        long nextByteToRead = 0;
+
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            while (nextByteToRead < fileSize) {
+                int partNumber = (int)(nextByteToRead / MULTI_UPLOAD_PART_SIZE_IN_BYTES);
+                byte[] chunk = getChunk(file, partNumber);
+                long end = nextByteToRead + chunk.length;
+
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create(url))
+                        .PUT(new ProgressTrackingBodyPublisher(chunk, tracker))
+                        .header("Content-Range", String.format("bytes %d-%d/%d", nextByteToRead, Math.max(0, end - 1), fileSize))
+                        .build();
+
+                HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+                if (response.statusCode() == 308) {
+                    // Resume upload from the last byte received by the server
+                    String range = response.headers().firstValue("range").orElse("");
+                    if (!range.isEmpty()) {
+                        long lastByte = Long.parseLong(range.substring(range.lastIndexOf('-') + 1));
+                        nextByteToRead = lastByte + 1;
+                    }
+                } else if (response.statusCode() != 200) {
+                    // Cancel the upload by sending a DELETE request
+                    HttpRequest deleteRequest = HttpRequest.newBuilder()
+                            .uri(URI.create(url))
+                            .DELETE()
+                            .build();
+                    client.send(deleteRequest, HttpResponse.BodyHandlers.discarding());
+                    throw new IOException("Failed to upload file: HTTP " + response.statusCode());
+                } else {
+                    break; // Upload completed successfully
+                }
+            }
+        } catch (Exception e) {
+            throw new TowerRuntimeException("Failed to upload file: " + e.getMessage(), e);
+        }
+    }
+
+} 

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/upload/GoogleUploader.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/upload/GoogleUploader.java
@@ -67,18 +67,26 @@ public class GoogleUploader extends AbstractProviderUploader {
                 }
             }
         } catch (Exception e) {
-            try {
-                // Cancel the upload by sending a DELETE request
-                HttpRequest deleteRequest = HttpRequest.newBuilder()
-                        .uri(URI.create(url))
-                        .DELETE()
-                        .build();
-                client.send(deleteRequest, HttpResponse.BodyHandlers.discarding());
-            } catch (Exception deleteError) {
-                throw new TowerRuntimeException("Failed to upload file and encountered error while attempting to cancel upload " + e.getMessage(), e);
-            }
+            abortUpload(urlResponse);
             throw new TowerRuntimeException("Failed to upload file: " + e.getMessage(), e);
         }
     }
 
-} 
+    @Override
+    public void abortUpload(DataLinkMultiPartUploadResponse urlResponse) {
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            String url = urlResponse.getUploadUrls().get(0);
+
+            // Cancel the upload by sending a DELETE request
+            HttpRequest deleteRequest = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .DELETE()
+                    .build();
+
+            client.send(deleteRequest, HttpResponse.BodyHandlers.discarding());
+        } catch (Exception e) {
+            throw new TowerRuntimeException("Failed to upload file and encountered error while attempting to cancel upload " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/responses/data/DataLinkFileTransferResult.java
+++ b/src/main/java/io/seqera/tower/cli/responses/data/DataLinkFileTransferResult.java
@@ -25,17 +25,28 @@ import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.utils.TableList;
 import io.seqera.tower.model.DataLinkItemType;
 
-public class DataLinkFileDownloadResult extends Response {
+public class DataLinkFileTransferResult extends Response {
 
+    public final FileTransferDirection transferDirection;
     public final List<SimplePathInfo> paths;
 
-    public DataLinkFileDownloadResult(List<SimplePathInfo> paths) {
+    public static DataLinkFileTransferResult donwloaded(List<SimplePathInfo> paths) {
+        return new DataLinkFileTransferResult(paths, FileTransferDirection.DOWNLOAD);
+    }
+
+    public static DataLinkFileTransferResult uploaded(List<SimplePathInfo> paths) {
+        return new DataLinkFileTransferResult(paths, FileTransferDirection.UPLOAD);
+    }
+
+    public DataLinkFileTransferResult(List<SimplePathInfo> paths, FileTransferDirection transferDirection) {
         this.paths = paths;
+        this.transferDirection = transferDirection;
     }
 
     @Override
     public void toString(PrintWriter out) {
-        out.println(ansi(String.format("%n  @|bold Successfully downloaded files |@%n")));
+        String transferDirectionLabel = transferDirection == FileTransferDirection.DOWNLOAD ? "downloaded" : "uploaded";
+        out.println(ansi(String.format("%n  @|bold Successfully %s files |@%n", transferDirectionLabel)));
         out.println("");
 
         List<String> descriptions = new ArrayList<>(List.of( "Type", "File count","Path"));
@@ -68,8 +79,10 @@ public class DataLinkFileDownloadResult extends Response {
             this.path = path;
             this.fileCount = fileCount;
         }
-
-
     }
+    public static enum FileTransferDirection  {
+        DOWNLOAD, UPLOAD
+    }
+
 
 }

--- a/src/test/java/io/seqera/tower/cli/data/DataLinksCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/data/DataLinksCmdTest.java
@@ -30,6 +30,7 @@ import io.seqera.tower.cli.responses.data.DataLinkFileTransferResult;
 import io.seqera.tower.cli.responses.data.DataLinksList;
 import io.seqera.tower.cli.utils.PaginationInfo;
 import io.seqera.tower.model.DataLinkDto;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -40,6 +41,7 @@ import org.mockserver.model.MediaType;
 import org.mockserver.verify.VerificationTimes;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -56,6 +58,11 @@ import static org.mockserver.model.HttpResponse.response;
 import static org.mockserver.model.JsonBody.json;
 
 public class DataLinksCmdTest extends BaseCmdTest {
+
+    @BeforeEach
+    void init(MockServerClient mock) {
+        mock.reset();
+    }
 
     @ParameterizedTest
     @CsvSource(delimiter = ';', value = {
@@ -968,5 +975,267 @@ public class DataLinksCmdTest extends BaseCmdTest {
         assertEquals(0, out.exitCode);
 
         Files.deleteIfExists(testFile);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = OutputType.class, names = {"json"})
+    void testUploadSingleFileToGoogle(OutputType format, MockServerClient mock) throws IOException {
+        // credentials fetch
+        mock.when(
+                request().withMethod("GET").withPath("/credentials").withQueryStringParameter("workspaceId", "75887156211589"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"credentials\":[{\"id\":\"google-creds-id\",\"name\":\"google\",\"description\":null,\"discriminator\":\"google\",\"baseUrl\":null,\"category\":null,\"deleted\":null,\"lastUsed\":\"2021-09-09T07:20:53Z\",\"dateCreated\":\"2021-09-08T05:48:51Z\",\"lastUpdated\":\"2021-09-08T05:48:51Z\"}]}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        // status check
+        mock.when(
+                request()
+                        .withMethod("GET").withPath("/data-links")
+                        .withQueryStringParameter("workspaceId", "75887156211589")
+                        .withQueryStringParameter("offset", "0")
+                        .withQueryStringParameter("max", "1"),
+                exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("data/links/datalinks_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        // mock fetch data links list
+        mock.when(
+                request().withMethod("GET").withPath("/data-links")
+                        .withQueryStringParameter("workspaceId", "75887156211589")
+                        .withQueryStringParameter("search", "google-storage"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(json("""
+                        {
+                          "dataLinks": [
+                            {
+                              "id": "v1-cloud-google-storage-id",
+                              "name": "google-storage",
+                              "description": null,
+                              "resourceRef": "gs://google-storage",
+                              "type": "bucket",
+                              "provider": "google",
+                              "region": "us-west-2",
+                              "credentials": [
+                                {
+                                  "id": "google-creds-id",
+                                  "name": "google",
+                                  "provider": "google"
+                                }
+                              ],
+                              "publicAccessible": false,
+                              "hidden": false,
+                              "status": null,
+                              "message": null
+                            }
+                          ]
+                        }
+                        """)).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        // Create a test file
+        Path testFile = tempDir().resolve("test.txt");
+        String content = "test content";
+        Files.write(testFile, content.getBytes());
+
+        // Mock multipart upload request
+        mock.when(
+                request()
+                        .withMethod("POST").withPath("/data-links/v1-cloud-google-storage-id/upload")
+                        .withQueryStringParameter("workspaceId", "75887156211589")
+                        .withQueryStringParameter("credentialsId", "google-creds-id"),
+                exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\n" +
+                        "    \"uploadId\": \"upload-123\",\n" +
+                        "    \"uploadUrls\": [\"http://localhost:" + mock.getPort() + "/upload\"]\n" +
+                        "}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        // Mock the actual upload with resumable upload behavior
+        mock.when(
+                request()
+                        .withMethod("PUT")
+                        .withPath("/upload")
+                        .withHeader("Content-Range", "bytes 0-" + (content.length() - 1) + "/" + content.length()),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+        );
+
+        ExecOut out = exec(format, mock, "data-links", "upload", "-w", "75887156211589", "-n", "google-storage",
+                "-c", "google-creds-id", testFile.toString());
+
+        assertOutput(format, out, DataLinkFileTransferResult.uploaded(List.of(
+                new DataLinkFileTransferResult.SimplePathInfo(DataLinkItemType.FILE, testFile.toString(), 1)
+        )));
+
+        // No errors thrown
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+
+        Files.deleteIfExists(testFile);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = OutputType.class, names = {"json"})
+    void testUploadSingleFileToAzure(OutputType format, MockServerClient mock) throws IOException {
+        // credentials fetch
+        mock.when(
+                request().withMethod("GET").withPath("/credentials").withQueryStringParameter("workspaceId", "75887156211589"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"credentials\":[{\"id\":\"azure-creds-id\",\"name\":\"azure\",\"description\":null,\"discriminator\":\"azure\",\"baseUrl\":null,\"category\":null,\"deleted\":null,\"lastUsed\":\"2021-09-09T07:20:53Z\",\"dateCreated\":\"2021-09-08T05:48:51Z\",\"lastUpdated\":\"2021-09-08T05:48:51Z\"}]}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        // status check
+        mock.when(
+                request()
+                        .withMethod("GET").withPath("/data-links")
+                        .withQueryStringParameter("workspaceId", "75887156211589")
+                        .withQueryStringParameter("offset", "0")
+                        .withQueryStringParameter("max", "1"),
+                exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("data/links/datalinks_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        // mock fetch data links list
+        mock.when(
+                request().withMethod("GET").withPath("/data-links")
+                        .withQueryStringParameter("workspaceId", "75887156211589")
+                        .withQueryStringParameter("search", "azure-storage"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(json("""
+                        {
+                          "dataLinks": [
+                            {
+                              "id": "v1-cloud-azurestorage-id",
+                              "name": "azure-storage",
+                              "description": null,
+                              "resourceRef": "az://azure-storage",
+                              "type": "bucket",
+                              "provider": "azure",
+                              "region": "us-west-2",
+                              "credentials": [
+                                {
+                                  "id": "azure-creds-id",
+                                  "name": "azure",
+                                  "provider": "azure"
+                                }
+                              ],
+                              "publicAccessible": false,
+                              "hidden": false,
+                              "status": null,
+                              "message": null
+                            }
+                          ]
+                        }
+                        """)).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        // Create a test file
+        Path testFile = tempDir().resolve("test.txt");
+        String content = "test content";
+        Files.write(testFile, content.getBytes());
+
+        // Mock multipart upload request with block IDs
+        mock.when(
+                request()
+                        .withMethod("POST").withPath("/data-links/v1-cloud-azurestorage-id/upload")
+                        .withQueryStringParameter("workspaceId", "75887156211589")
+                        .withQueryStringParameter("credentialsId", "azure-creds-id"),
+                exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\n" +
+                        "    \"uploadId\": \"upload-123\",\n" +
+                        "    \"uploadUrls\": [\"http://localhost:" + mock.getPort() + "/upload?blockid=block1&comp=block\"]\n" +
+                        "}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        // Mock the block upload
+        mock.when(
+                request()
+                        .withMethod("PUT")
+                        .withPath("/upload")
+                        .withQueryStringParameter("blockid", "block1")
+                        .withQueryStringParameter("comp", "block"),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(201)
+        );
+
+        // Mock the block list finalization
+        mock.when(
+                request()
+                        .withMethod("PUT")
+                        .withPath("/upload")
+                        .withQueryStringParameter("comp", "blocklist")
+                        .withBody("<?xml version=\"1.0\" encoding=\"utf-8\"?><BlockList><Uncommitted>block1</Uncommitted></BlockList>"),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(201)
+        );
+
+        ExecOut out = exec(format, mock, "data-links", "upload", "-w", "75887156211589", "-n", "azure-storage",
+                "-c", "azure-creds-id", testFile.toString());
+
+        assertOutput(format, out, DataLinkFileTransferResult.uploaded(List.of(
+                new DataLinkFileTransferResult.SimplePathInfo(DataLinkItemType.FILE, testFile.toString(), 1)
+        )));
+
+        // No errors thrown
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+
+        Files.deleteIfExists(testFile);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = OutputType.class, names = {"json"})
+    void testUploadTooManyFiles(OutputType format, MockServerClient mock) throws IOException {
+        // Create a temporary directory with more than 300 files
+        Path tempDirectory = tempDir().resolve("many-files");
+        Files.createDirectories(tempDirectory);
+        
+        // Create 301 files
+        for (int i = 0; i < 301; i++) {
+            Path file = tempDirectory.resolve("file" + i + ".txt");
+            Files.write(file, ("content " + i).getBytes());
+        }
+
+        // credentials fetch
+        mock.when(
+                request().withMethod("GET").withPath("/credentials").withQueryStringParameter("workspaceId", "75887156211589"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"credentials\":[{\"id\":\"aws-creds-id\",\"name\":\"aws\",\"description\":null,\"discriminator\":\"aws\",\"baseUrl\":null,\"category\":null,\"deleted\":null,\"lastUsed\":\"2021-09-09T07:20:53Z\",\"dateCreated\":\"2021-09-08T05:48:51Z\",\"lastUpdated\":\"2021-09-08T05:48:51Z\"}]}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(format, mock, "data-links", "upload", "-w", "75887156211589", "-n", "aws-storage",
+                "-c", "aws-creds-id", tempDirectory.toString());
+
+        // Verify error message
+        assertEquals(errorMessage(out.app, new TowerRuntimeException("Cannot upload more than 300 files at once. Found at least 301 files at provided paths. Please reduce number of files to upload in single batch to 300.")), out.stdErr);
+        assertEquals("", out.stdOut);
+        assertEquals(1, out.exitCode);
+
+        // Cleanup
+        deleteDirectory(tempDirectory);
+    }
+
+    private void deleteDirectory(Path directory) throws IOException {
+        if (Files.exists(directory)) {
+            Files.walk(directory)
+                    .sorted((a, b) -> b.compareTo(a))
+                    .forEach(path -> {
+                        try {
+                            Files.deleteIfExists(path);
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    });
+        }
     }
 }


### PR DESCRIPTION
Closes: https://github.com/seqeralabs/tower-cli/issues/408 - alternative implementation to the download/upload logic with copy notation proposed in the issue. Instead explicit download and upload commands have been implemented.

Add support for `tw data-link upload` command to upload files and directories to data-link.

```
tw data-links upload --name a-test-bucket -c gcp ~/Work/testdir/uploads/subfolder

Uploading file: /Users/georgi.hristov/Work/testdir/uploads/subfolder/subfolder2/subfolder3/Ciao.txt
 Progress: [========================================] 100% (12/12 bytes, ETA: 0.0s)
Uploading file: /Users/georgi.hristov/Work/testdir/uploads/subfolder/subfolder2/subfolder3/subfolder4/subfolder5/Ciao.txt
 Progress: [========================================] 100% (12/12 bytes, ETA: 0.0s)
Uploading file: /Users/georgi.hristov/Work/testdir/uploads/subfolder/subfolder2/subfolder3/subfolder4/Hello.txt
 Progress: [========================================] 100% (13/13 bytes, ETA: 0.0s)
Uploading file: /Users/georgi.hristov/Work/testdir/uploads/subfolder/subfolder2/Hello.txt
```