### PR TITLE
feat(PLAT-2723): Support creation of Seqera Compute environments

### DIFF
--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -472,6 +472,12 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"io.seqera.tower.cli.commands.computeenvs.add.AddSeqeraComputeCmd",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"io.seqera.tower.cli.commands.computeenvs.add.AddSlurmCmd",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
@@ -665,6 +671,12 @@
   "name":"io.seqera.tower.cli.commands.computeenvs.platforms.MoabPlatform$AdvancedOptions",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true
+},
+{
+  "name":"io.seqera.tower.cli.commands.computeenvs.platforms.SeqeraComputePlatform",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
   "name":"io.seqera.tower.cli.commands.computeenvs.platforms.SlurmPlatform",

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/AddCmd.java
@@ -29,6 +29,7 @@ import io.seqera.tower.cli.commands.computeenvs.add.AddGoogleLifeSciencesCmd;
 import io.seqera.tower.cli.commands.computeenvs.add.AddK8sCmd;
 import io.seqera.tower.cli.commands.computeenvs.add.AddLsfCmd;
 import io.seqera.tower.cli.commands.computeenvs.add.AddMoabCmd;
+import io.seqera.tower.cli.commands.computeenvs.add.AddSeqeraComputeCmd;
 import io.seqera.tower.cli.commands.computeenvs.add.AddSlurmCmd;
 import io.seqera.tower.cli.commands.computeenvs.add.AddUgeCmd;
 import io.seqera.tower.cli.exceptions.ShowUsageException;
@@ -53,6 +54,7 @@ import java.io.IOException;
                 AddGoogleLifeSciencesCmd.class,
                 AddGoogleBatchCmd.class,
                 AddAzureCmd.class,
+                AddSeqeraComputeCmd.class
         }
 )
 public class AddCmd extends AbstractComputeEnvCmd {

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/add/AbstractAddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/add/AbstractAddCmd.java
@@ -128,6 +128,11 @@ public abstract class AbstractAddCmd extends AbstractApiCmd {
     }
 
     private String findWorkspaceCredentials(PlatformEnum type, Long wspId) throws ApiException {
+        if (type == PlatformEnum.SEQERACOMPUTE_PLATFORM) {
+            // seqera-compute handles credentials automatically
+            return null;
+        }
+
         List<Credentials> credentials = credentialsApi().listCredentials(wspId, type.getValue()).getCredentials();
         if (credentials.isEmpty()) {
             throw new TowerException("No valid credentials found at the workspace");

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/add/AddSeqeraComputeCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/add/AddSeqeraComputeCmd.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.commands.computeenvs.add;
+
+import io.seqera.tower.cli.commands.computeenvs.platforms.Platform;
+import io.seqera.tower.cli.commands.computeenvs.platforms.SeqeraComputePlatform;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+        name = "seqera-compute",
+        description = "Add new Seqera Compute environment."
+)
+public class AddSeqeraComputeCmd extends AbstractAddCmd {
+
+    @CommandLine.Mixin
+    SeqeraComputePlatform platform;
+
+    @Override
+    protected Platform getPlatform() {
+        return platform;
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AbstractPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AbstractPlatform.java
@@ -34,9 +34,6 @@ import java.util.Map;
 
 public abstract class AbstractPlatform<T extends ComputeConfig> implements Platform {
 
-    @Option(names = {"--work-dir"}, description = "Work directory.", required = true)
-    public String workDir;
-
     @ArgGroup(heading = "%nStaging options:%n", validate = false)
     public StagingOptions staging;
 

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AltairPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AltairPlatform.java
@@ -27,6 +27,9 @@ import java.io.IOException;
 
 public class AltairPlatform extends AbstractPlatform<AltairPbsComputeConfig> {
 
+    @Option(names = {"--work-dir"}, description = "Work directory.", required = true)
+    public String workDir;
+
     @Option(names = {"-u", "--user-name"}, description = "The username on the cluster used to launch the pipeline execution.")
     public String userName;
 

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AwsBatchForgePlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AwsBatchForgePlatform.java
@@ -32,6 +32,9 @@ import java.util.List;
 
 public class AwsBatchForgePlatform extends AbstractPlatform<AwsBatchConfig> {
 
+    @Option(names = {"--work-dir"}, description = "Work directory.", required = true)
+    public String workDir;
+
     @Option(names = {"-r", "--region"}, description = "AWS region.", required = true)
     public String region;
 

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AwsBatchManualPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AwsBatchManualPlatform.java
@@ -28,6 +28,9 @@ import java.io.IOException;
 
 public class AwsBatchManualPlatform extends AbstractPlatform<AwsBatchConfig> {
 
+    @Option(names = {"--work-dir"}, description = "Work directory.", required = true)
+    public String workDir;
+
     @Option(names = {"-r", "--region"}, description = "AWS region.", required = true)
     public String region;
 

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchForgePlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchForgePlatform.java
@@ -35,6 +35,9 @@ import java.util.Map;
 
 public class AzBatchForgePlatform extends AbstractPlatform<AzBatchConfig> {
 
+    @Option(names = {"--work-dir"}, description = "Work directory.", required = true)
+    public String workDir;
+
     @Option(names = {"-l", "--location"}, description = "The Azure location where the workload will be deployed.", required = true)
     public String location;
 

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchManualPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchManualPlatform.java
@@ -28,6 +28,9 @@ import java.io.IOException;
 
 public class AzBatchManualPlatform extends AbstractPlatform<AzBatchConfig> {
 
+    @Option(names = {"--work-dir"}, description = "Work directory.", required = true)
+    public String workDir;
+
     @Option(names = {"-l", "--location"}, description = "The Azure location where the workload will be deployed.", required = true)
     public String location;
 

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/EksPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/EksPlatform.java
@@ -28,6 +28,9 @@ import java.io.IOException;
 
 public class EksPlatform extends AbstractPlatform<EksComputeConfig> {
 
+    @Option(names = {"--work-dir"}, description = "Work directory.", required = true)
+    public String workDir;
+
     @Option(names = {"-r", "--region"}, description = "AWS region.", required = true)
     public String region;
 

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/GkePlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/GkePlatform.java
@@ -28,6 +28,9 @@ import java.io.IOException;
 
 public class GkePlatform extends AbstractPlatform<GkeComputeConfig> {
 
+    @Option(names = {"--work-dir"}, description = "Work directory.", required = true)
+    public String workDir;
+
     @Option(names = {"-r", "--region"}, description = "AWS region.", required = true)
     public String region;
 

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/GoogleBatchPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/GoogleBatchPlatform.java
@@ -27,6 +27,9 @@ import java.io.IOException;
 
 public class GoogleBatchPlatform extends AbstractPlatform<GoogleBatchConfig> {
 
+    @Option(names = {"--work-dir"}, description = "Work directory.", required = true)
+    public String workDir;
+
     @Option(names = {"-l", "--location"}, description = "The location where the job executions are deployed to Google Batch API.", required = true)
     public String location;
 

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/GoogleLifeSciencesPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/GoogleLifeSciencesPlatform.java
@@ -28,6 +28,9 @@ import java.util.List;
 
 public class GoogleLifeSciencesPlatform extends AbstractPlatform<GoogleLifeSciencesConfig> {
 
+    @Option(names = {"--work-dir"}, description = "Work directory.", required = true)
+    public String workDir;
+
     @Option(names = {"-r", "--region"}, description = "The region where the workload will be executed.", required = true)
     public String region;
 

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/K8sPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/K8sPlatform.java
@@ -29,6 +29,9 @@ import java.nio.file.Path;
 
 public class K8sPlatform extends AbstractPlatform<K8sComputeConfig> {
 
+    @Option(names = {"--work-dir"}, description = "Work directory.", required = true)
+    public String workDir;
+
     @Option(names = {"-s", "--server"}, description = "Master server.", required = true)
     public String server;
 

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/LsfPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/LsfPlatform.java
@@ -27,6 +27,9 @@ import java.io.IOException;
 
 public class LsfPlatform extends AbstractPlatform<LsfComputeConfig> {
 
+    @Option(names = {"--work-dir"}, description = "Work directory.", required = true)
+    public String workDir;
+
     @Option(names = {"-u", "--user-name"}, description = "The username on the cluster used to launch the pipeline execution.")
     public String userName;
 

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/MoabPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/MoabPlatform.java
@@ -27,6 +27,9 @@ import java.io.IOException;
 
 public class MoabPlatform extends AbstractPlatform<MoabComputeConfig> {
 
+    @Option(names = {"--work-dir"}, description = "Work directory.", required = true)
+    public String workDir;
+
     @Option(names = {"-u", "--user-name"}, description = "The username on the cluster used to launch the pipeline execution.")
     public String userName;
 

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/SeqeraComputePlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/SeqeraComputePlatform.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.commands.computeenvs.platforms;
+
+import io.seqera.tower.ApiException;
+import io.seqera.tower.model.ComputeEnvComputeConfig.PlatformEnum;
+import io.seqera.tower.model.SeqeraComputeConfig;
+import picocli.CommandLine;
+
+import java.io.IOException;
+
+public class SeqeraComputePlatform extends AbstractPlatform<SeqeraComputeConfig> {
+
+    @CommandLine.Option(names = {"--work-dir"}, description = "Work directory suffix relative to the S3 bucket that will be created by Seqera Compute.")
+    public String workDir;
+
+    @CommandLine.Option(names = {"-r", "--region"}, description = "AWS region.", required = true)
+    public String region;
+
+    public SeqeraComputePlatform() {
+        super(PlatformEnum.SEQERACOMPUTE_PLATFORM);
+    }
+
+    @Override
+    public SeqeraComputeConfig computeConfig() throws ApiException, IOException {
+        SeqeraComputeConfig config = new SeqeraComputeConfig();
+
+        // NOTE: even though 'SeqeraComputeConfig' extends 'AwsBatchConfig', most
+        // settings will automatically be configured by seqera compute and can't
+        // be overridden.
+
+        config
+                .region(region)
+                .preRunScript(preRunScriptString())
+                .postRunScript(postRunScriptString())
+                .nextflowConfig(nextflowConfigString())
+                .environment(environmentVariables());
+
+        return config;
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/SlurmPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/SlurmPlatform.java
@@ -27,6 +27,9 @@ import java.io.IOException;
 
 public class SlurmPlatform extends AbstractPlatform<SlurmComputeConfig> {
 
+    @Option(names = {"--work-dir"}, description = "Work directory.", required = true)
+    public String workDir;
+
     @Option(names = {"-u", "--user-name"}, description = "The username on the cluster used to launch the pipeline execution.")
     public String userName;
 

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/UnivaPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/UnivaPlatform.java
@@ -27,6 +27,9 @@ import java.io.IOException;
 
 public class UnivaPlatform extends AbstractPlatform<UnivaComputeConfig> {
 
+    @Option(names = {"--work-dir"}, description = "Work directory.", required = true)
+    public String workDir;
+
     @Option(names = {"-u", "--user-name"}, description = "The username on the cluster used to launch the pipeline execution.")
     public String userName;
 

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/SeqeraComputePlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/SeqeraComputePlatformTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.computeenvs.platforms;
+
+import io.seqera.tower.cli.BaseCmdTest;
+import io.seqera.tower.cli.commands.enums.OutputType;
+import io.seqera.tower.cli.responses.computeenvs.ComputeEnvAdded;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.model.MediaType;
+
+import java.io.IOException;
+
+import static io.seqera.tower.cli.commands.AbstractApiCmd.USER_WORKSPACE_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockserver.matchers.Times.exactly;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.model.JsonBody.json;
+
+public class SeqeraComputePlatformTest extends BaseCmdTest {
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testAdd(OutputType format, MockServerClient mock) {
+        mock.reset();
+
+        // given
+        mock.when(
+                request()
+                        .withMethod("POST")
+                        .withPath("/compute-envs")
+                        .withBody(json("""
+                                {
+                                    "computeEnv": {
+                                        "name": "my-compute-env",
+                                        "platform": "seqeracompute-platform",
+                                        "config": {
+                                            "region": "eu-west-1"
+                                        }
+                                    }
+                                }""")),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}")
+        );
+
+        // when
+        var out = exec(format, mock, "compute-envs", "add", "seqera-compute",
+                "--name", "my-compute-env",
+                "--region", "eu-west-1"
+        );
+
+        // then
+        var expected = new ComputeEnvAdded("seqeracompute-platform", "isnEDBLvHDAIteOEF44ow", "my-compute-env", null, USER_WORKSPACE_NAME);
+        assertOutput(format, out, expected);
+    }
+
+    @Test
+    void testAddWithOptions(MockServerClient mock) throws IOException {
+        mock.reset();
+
+        // given
+        mock.when(
+                request()
+                        .withMethod("POST")
+                        .withPath("/compute-envs")
+                        .withBody(json("""
+                                {
+                                    "computeEnv": {
+                                        "name": "another-compute-env",
+                                        "platform": "seqeracompute-platform",
+                                        "config": {
+                                            "region": "eu-west-2",
+                                            "preRunScript": "pre_run_me",
+                                            "postRunScript": "post_run_me",
+                                            "environment": [
+                                                { "name": "KEY1", "value": "value1", "head": true, "compute": false},
+                                                { "name": "KEY2", "value": "value2", "head": true, "compute": true}
+                                            ],
+                                            "nextflowConfig": "nextflow_config"
+                                        }
+                                    }
+                                }
+                                """)),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}")
+        );
+
+        // when
+        ExecOut out = exec(mock, "compute-envs", "add", "seqera-compute",
+                "-n", "another-compute-env",
+                "-r", "eu-west-2",
+                "--work-dir", "my-work-dir",
+                "--nextflow-config", tempFile("nextflow_config", "nextflow", "config"),
+                "-e", "head:KEY1=value1", "-e", "both:KEY2=value2",
+                "--pre-run", tempFile("pre_run_me", "pre", "sh"),
+                "--post-run", tempFile("post_run_me", "post", "sh")
+        );
+
+        // then
+        var expected = new ComputeEnvAdded("seqeracompute-platform", "isnEDBLvHDAIteOEF44ow", "another-compute-env", null, USER_WORKSPACE_NAME);
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+        assertEquals(expected.toString(), out.stdOut);
+    }
+}


### PR DESCRIPTION
Support creation of Seqera Compute environment using tower-cli.

Note: because Seqera Compute automatically creates S3 buckets for CEs, `--work-dir` is optional and has a slightly different meaning. So the `CommandLine.Option` field had to be moved out of `AbstractPlatform` and instead added to each platform individually.