### PR TITLE
Add --snapshots flag at AWS Batch forge CE

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AwsBatchForgePlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AwsBatchForgePlatform.java
@@ -59,6 +59,9 @@ public class AwsBatchForgePlatform extends AbstractPlatform<AwsBatchConfig> {
     @Option(names = {"--fast-storage"}, description = "Allow the use of NVMe instance storage to speed up I/O and disk access operations (requires Fusion v2).")
     public boolean fastStorage;
 
+    @Option(names = {"--snapshots"}, description = "Allows Fusion to automatically restore a job when it is interrupted by a spot reclamation")
+    public boolean snapshots;
+
     @Option(names = {"--fargate"}, description = "Run the Nextflow head job using the Fargate container service (requires Fusion v2 and Spot provisioning model).")
     public boolean fargate;
 
@@ -107,6 +110,7 @@ public class AwsBatchForgePlatform extends AbstractPlatform<AwsBatchConfig> {
                 .fusion2Enabled(isFusionV2Enabled())
                 .waveEnabled(wave)
                 .nvnmeStorageEnabled(fastStorage)
+                .fusionSnapshots(snapshots)
 
                 // Forge
                 .forge(buildForge())


### PR DESCRIPTION
This pull request introduces a new feature to the `AwsBatchForgePlatform` class, enabling support for Fusion snapshots. This allows jobs to be automatically restored after interruptions caused by spot reclamations.

### Feature Addition: Fusion Snapshots

* [`src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AwsBatchForgePlatform.java`](diffhunk://#diff-38331a6aac670487e6c5df23631eeb76d5e621b3c1e0ec760464564e06ed3edfR62-R64): Added a new `--snapshots` option to enable Fusion snapshots, allowing automatic restoration of jobs interrupted by spot reclamations.
* [`src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AwsBatchForgePlatform.java`](diffhunk://#diff-38331a6aac670487e6c5df23631eeb76d5e621b3c1e0ec760464564e06ed3edfR113): Updated the `computeConfig` method to include the `fusionSnapshots` configuration parameter, ensuring the snapshots feature is applied when the option is enabled.