### PR TITLE
Added response body when throwing data-link upload error

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/data/links/upload/AwsUploader.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/upload/AwsUploader.java
@@ -74,7 +74,7 @@ public class AwsUploader extends AbstractProviderUploader {
 
                 if (response.statusCode() != 200) {
                     withError = true;
-                    throw new IOException("Failed to upload file: HTTP " + response.statusCode());
+                    throw new IOException("Failed to upload file: HTTP " + response.statusCode() +"Message: " + response.body());
                 }
 
                 Optional<String> etag = response.headers().firstValue("ETag");


### PR DESCRIPTION
Added response body when throwing data-link upload error, because S3 returns the error message in the body
https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html