### PR TITLE
Plat 2365 label error handling improvements

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/labels/AddLabelsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/labels/AddLabelsCmd.java
@@ -18,19 +18,17 @@
 package io.seqera.tower.cli.commands.labels;
 
 import io.seqera.tower.ApiException;
-import io.seqera.tower.cli.commands.computeenvs.AbstractComputeEnvCmd;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
-import io.seqera.tower.cli.exceptions.ShowUsageException;
 import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.labels.LabelAdded;
+import io.seqera.tower.cli.utils.ResponseHelper;
 import io.seqera.tower.model.CreateLabelRequest;
 import io.seqera.tower.model.CreateLabelResponse;
 import picocli.CommandLine;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.io.PrintWriter;
 
 @CommandLine.Command(
         name = "add",
@@ -67,9 +65,15 @@ public class AddLabelsCmd extends AbstractLabelsCmd {
 
         try {
             CreateLabelResponse res = labelsApi().createLabel(req, wspId);
-            return new LabelAdded(res.getId(), res.getName(), res.getResource(),res.getValue(),workspaceOptionalOptions.workspace);
+            return new LabelAdded(res.getId(), res.getName(), res.getResource(), res.getValue(), workspaceOptionalOptions.workspace);
+        } catch (ApiException apiException) {
+            throw new TowerException(
+                String.format("Unable to create label for workspace '%d': %s", wspId, ResponseHelper.decodeMessage(apiException))
+            );
         } catch (Exception e) {
-            throw new TowerException(String.format("Unable to create label for workspace '%d'", wspId));
+            throw new TowerException(
+                    String.format("Unable to create label for workspace '%d': %s", wspId, e.getMessage())
+            );
         }
     }
 

--- a/src/main/java/io/seqera/tower/cli/commands/labels/DeleteLabelsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/labels/DeleteLabelsCmd.java
@@ -19,8 +19,10 @@ package io.seqera.tower.cli.commands.labels;
 
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
+import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.labels.DeleteLabelsResponse;
+import io.seqera.tower.cli.utils.ResponseHelper;
 import picocli.CommandLine;
 
 import java.io.IOException;
@@ -38,9 +40,15 @@ public class DeleteLabelsCmd extends AbstractLabelsCmd {
     public WorkspaceOptionalOptions workspaceOptionalOptions;
 
     @Override
-    protected Response exec() throws ApiException, IOException {
+    protected Response exec() throws ApiException, TowerException, IOException {
         Long wspId = workspaceId(workspaceOptionalOptions.workspace);
-        labelsApi().deleteLabel(labelId, wspId);
-        return new DeleteLabelsResponse(labelId, workspaceId(workspaceOptionalOptions.workspace));
+        try {
+            labelsApi().deleteLabel(labelId, wspId);
+            return new DeleteLabelsResponse(labelId, workspaceId(workspaceOptionalOptions.workspace));
+        } catch (ApiException e) {
+            throw new TowerException(
+                    String.format("Unable to delete label '%d' for workspace '%d': %s", labelId, wspId, ResponseHelper.decodeMessage(e))
+            );
+        }
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/labels/DeleteLabelsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/labels/DeleteLabelsCmd.java
@@ -46,9 +46,10 @@ public class DeleteLabelsCmd extends AbstractLabelsCmd {
             labelsApi().deleteLabel(labelId, wspId);
             return new DeleteLabelsResponse(labelId, workspaceId(workspaceOptionalOptions.workspace));
         } catch (ApiException e) {
-            throw new TowerException(
-                    String.format("Unable to delete label '%d' for workspace '%d': %s", labelId, wspId, ResponseHelper.decodeMessage(e))
-            );
+            String reason = e.getResponseBody() == null && e.getCode() >= 400 && e.getCode() < 500
+                    ? "Cannot find label with the provided ID"
+                    : ResponseHelper.decodeMessage(e);
+            throw new TowerException(String.format("Unable to delete label '%d' for workspace '%d': %s", labelId, wspId, reason));
         }
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/labels/UpdateLabelsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/labels/UpdateLabelsCmd.java
@@ -18,13 +18,11 @@
 package io.seqera.tower.cli.commands.labels;
 
 import io.seqera.tower.ApiException;
-import io.seqera.tower.cli.commands.computeenvs.AbstractComputeEnvCmd;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
-import io.seqera.tower.cli.exceptions.ShowUsageException;
 import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.responses.Response;
-import io.seqera.tower.cli.responses.labels.LabelAdded;
 import io.seqera.tower.cli.responses.labels.LabelUpdated;
+import io.seqera.tower.cli.utils.ResponseHelper;
 import io.seqera.tower.model.UpdateLabelRequest;
 import io.seqera.tower.model.UpdateLabelResponse;
 import picocli.CommandLine;
@@ -62,9 +60,15 @@ public class UpdateLabelsCmd extends AbstractLabelsCmd {
         Long wsp = workspaceId(workspaceRef.workspace);
         try {
             UpdateLabelResponse res = labelsApi().updateLabel(labelId, req, wsp);
-            return new LabelUpdated(res.getId(),res.getName(),res.getValue(),workspaceRef.workspace);
+            return new LabelUpdated(res.getId(), res.getName(), res.getValue(), workspaceRef.workspace);
+        } catch (ApiException e) {
+            throw new TowerException(
+                    String.format("Unable to update label '%d' for workspace '%d': %s", labelId, wsp, ResponseHelper.decodeMessage(e))
+            );
         } catch (Exception e) {
-            throw new TowerException(String.format("Unable to update label '%d' for workspace '%d'",labelId, wsp));
+            throw new TowerException(
+                    String.format("Unable to update label '%d' for workspace '%d': %s", labelId, wsp, e.getMessage())
+            );
         }
     }
 }

--- a/src/main/java/io/seqera/tower/cli/utils/ResponseHelper.java
+++ b/src/main/java/io/seqera/tower/cli/utils/ResponseHelper.java
@@ -118,7 +118,7 @@ public class ResponseHelper {
         err.println(CommandLine.Help.Ansi.AUTO.string((String.format("%n @|bold,red ERROR:|@ @|red %s|@%n", line))));
     }
 
-    private static String decodeMessage(ApiException ex) {
+    public static String decodeMessage(ApiException ex) {
         if (ex.getResponseBody() == null) {
             return ex.getMessage();
         }


### PR DESCRIPTION
# Description

Closes [PLAT-2365](https://seqera.atlassian.net/browse/PLAT-2365)

Improves the error handling in label cmd.

> [!IMPORTANT]
> Additional testing guidelines included in the Jira ticket for Seqera developers (requires local Seqera Platform instance).

# Guidelines for testing

1. In Seqera Platform (production or local dev instance):
2. Create a Tower Access Token if needed
3. Export token and API endpoint:
```
$> export TOWER_ACCESS_TOKEN=<your_token>
$> export TOWER_API_ENDPOINT=http://localhost:8000/api  // omit this if you are targeting production
```
4. Create an organization and workspace if none is available
5. Try creating a new label with invalid syntax (use `./tw --insecure` when targeting local dev instance):
```
$> ./tw labels add -w <workspace_identifier> -n test_label_# -v testValue

 ERROR: Unable to create label for workspace '268956704112485': Label name must contain a minimum of 2 and a maximum of 39 alphanumeric characters separated by dashes or underscores
```
The error message should contain the reason of the failure (invalid label name).

6. Try updating an existing label with invalid syntax:
```
$> ./tw labels update -i <label_id> -w <workspace_identifier> -n test_label_# -v testValue

 ERROR: Unable to update label '125735402225740' for workspace '268956704112485': Label name must contain a minimum of 2 and a maximum of 39 alphanumeric characters separated by dashes or underscores
```
The error message should contain the reason of the failure (invalid label name).

7. Try deleting a non-existent label:
```
$> ./tw labels delete -i <non_existent_label_id> -w <workspace_identifier>

 ERROR: Unable to delete label '185167563765341' for workspace '268956704112485': Cannot find label with the provided ID
```
The error message should contain the reason of the failure (label ID not found).




[PLAT-2365]: https://seqera.atlassian.net/browse/PLAT-2365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ