### PR TITLE
Upgrade vulnerable dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,12 +139,6 @@ tw CLI is a platform binary executable created by a native compilation from Java
 
     This ensures that SDKMan uses the tower-cli project-specific `.sdkmanrc` configuration.
 
-1. Install `native-image`:
-
-    ```bash
-    gu install native-image
-    ```
-
 1. Export your Github credentials. Github requires authentication for public packages (the token only requires the `read:packages` scope):
 
     ```bash

--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,8 @@ repositories {
 dependencies {
     implementation 'javax.activation:activation:1.1.1'
     implementation 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'ch.qos.logback:logback-core:1.2.11'
-    implementation 'ch.qos.logback:logback-classic:1.2.11'
+    implementation 'ch.qos.logback:logback-core:1.5.18'
+    implementation 'ch.qos.logback:logback-classic:1.5.18'
     implementation 'io.seqera.tower:tower-java-sdk:1.43.1'
     implementation 'info.picocli:picocli:4.6.3'
     implementation 'org.apache.commons:commons-compress:1.22'

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,13 @@ dependencies {
     implementation 'ch.qos.logback:logback-core:1.5.18'
     implementation 'ch.qos.logback:logback-classic:1.5.18'
     implementation 'io.seqera.tower:tower-java-sdk:1.43.1'
+
+    // Upgrade Jersey client dependencies to non-vulnerable 2.x version
+    implementation "org.glassfish.jersey.core:jersey-client:2.47"
+    implementation "org.glassfish.jersey.media:jersey-media-multipart:2.47"
+    implementation "org.glassfish.jersey.media:jersey-media-json-jackson:2.47"
+    implementation "org.glassfish.jersey.inject:jersey-hk2:2.47"
+
     implementation 'info.picocli:picocli:4.6.3'
     implementation 'org.apache.commons:commons-compress:1.22'
     implementation 'org.tukaani:xz:1.9'

--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,9 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:1.7.36'
     implementation 'ch.qos.logback:logback-core:1.5.18'
     implementation 'ch.qos.logback:logback-classic:1.5.18'
-    implementation 'io.seqera.tower:tower-java-sdk:1.43.1'
 
-    // Upgrade Jersey client dependencies to non-vulnerable 2.x version
+    implementation 'io.seqera.tower:tower-java-sdk:1.43.1'
+    // Upgrade transitive Jersey client dependencies to non-vulnerable 2.x version
     implementation "org.glassfish.jersey.core:jersey-client:2.47"
     implementation "org.glassfish.jersey.media:jersey-media-multipart:2.47"
     implementation "org.glassfish.jersey.media:jersey-media-json-jackson:2.47"
@@ -44,6 +44,9 @@ dependencies {
     testImplementation 'org.mock-server:mockserver-client-java:5.13.0'
     testImplementation 'org.mock-server:mockserver-netty:5.13.0'
     testImplementation 'org.mock-server:mockserver-junit-jupiter:5.13.0'
+    // Upgrade transitive mock-server dependencies to non-vulnerable 2.x version
+    testImplementation 'commons-io:commons-io:2.20.0'
+
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'

--- a/build.gradle
+++ b/build.gradle
@@ -36,14 +36,14 @@ dependencies {
     implementation "org.glassfish.jersey.inject:jersey-hk2:2.47"
 
     implementation 'info.picocli:picocli:4.6.3'
-    implementation 'org.apache.commons:commons-compress:1.22'
+    implementation 'org.apache.commons:commons-compress:1.28.0'
     implementation 'org.tukaani:xz:1.9'
     implementation 'io.github.classgraph:classgraph:4.8.165'
     annotationProcessor 'info.picocli:picocli-codegen:4.6.3'
 
-    testImplementation 'org.mock-server:mockserver-client-java:5.13.0'
-    testImplementation 'org.mock-server:mockserver-netty:5.13.0'
-    testImplementation 'org.mock-server:mockserver-junit-jupiter:5.13.0'
+    testImplementation 'org.mock-server:mockserver-client-java:5.15.0'
+    testImplementation 'org.mock-server:mockserver-netty:5.15.0'
+    testImplementation 'org.mock-server:mockserver-junit-jupiter:5.15.0'
     // Upgrade transitive mock-server dependencies to non-vulnerable 2.x version
     testImplementation 'commons-io:commons-io:2.20.0'
 

--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -5051,6 +5051,14 @@
   "allDeclaredMethods":true
 },
 {
+  "name": "org.glassfish.jersey.jackson.internal.DefaultJacksonJaxbJsonProvider",
+  "allDeclaredConstructors": true
+},
+{
+  "name": "com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector",
+  "allDeclaredConstructors": true
+},
+{
   "name":"org.jvnet.hk2.internal.DynamicConfigurationServiceImpl",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,


### PR DESCRIPTION

# Description

- Bump versions of vulnerable transitive dependencies to non-vulnerable versions.
- Remove obsolete instruction from `README.md`.

## Guildeines for testing

- [ ] Build the executable (JAR and native).
- [ ] Run commands: there are no regressions.