### PR TITLE
feat: add stdin support for file options

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
@@ -44,7 +44,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
-import static io.seqera.tower.cli.utils.FilesHelper.readString;
+import static io.seqera.tower.cli.utils.FilesHelper.readStringOrStdin;
 import static io.seqera.tower.cli.utils.ModelHelper.coalesce;
 import static io.seqera.tower.cli.utils.ModelHelper.createLaunchRequest;
 import static io.seqera.tower.cli.utils.ModelHelper.removeEmptyValues;
@@ -62,7 +62,7 @@ public class LaunchCmd extends AbstractRootCmd {
     @CommandLine.Mixin
     public WorkspaceOptionalOptions workspace;
 
-    @Option(names = {"--params-file"}, description = "Pipeline parameters in JSON or YAML format. Provide the path to a file containing the content.")
+    @Option(names = {"--params-file"}, description = "Pipeline parameters in JSON or YAML format. Provide the path to a file containing the content. Use '-' to read from stdin.")
     Path paramsFile;
 
     @Option(names = {"-c", "--compute-env"}, description = "Compute environment identifier where the pipeline will run. Defaults to workspace primary compute environment if omitted. Provide the name or identifier.")
@@ -144,11 +144,11 @@ public class LaunchCmd extends AbstractRootCmd {
                 .configProfiles(coalesce(profile, base.getConfigProfiles()))
                 .userSecrets(coalesce(removeEmptyValues(adv().userSecrets), base.getUserSecrets()))
                 .workspaceSecrets(coalesce(removeEmptyValues(adv().workspaceSecrets), base.getWorkspaceSecrets()))
-                .configText(coalesce(readString(adv().config), base.getConfigText()))
+                .configText(coalesce(readStringOrStdin(adv().config), base.getConfigText()))
                 .towerConfig(base.getTowerConfig())
-                .paramsText(coalesce(readString(paramsFile), base.getParamsText()))
-                .preRunScript(coalesce(readString(adv().preRunScript), base.getPreRunScript()))
-                .postRunScript(coalesce(readString(adv().postRunScript), base.getPostRunScript()))
+                .paramsText(coalesce(readStringOrStdin(paramsFile), base.getParamsText()))
+                .preRunScript(coalesce(readStringOrStdin(adv().preRunScript), base.getPreRunScript()))
+                .postRunScript(coalesce(readStringOrStdin(adv().postRunScript), base.getPostRunScript()))
                 .mainScript(coalesce(adv().mainScript, base.getMainScript()))
                 .entryName(coalesce(adv().entryName, base.getEntryName()))
                 .schemaName(coalesce(adv().schemaName, base.getSchemaName()))
@@ -267,13 +267,13 @@ public class LaunchCmd extends AbstractRootCmd {
 
     public static class AdvancedOptions {
 
-        @Option(names = {"--config"}, description = "Nextflow configuration as text (overrides config files). Provide the path to a file containing the content.")
+        @Option(names = {"--config"}, description = "Nextflow configuration as text (overrides config files). Provide the path to a file containing the content. Use '-' to read from stdin.")
         public Path config;
 
-        @Option(names = {"--pre-run"}, description = "Add a script that executes in the nf-launch script prior to invoking Nextflow processes. See: https://docs.seqera.io/platform-cloud/launch/advanced#pre-and-post-run-scripts. Provide the path to a file containing the content.")
+        @Option(names = {"--pre-run"}, description = "Add a script that executes in the nf-launch script prior to invoking Nextflow processes. See: https://docs.seqera.io/platform-cloud/launch/advanced#pre-and-post-run-scripts. Provide the path to a file containing the content. Use '-' to read from stdin.")
         public Path preRunScript;
 
-        @Option(names = {"--post-run"}, description = "Add a script that executes after all Nextflow processes have completed. See: https://docs.seqera.io/platform-cloud/launch/advanced#pre-and-post-run-scripts. Provide the path to a file containing the content.")
+        @Option(names = {"--post-run"}, description = "Add a script that executes after all Nextflow processes have completed. See: https://docs.seqera.io/platform-cloud/launch/advanced#pre-and-post-run-scripts. Provide the path to a file containing the content. Use '-' to read from stdin.")
         public Path postRunScript;
 
         @Option(names = {"--pull-latest"}, description = "Pull the latest version of the pipeline from the repository.")

--- a/src/main/java/io/seqera/tower/cli/utils/FilesHelper.java
+++ b/src/main/java/io/seqera/tower/cli/utils/FilesHelper.java
@@ -20,6 +20,8 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -33,6 +35,26 @@ public class FilesHelper {
             return null;
         }
         return Files.readString(path);
+    }
+
+    /**
+     * Reads file content, treating "-" as a request to read from stdin.
+     * Used by launch-related options. Does not close System.in so multiple
+     * launch options can read from stdin within the same invocation
+     * (the first reader consumes the whole stream).
+     */
+    public static String readStringOrStdin(Path path) throws IOException {
+        if (path == null) {
+            return null;
+        }
+        if ("-".equals(path.toString())) {
+            return readFromStdin(System.in);
+        }
+        return Files.readString(path);
+    }
+
+    static String readFromStdin(InputStream in) throws IOException {
+        return new String(in.readAllBytes(), StandardCharsets.UTF_8);
     }
 
     public static void saveString(String fileName, String text) {

--- a/src/test/java/io/seqera/tower/cli/utils/FilesHelperTest.java
+++ b/src/test/java/io/seqera/tower/cli/utils/FilesHelperTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.utils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class FilesHelperTest {
+
+    @Test
+    void readStringOrStdinReturnsNullForNullPath() throws IOException {
+        assertNull(FilesHelper.readStringOrStdin(null));
+    }
+
+    @Test
+    void readStringOrStdinReadsRegularFile(@TempDir Path tmp) throws IOException {
+        Path file = tmp.resolve("params.json");
+        Files.writeString(file, "{\"genome\":\"GRCh38\"}");
+        assertEquals("{\"genome\":\"GRCh38\"}", FilesHelper.readStringOrStdin(file));
+    }
+
+    @Test
+    void readStringOrStdinPreservesInputVerbatim() throws IOException {
+        // No line-ending rewrite, no trailing newline injection, UTF-8 preserved.
+        String input = "process {\n    executor = 'awsbatch'\n}\n";
+        InputStream in = new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8));
+        assertEquals(input, FilesHelper.readFromStdin(in));
+    }
+
+    @Test
+    void readStringOrStdinPreservesUtf8MultiByte() throws IOException {
+        // Non-ASCII content should survive — guards against platform-default charset.
+        String input = "name: \"αβγ — 日本語\"\n";
+        InputStream in = new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8));
+        assertEquals(input, FilesHelper.readFromStdin(in));
+    }
+
+    @Test
+    void readFromStdinDoesNotCloseInput() throws IOException {
+        // Reading must not close the underlying stream — guards against the previous
+        // try-with-resources bug where closing System.in broke subsequent reads from
+        // the same launch invocation.
+        boolean[] closed = {false};
+        InputStream in = new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8)) {
+            @Override
+            public void close() {
+                closed[0] = true;
+            }
+        };
+        FilesHelper.readFromStdin(in);
+        assertFalse(closed[0], "readFromStdin must not close the input stream");
+    }
+
+    @Test
+    void readStringOrStdinHandlesEmptyInput() throws IOException {
+        InputStream in = new ByteArrayInputStream(new byte[0]);
+        assertEquals("", FilesHelper.readFromStdin(in));
+    }
+}


### PR DESCRIPTION
This PR adds support for reading file content from stdin using the `-` convention for file-based options in pipeline launch commands.

### What's Changed

Users can now pass `-` as the value for any file option to read content from stdin instead of a file path:

- `--params-file -` - Read pipeline parameters from stdin
- `--config -` - Read Nextflow config from stdin  
- `--pre-run -` - Read pre-run script from stdin
- `--post-run -` - Read post-run script from stdin

For example:
```bash
# Pass parameters via pipe
echo '{"genome": "GRCh38"}' | tw launch my-pipeline --params-file -

# Pass config via heredoc
tw launch my-pipeline --config - <<EOF
process {
    executor = 'awsbatch'
    queue = 'my-queue'
}
EOF

# Pass pre-run script from stdin
cat setup.sh | tw launch my-pipeline --pre-run -

# Chain with other commands
curl https://example.com/params.json | tw launch my-pipeline --params-file -
```