### PR TITLE
feat: add support for resource labels in launch command

### DIFF
--- a/src/test/resources/runcmd/labels_user.json
+++ b/src/test/resources/runcmd/labels_user.json
@@ -14,7 +14,21 @@
       "value": null,
       "resource": false,
       "isDefault": false
+    },
+    {
+      "id": 11,
+      "name": "ResourceLabelOne",
+      "value": "ValueOne",
+      "resource": true,
+      "isDefault": false
+    },
+    {
+      "id": 12,
+      "name": "ResourceLabelTwo",
+      "value": "ValueTwo",
+      "resource": true,
+      "isDefault": false
     }
   ],
-  "totalsize": 2
+  "totalSize": 4
 }


### PR DESCRIPTION
Related issue: https://github.com/seqeralabs/tower-cli/issues/545

Adds support for resource labels to the `launch` command.

**Guidance for testing:**

Follow the steps in the linked issue's "steps to reproduce" and no error shoud occur.

* Create a CE with a resource label (e.g. 'bug=true').
* Point the Platform CLI to the instance where your CE exists.
* ry to invoke a pipeline (this is an example of unsaved pipeline):

```
./tw launch --labels="bug=true" --workspace WORKSPACE_ID --compute-env CE_NAME --name test --revision master https://github.com/nextflow-io/hello
```