### PR TITLE
feat: add --boot-disk-size option for AWS Batch Forge CE

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AwsBatchForgePlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AwsBatchForgePlatform.java
@@ -153,6 +153,7 @@ public class AwsBatchForgePlatform extends AbstractPlatform<AwsBatchConfig> {
                 .ec2KeyPair(adv().keyPair)
                 .minCpus(adv().minCpus == null ? 0 : adv().minCpus)
                 .ebsBlockSize(adv().ebsBlockSize)
+                .ebsBootSize(adv().bootDiskSizeGb)
                 .bidPercentage(adv().bidPercentage)
                 .fargateHeadEnabled(fargate);
 
@@ -231,6 +232,9 @@ public class AwsBatchForgePlatform extends AbstractPlatform<AwsBatchConfig> {
 
         @Option(names = {"--min-cpus"}, description = "The minimum number of CPUs provisioned in this environment that will remain active and you will be billed regardless of whether you are running any workloads.")
         public Integer minCpus;
+
+        @Option(names = {"--boot-disk-size"}, description = "Enter the boot disk size as GB.")
+        public Integer bootDiskSizeGb;
 
         @Option(names = {"--head-job-cpus"}, description = "The number of CPUs to be allocated for the Nextflow runner job.")
         public Integer headJobCpus;


### PR DESCRIPTION
## Add support for `--boot-disk-size` option in AWS Batch Forge compute environments

### Description
Fix for #470, this PR adds support for the `--boot-disk-size` option when creating AWS Batch Forge compute environments, allowing users to specify a custom EBS boot disk size (in GB) for their EC2 instances.

### Changes
- Added `--boot-disk-size` command-line option to `AwsBatchForgePlatform` advanced options
- The option sets the `ebsBootSize` parameter in the `ForgeConfig` object, which is sent in the POST request to `/compute-envs`
- Implementation follows the same pattern as the existing Google Batch platform

### Usage
```bash
tw compute-envs add aws-batch forge \
  -n "my-compute-env" \
  -r "us-east-1" \
  --work-dir "s3://my-bucket/work" \
  --max-cpus 100 \
  --boot-disk-size 100