### PR TITLE
Add --head-job-cpus and --head-job-memory options to launch command

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
@@ -167,8 +167,8 @@ public class LaunchCmd extends AbstractRootCmd {
                 .optimizationId(coalesce(adv().disableOptimization, false) ? null : base.getOptimizationId())
                 .optimizationTargets(coalesce(adv().disableOptimization, false) ? null : base.getOptimizationTargets())
                 .labelIds(base.getLabelIds())
-                .headJobCpus(base.getHeadJobCpus())
-                .headJobMemoryMb(base.getHeadJobMemoryMb())
+                .headJobCpus(coalesce(adv().headJobCpus, base.getHeadJobCpus()))
+                .headJobMemoryMb(coalesce(adv().headJobMemoryMb, base.getHeadJobMemoryMb()))
                 .launchContainer(launchContainer);
     }
 
@@ -383,6 +383,12 @@ public class LaunchCmd extends AbstractRootCmd {
 
         @Option(names = {"--disable-optimization"}, description = "Turn off the optimization for the pipeline before launching.")
         public Boolean disableOptimization;
+
+        @Option(names = {"--head-job-cpus"}, description = "The number of CPUs to be allocated for the Nextflow runner job (overrides compute environment setting).")
+        public Integer headJobCpus;
+
+        @Option(names = {"--head-job-memory"}, description = "The number of MiB of memory reserved for the Nextflow runner job (overrides compute environment setting).")
+        public Integer headJobMemoryMb;
 
     }
 


### PR DESCRIPTION
Add --head-job-cpus and --head-job-memory options to launch command

Allow users to override the compute environment's head job resource
settings when launching a pipeline via the CLI.