### PR TITLE
Fix missing compute env status `DELETING`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation 'ch.qos.logback:logback-core:1.5.19'
     implementation 'ch.qos.logback:logback-classic:1.5.19'
 
-    implementation 'io.seqera.tower:tower-java-sdk:1.43.1'
+    implementation 'io.seqera.tower:tower-java-sdk:1.43.2'
     // Upgrade transitive Jersey client dependencies to non-vulnerable 2.x version
     implementation "org.glassfish.jersey.core:jersey-client:2.47"
     implementation "org.glassfish.jersey.media:jersey-media-multipart:2.47"

--- a/src/main/java/io/seqera/tower/cli/utils/FormatHelper.java
+++ b/src/main/java/io/seqera/tower/cli/utils/FormatHelper.java
@@ -249,6 +249,8 @@ public class FormatHelper {
                 return ansi("@|fg(red) INVALID|@");
             case AVAILABLE:
                 return ansi("@|fg(green) AVAILABLE|@");
+            case DELETING:
+                return ansi("@|fg(214) DELETING|@");
             default:
                 return status.toString();
         }


### PR DESCRIPTION
## Description

- Apply patched version of the SDK that includes the recent CE status `DELETING`.

## Guidelines for testing

- [ ] Create a CE and transition it to `DELETING` status.
- [ ] Run `tw compute_envs` commands such as `tw compute_envs list` or `tw compute_envs view`: the execution is successful.