### PR TITLE
feat: Add support for single VM compute environments

### DIFF
--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -422,9 +422,21 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"io.seqera.tower.cli.commands.computeenvs.add.AddAwsCloudCmd",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"io.seqera.tower.cli.commands.computeenvs.add.AddAwsCmd",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"io.seqera.tower.cli.commands.computeenvs.add.AddAzureCloudCmd",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
@@ -447,6 +459,12 @@
 },
 {
   "name":"io.seqera.tower.cli.commands.computeenvs.add.AddGoogleBatchCmd",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"io.seqera.tower.cli.commands.computeenvs.add.AddGoogleCloudCmd",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "methods":[{"name":"<init>","parameterTypes":[] }]
@@ -580,6 +598,17 @@
   "allDeclaredMethods":true
 },
 {
+  "name":"io.seqera.tower.cli.commands.computeenvs.platforms.AwsCloudPlatform",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"io.seqera.tower.cli.commands.computeenvs.platforms.AwsCloudPlatform$AdvancedOptions",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
   "name":"io.seqera.tower.cli.commands.computeenvs.platforms.AzBatchForgePlatform",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
@@ -603,6 +632,17 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"io.seqera.tower.cli.commands.computeenvs.platforms.AzCloudPlatform",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"io.seqera.tower.cli.commands.computeenvs.platforms.AzCloudPlatform$AdvancedOptions",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
   "name":"io.seqera.tower.cli.commands.computeenvs.platforms.EksPlatform",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
@@ -622,6 +662,17 @@
 },
 {
   "name":"io.seqera.tower.cli.commands.computeenvs.platforms.GoogleBatchPlatform$AdvancedOptions",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
+  "name":"io.seqera.tower.cli.commands.computeenvs.platforms.GoogleCloudPlatform",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"io.seqera.tower.cli.commands.computeenvs.platforms.GoogleCloudPlatform$AdvancedOptions",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true
 },

--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -6,6 +6,9 @@
   "name":"[C"
 },
 {
+  "name":"[Lcom.fasterxml.jackson.databind.deser.BeanDeserializerModifier;"
+},
+{
   "name":"[Lcom.fasterxml.jackson.databind.deser.Deserializers;"
 },
 {
@@ -81,6 +84,10 @@
 {
   "name":"com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector",
   "allDeclaredConstructors":true
+},
+{
+  "name":"com.fasterxml.jackson.module.jaxb.ser.DataHandlerJsonSerializer",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
   "name":"com.sun.crypto.provider.AESCipher$General",
@@ -2575,6 +2582,7 @@
 },
 {
   "name":"io.seqera.tower.model.AwsCloudConfig",
+  "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true,
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"addAllowBucketsItem","parameterTypes":["java.lang.String"] }, {"name":"addEnvironmentItem","parameterTypes":["io.seqera.tower.model.ConfigEnvVariable"] }, {"name":"addForgedResourcesItem","parameterTypes":["java.util.Map"] }, {"name":"addSecurityGroupsItem","parameterTypes":["java.lang.String"] }, {"name":"allowBuckets","parameterTypes":["java.util.List"] }, {"name":"arm64Enabled","parameterTypes":["java.lang.Boolean"] }, {"name":"ebsBootSize","parameterTypes":["java.lang.Integer"] }, {"name":"ec2KeyPair","parameterTypes":["java.lang.String"] }, {"name":"environment","parameterTypes":["java.util.List"] }, {"name":"equals","parameterTypes":["java.lang.Object"] }, {"name":"forgedResources","parameterTypes":["java.util.List"] }, {"name":"fusion2Enabled","parameterTypes":["java.lang.Boolean"] }, {"name":"getAllowBuckets","parameterTypes":[] }, {"name":"getArm64Enabled","parameterTypes":[] }, {"name":"getDiscriminator","parameterTypes":[] }, {"name":"getEbsBootSize","parameterTypes":[] }, {"name":"getEc2KeyPair","parameterTypes":[] }, {"name":"getEnvironment","parameterTypes":[] }, {"name":"getForgedResources","parameterTypes":[] }, {"name":"getFusion2Enabled","parameterTypes":[] }, {"name":"getGpuEnabled","parameterTypes":[] }, {"name":"getHeadJobOptions","parameterTypes":[] }, {"name":"getHostName","parameterTypes":[] }, {"name":"getImageId","parameterTypes":[] }, {"name":"getInstanceProfileArn","parameterTypes":[] }, {"name":"getInstanceType","parameterTypes":[] }, {"name":"getLaunchDir","parameterTypes":[] }, {"name":"getLogGroup","parameterTypes":[] }, {"name":"getMaxQueueSize","parameterTypes":[] }, {"name":"getNextflowConfig","parameterTypes":[] }, {"name":"getPort","parameterTypes":[] }, {"name":"getPostRunScript","parameterTypes":[] }, {"name":"getPreRunScript","parameterTypes":[] }, {"name":"getPropagateHeadJobOptions","parameterTypes":[] }, {"name":"getRegion","parameterTypes":[] }, {"name":"getSecurityGroups","parameterTypes":[] }, {"name":"getSubnetId","parameterTypes":[] }, {"name":"getUserName","parameterTypes":[] }, {"name":"getWaveEnabled","parameterTypes":[] }, {"name":"getWorkDir","parameterTypes":[] }, {"name":"gpuEnabled","parameterTypes":["java.lang.Boolean"] }, {"name":"hashCode","parameterTypes":[] }, {"name":"headJobOptions","parameterTypes":["java.lang.String"] }, {"name":"hostName","parameterTypes":["java.lang.String"] }, {"name":"imageId","parameterTypes":["java.lang.String"] }, {"name":"instanceProfileArn","parameterTypes":["java.lang.String"] }, {"name":"instanceType","parameterTypes":["java.lang.String"] }, {"name":"launchDir","parameterTypes":["java.lang.String"] }, {"name":"logGroup","parameterTypes":["java.lang.String"] }, {"name":"maxQueueSize","parameterTypes":["java.lang.Integer"] }, {"name":"nextflowConfig","parameterTypes":["java.lang.String"] }, {"name":"port","parameterTypes":["java.lang.Integer"] }, {"name":"postRunScript","parameterTypes":["java.lang.String"] }, {"name":"preRunScript","parameterTypes":["java.lang.String"] }, {"name":"propagateHeadJobOptions","parameterTypes":["java.lang.Boolean"] }, {"name":"region","parameterTypes":["java.lang.String"] }, {"name":"securityGroups","parameterTypes":["java.util.List"] }, {"name":"setAllowBuckets","parameterTypes":["java.util.List"] }, {"name":"setArm64Enabled","parameterTypes":["java.lang.Boolean"] }, {"name":"setEbsBootSize","parameterTypes":["java.lang.Integer"] }, {"name":"setEc2KeyPair","parameterTypes":["java.lang.String"] }, {"name":"setEnvironment","parameterTypes":["java.util.List"] }, {"name":"setForgedResources","parameterTypes":["java.util.List"] }, {"name":"setFusion2Enabled","parameterTypes":["java.lang.Boolean"] }, {"name":"setGpuEnabled","parameterTypes":["java.lang.Boolean"] }, {"name":"setHeadJobOptions","parameterTypes":["java.lang.String"] }, {"name":"setHostName","parameterTypes":["java.lang.String"] }, {"name":"setImageId","parameterTypes":["java.lang.String"] }, {"name":"setInstanceProfileArn","parameterTypes":["java.lang.String"] }, {"name":"setInstanceType","parameterTypes":["java.lang.String"] }, {"name":"setLaunchDir","parameterTypes":["java.lang.String"] }, {"name":"setLogGroup","parameterTypes":["java.lang.String"] }, {"name":"setMaxQueueSize","parameterTypes":["java.lang.Integer"] }, {"name":"setNextflowConfig","parameterTypes":["java.lang.String"] }, {"name":"setPort","parameterTypes":["java.lang.Integer"] }, {"name":"setPostRunScript","parameterTypes":["java.lang.String"] }, {"name":"setPreRunScript","parameterTypes":["java.lang.String"] }, {"name":"setPropagateHeadJobOptions","parameterTypes":["java.lang.Boolean"] }, {"name":"setRegion","parameterTypes":["java.lang.String"] }, {"name":"setSecurityGroups","parameterTypes":["java.util.List"] }, {"name":"setSubnetId","parameterTypes":["java.lang.String"] }, {"name":"setUserName","parameterTypes":["java.lang.String"] }, {"name":"setWaveEnabled","parameterTypes":["java.lang.Boolean"] }, {"name":"setWorkDir","parameterTypes":["java.lang.String"] }, {"name":"subnetId","parameterTypes":["java.lang.String"] }, {"name":"toIndentedString","parameterTypes":["java.lang.Object"] }, {"name":"toString","parameterTypes":[] }, {"name":"userName","parameterTypes":["java.lang.String"] }, {"name":"waveEnabled","parameterTypes":["java.lang.Boolean"] }, {"name":"workDir","parameterTypes":["java.lang.String"] }]
@@ -4875,6 +4883,10 @@
   "queryAllDeclaredConstructors":true
 },
 {
+  "name":"java.lang.Class",
+  "methods":[{"name":"isRecord","parameterTypes":[] }]
+},
+{
   "name":"java.lang.Class[]"
 },
 {
@@ -5236,7 +5248,7 @@
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true,
-  "methods":[{"name":"<init>","parameterTypes":[] }]
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"<init>","parameterTypes":["javax.inject.Provider","javax.inject.Provider"] }]
 },
 {
   "name":"org.glassfish.jersey.client.ClientAsyncExecutor",
@@ -5259,6 +5271,10 @@
 },
 {
   "name":"org.glassfish.jersey.inject.hk2.Hk2InjectionManagerFactory",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.glassfish.jersey.inject.hk2.Hk2Registrables",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
@@ -5291,7 +5307,7 @@
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true,
-  "methods":[{"name":"<init>","parameterTypes":[] }]
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"<init>","parameterTypes":["javax.inject.Provider","javax.inject.Provider","javax.inject.Provider"] }]
 },
 {
   "name":"org.glassfish.jersey.internal.RuntimeDelegateImpl",
@@ -5318,7 +5334,10 @@
 },
 {
   "name":"org.glassfish.jersey.jackson.internal.DefaultJacksonJaxbJsonProvider",
-  "allDeclaredConstructors":true
+  "allDeclaredFields":true,
+  "allDeclaredConstructors":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":["javax.ws.rs.ext.Providers","javax.ws.rs.core.Configuration"] }, {"name":"findAndRegisterModules","parameterTypes":[] }]
 },
 {
   "name":"org.glassfish.jersey.jackson.internal.JacksonAutoDiscoverable",
@@ -5326,6 +5345,11 @@
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true,
   "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.glassfish.jersey.jackson.internal.JaxrsFeatureBag",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
 },
 {
   "name":"org.glassfish.jersey.jackson.internal.jackson.jaxrs.base.ProviderBase",
@@ -5363,7 +5387,7 @@
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true,
-  "methods":[{"name":"<init>","parameterTypes":["javax.ws.rs.ext.Providers"] }]
+  "methods":[{"name":"<init>","parameterTypes":["javax.ws.rs.ext.Providers"] }, {"name":"<init>","parameterTypes":["javax.ws.rs.ext.Providers","javax.inject.Provider"] }]
 },
 {
   "name":"org.glassfish.jersey.media.multipart.internal.MultiPartWriter",
@@ -5401,6 +5425,13 @@
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
   "allDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"org.glassfish.jersey.message.internal.EnumMessageProvider",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/AddCmd.java
@@ -20,11 +20,14 @@ package io.seqera.tower.cli.commands.computeenvs;
 
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.computeenvs.add.AddAltairCmd;
+import io.seqera.tower.cli.commands.computeenvs.add.AddAwsCloudCmd;
 import io.seqera.tower.cli.commands.computeenvs.add.AddAwsCmd;
+import io.seqera.tower.cli.commands.computeenvs.add.AddAzureCloudCmd;
 import io.seqera.tower.cli.commands.computeenvs.add.AddAzureCmd;
 import io.seqera.tower.cli.commands.computeenvs.add.AddEksCmd;
 import io.seqera.tower.cli.commands.computeenvs.add.AddGkeCmd;
 import io.seqera.tower.cli.commands.computeenvs.add.AddGoogleBatchCmd;
+import io.seqera.tower.cli.commands.computeenvs.add.AddGoogleCloudCmd;
 import io.seqera.tower.cli.commands.computeenvs.add.AddGoogleLifeSciencesCmd;
 import io.seqera.tower.cli.commands.computeenvs.add.AddK8sCmd;
 import io.seqera.tower.cli.commands.computeenvs.add.AddLsfCmd;
@@ -44,6 +47,7 @@ import java.io.IOException;
         subcommands = {
                 AddK8sCmd.class,
                 AddAwsCmd.class,
+                AddAwsCloudCmd.class,
                 AddEksCmd.class,
                 AddSlurmCmd.class,
                 AddLsfCmd.class,
@@ -53,7 +57,9 @@ import java.io.IOException;
                 AddGkeCmd.class,
                 AddGoogleLifeSciencesCmd.class,
                 AddGoogleBatchCmd.class,
+                AddGoogleCloudCmd.class,
                 AddAzureCmd.class,
+                AddAzureCloudCmd.class,
                 AddSeqeraComputeCmd.class
         }
 )

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/add/AddAwsCloudCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/add/AddAwsCloudCmd.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.commands.computeenvs.add;
+
+import io.seqera.tower.cli.commands.computeenvs.platforms.AwsCloudPlatform;
+import io.seqera.tower.cli.commands.computeenvs.platforms.Platform;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+
+@Command(
+        name = "aws-cloud",
+        description = "Add new AWS Cloud compute environment."
+)
+public class AddAwsCloudCmd extends AbstractAddCmd {
+
+    @Mixin
+    public AwsCloudPlatform platform;
+
+    @Override
+    protected Platform getPlatform() {
+        return platform;
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/add/AddAzureCloudCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/add/AddAzureCloudCmd.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.commands.computeenvs.add;
+
+import io.seqera.tower.cli.commands.computeenvs.platforms.AzCloudPlatform;
+import io.seqera.tower.cli.commands.computeenvs.platforms.Platform;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+
+@Command(
+        name = "azure-cloud",
+        description = "Add new Azure Cloud compute environment."
+)
+public class AddAzureCloudCmd extends AbstractAddCmd {
+
+    @Mixin
+    public AzCloudPlatform platform;
+
+    @Override
+    protected Platform getPlatform() {
+        return platform;
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/add/AddGoogleCloudCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/add/AddGoogleCloudCmd.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.commands.computeenvs.add;
+
+import io.seqera.tower.cli.commands.computeenvs.platforms.GoogleCloudPlatform;
+import io.seqera.tower.cli.commands.computeenvs.platforms.Platform;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+
+@Command(
+        name = "google-cloud",
+        description = "Add new Google Cloud compute environment."
+)
+public class AddGoogleCloudCmd extends AbstractAddCmd {
+
+    @Mixin
+    public GoogleCloudPlatform platform;
+
+    @Override
+    protected Platform getPlatform() {
+        return platform;
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AwsCloudPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AwsCloudPlatform.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.commands.computeenvs.platforms;
+
+import io.seqera.tower.ApiException;
+import io.seqera.tower.model.AwsCloudConfig;
+import io.seqera.tower.model.ComputeEnvComputeConfig.PlatformEnum;
+import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.Option;
+
+import java.io.IOException;
+import java.util.List;
+
+public class AwsCloudPlatform extends AbstractPlatform<AwsCloudConfig> {
+
+    @Option(names = {"--work-dir"}, description = "Work directory.", required = true)
+    public String workDir;
+
+    @Option(names = {"-r", "--region"}, description = "AWS region.", required = true)
+    public String region;
+
+    @Option(names = {"--allow-buckets"}, description = "S3 buckets that the compute environment can access.", split = ",")
+    public List<String> allowBuckets;
+
+    @ArgGroup(heading = "%nAdvanced options:%n", validate = false)
+    public AdvancedOptions adv;
+
+    public AwsCloudPlatform() {
+        super(PlatformEnum.AWS_CLOUD);
+    }
+
+    @Override
+    public AwsCloudConfig computeConfig() throws ApiException, IOException {
+        AwsCloudConfig config = new AwsCloudConfig();
+
+        config
+                .waveEnabled(true)
+                .fusion2Enabled(true)
+
+                // Main
+                .region(region)
+                .allowBuckets(allowBuckets);
+
+        // Advanced
+        if (adv != null) {
+            config
+                    .instanceType(adv.instanceType)
+                    .imageId(adv.imageId)
+                    .arm64Enabled(adv.arm64Enabled)
+                    .ec2KeyPair(adv.ec2KeyPair)
+                    .ebsBootSize(adv.ebsBootSize)
+                    .instanceProfileArn(adv.instanceProfileArn)
+                    .subnetId(adv.subnetId)
+                    .securityGroups(adv.securityGroups);
+        }
+
+        // Common
+        config.workDir(workDir)
+                .preRunScript(preRunScriptString())
+                .postRunScript(postRunScriptString())
+                .nextflowConfig(nextflowConfigString())
+                .environment(environmentVariables());
+
+        return config;
+    }
+
+    public static class AdvancedOptions {
+        @Option(names = {"--arm64"}, description = "Use ARM64 (Graviton) based instances.")
+        public Boolean arm64Enabled;
+
+        @Option(names = {"--boot-disk-size"}, description = "Enter the boot disk size in GB.")
+        public Integer ebsBootSize;
+
+        @Option(names = {"--ec2-key-pair"}, description = "EC2 key pair to enable SSH connectivity to running instances.")
+        public String ec2KeyPair;
+
+        @Option(names = {"--image-id"}, description = "AMI ID for the EC2 instance.")
+        public String imageId;
+
+        @Option(names = {"--instance-profile-arn"}, description = "IAM instance profile ARN for the EC2 instance.")
+        public String instanceProfileArn;
+
+        @Option(names = {"--instance-type"}, description = "EC2 instance type.")
+        public String instanceType;
+
+        @Option(names = {"--security-groups"}, description = "Security group IDs for network access control.", split = ",")
+        public List<String> securityGroups;
+
+        @Option(names = {"--subnet-id"}, description = "VPC subnet ID for instance placement.")
+        public String subnetId;
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzCloudPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzCloudPlatform.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.commands.computeenvs.platforms;
+
+import io.seqera.tower.ApiException;
+import io.seqera.tower.model.AzCloudConfig;
+import io.seqera.tower.model.ComputeEnvComputeConfig.PlatformEnum;
+import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.Option;
+
+import java.io.IOException;
+
+public class AzCloudPlatform extends AbstractPlatform<AzCloudConfig> {
+
+    @Option(names = {"--work-dir"}, description = "Work directory.", required = true)
+    public String workDir;
+
+    @Option(names = {"-r", "--region"}, description = "Azure region.", required = true)
+    public String region;
+
+    @Option(names = {"--resource-group"}, description = "Azure resource group name.", required = true)
+    public String resourceGroup;
+
+    @ArgGroup(heading = "%nAdvanced options:%n", validate = false)
+    public AdvancedOptions adv;
+
+    public AzCloudPlatform() {
+        super(PlatformEnum.AZURE_CLOUD);
+    }
+
+    @Override
+    public AzCloudConfig computeConfig() throws ApiException, IOException {
+        AzCloudConfig config = new AzCloudConfig();
+
+        config
+                .waveEnabled(true)
+                .fusion2Enabled(true)
+
+                // Main
+                .region(region)
+                .resourceGroup(resourceGroup);
+
+        // Advanced
+        if (adv != null) {
+            config
+                    .instanceType(adv.instanceType)
+                    .subscriptionId(adv.subscriptionId)
+                    .networkId(adv.networkId)
+                    .managedIdentityId(adv.managedIdentityId)
+                    .managedIdentityClientId(adv.managedIdentityClientId)
+                    .logWorkspaceId(adv.logWorkspaceId)
+                    .logTableName(adv.logTableName)
+                    .dataCollectionEndpoint(adv.dataCollectionEndpoint)
+                    .dataCollectionRuleId(adv.dataCollectionRuleId);
+        }
+
+        // Common
+        config.workDir(workDir)
+                .preRunScript(preRunScriptString())
+                .postRunScript(postRunScriptString())
+                .nextflowConfig(nextflowConfigString())
+                .environment(environmentVariables());
+
+        return config;
+    }
+
+    public static class AdvancedOptions {
+        @Option(names = {"--data-collection-endpoint"}, description = "Data collection endpoint URL.")
+        public String dataCollectionEndpoint;
+
+        @Option(names = {"--data-collection-rule-id"}, description = "Data collection rule ID.")
+        public String dataCollectionRuleId;
+
+        @Option(names = {"--instance-type"}, description = "Azure virtual machine type.")
+        public String instanceType;
+
+        @Option(names = {"--log-table-name"}, description = "Log Analytics table name.")
+        public String logTableName;
+
+        @Option(names = {"--log-workspace-id"}, description = "Log Analytics workspace ID.")
+        public String logWorkspaceId;
+
+        @Option(names = {"--managed-identity-client-id"}, description = "Managed identity client ID.")
+        public String managedIdentityClientId;
+
+        @Option(names = {"--managed-identity-id"}, description = "Managed identity resource ID.")
+        public String managedIdentityId;
+
+        @Option(names = {"--network-id"}, description = "Azure virtual network ID.")
+        public String networkId;
+
+        @Option(names = {"--subscription-id"}, description = "Azure subscription ID.")
+        public String subscriptionId;
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/GoogleCloudPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/GoogleCloudPlatform.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.commands.computeenvs.platforms;
+
+import io.seqera.tower.ApiException;
+import io.seqera.tower.model.ComputeEnvComputeConfig.PlatformEnum;
+import io.seqera.tower.model.GoogleCloudConfig;
+import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.Option;
+
+import java.io.IOException;
+
+public class GoogleCloudPlatform extends AbstractPlatform<GoogleCloudConfig> {
+
+    @Option(names = {"--work-dir"}, description = "Work directory.", required = true)
+    public String workDir;
+
+    @Option(names = {"-r", "--region"}, description = "Google Cloud region.", required = true)
+    public String region;
+
+    @Option(names = {"-z", "--zone"}, description = "Google Cloud zone within the region.", required = true)
+    public String zone;
+
+    @ArgGroup(heading = "%nAdvanced options:%n", validate = false)
+    public AdvancedOptions adv;
+
+    public GoogleCloudPlatform() {
+        super(PlatformEnum.GOOGLE_CLOUD);
+    }
+
+    @Override
+    public GoogleCloudConfig computeConfig() throws ApiException, IOException {
+        GoogleCloudConfig config = new GoogleCloudConfig();
+
+        config
+                .waveEnabled(true)
+                .fusion2Enabled(true)
+
+                // Main
+                .region(region)
+                .zone(zone);
+
+        // Advanced
+        if (adv != null) {
+            config
+                    .arm64Enabled(adv.arm64Enabled)
+                    .gpuEnabled(adv.gpuEnabled)
+                    .imageId(adv.imageId)
+                    .instanceType(adv.instanceType)
+                    .bootDiskSizeGb(adv.bootDiskSizeGb);
+        }
+
+        // Common
+        config.workDir(workDir)
+                .preRunScript(preRunScriptString())
+                .postRunScript(postRunScriptString())
+                .nextflowConfig(nextflowConfigString())
+                .environment(environmentVariables());
+
+        return config;
+    }
+
+    public static class AdvancedOptions {
+        @Option(names = {"--arm64"}, description = "Use ARM64 (Axion) based instances.")
+        public Boolean arm64Enabled;
+
+        @Option(names = {"--boot-disk-size"}, description = "Boot disk size in GB.")
+        public Integer bootDiskSizeGb;
+
+        @Option(names = {"--gpu"}, description = "Enable GPU-enabled instances.")
+        public Boolean gpuEnabled;
+
+        @Option(names = {"--image-id"}, description = "Image ID for the Compute Engine instance.")
+        public String imageId;
+
+        @Option(names = {"--instance-type"}, description = "Compute Engine machine type.")
+        public String instanceType;
+    }
+}

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AwsCloudPlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AwsCloudPlatformTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.computeenvs.platforms;
+
+import io.seqera.tower.cli.BaseCmdTest;
+import io.seqera.tower.cli.commands.enums.OutputType;
+import io.seqera.tower.cli.responses.computeenvs.ComputeEnvAdded;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.model.MediaType;
+
+import java.io.IOException;
+
+import static io.seqera.tower.cli.commands.AbstractApiCmd.USER_WORKSPACE_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockserver.matchers.Times.exactly;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.model.JsonBody.json;
+
+public class AwsCloudPlatformTest extends BaseCmdTest {
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testAdd(OutputType format, MockServerClient mock) {
+        mock.reset();
+
+        // given
+        mock.when(
+                request()
+                        .withMethod("GET")
+                        .withPath("/credentials")
+                        .withQueryStringParameter("platformId", "aws-cloud"),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"credentials\":[{\"id\":\"6XfOhoztUq6de3Dw3X9LSb\",\"name\":\"aws\",\"description\":null,\"discriminator\":\"aws\",\"baseUrl\":null,\"category\":null,\"deleted\":null,\"lastUsed\":\"2021-09-08T18:20:46Z\",\"dateCreated\":\"2021-09-08T12:57:04Z\",\"lastUpdated\":\"2021-09-08T12:57:04Z\"}]}")
+        );
+
+        mock.when(
+                request()
+                        .withMethod("POST")
+                        .withPath("/compute-envs")
+                        .withBody(json("""
+                                {
+                                    "computeEnv": {
+                                        "name": "my-aws-cloud-ce",
+                                        "platform": "aws-cloud",
+                                        "config": {
+                                            "workDir": "s3://my-bucket",
+                                            "region": "us-east-1",
+                                            "fusion2Enabled": true,
+                                            "waveEnabled": true
+                                        },
+                                        "credentialsId": "6XfOhoztUq6de3Dw3X9LSb"
+                                    }
+                                }""")),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}")
+        );
+
+        // when
+        var out = exec(format, mock, "compute-envs", "add", "aws-cloud",
+                "--name", "my-aws-cloud-ce",
+                "--work-dir", "s3://my-bucket",
+                "--region", "us-east-1"
+        );
+
+        // then
+        var expected = new ComputeEnvAdded("aws-cloud", "isnEDBLvHDAIteOEF44ow", "my-aws-cloud-ce", null, USER_WORKSPACE_NAME);
+        assertOutput(format, out, expected);
+    }
+
+    @Test
+    void testAddWithAdvancedOptions(MockServerClient mock) throws IOException {
+        mock.reset();
+
+        // given
+        mock.when(
+                request()
+                        .withMethod("GET")
+                        .withPath("/credentials")
+                        .withQueryStringParameter("platformId", "aws-cloud"),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"credentials\":[{\"id\":\"6XfOhoztUq6de3Dw3X9LSb\",\"name\":\"aws\",\"description\":null,\"discriminator\":\"aws\",\"baseUrl\":null,\"category\":null,\"deleted\":null,\"lastUsed\":\"2021-09-08T18:20:46Z\",\"dateCreated\":\"2021-09-08T12:57:04Z\",\"lastUpdated\":\"2021-09-08T12:57:04Z\"}]}")
+        );
+
+        mock.when(
+                request()
+                        .withMethod("POST")
+                        .withPath("/compute-envs")
+                        .withBody(json("""
+                                {
+                                    "computeEnv": {
+                                        "name": "my-aws-cloud-advanced",
+                                        "platform": "aws-cloud",
+                                        "config": {
+                                            "workDir": "s3://my-bucket",
+                                            "region": "eu-west-1",
+                                            "instanceType": "t3.medium",
+                                            "imageId": "ami-12345678",
+                                            "fusion2Enabled": true,
+                                            "waveEnabled": true,
+                                            "arm64Enabled": true,
+                                            "ec2KeyPair": "my-key-pair",
+                                            "ebsBootSize": 100,
+                                            "instanceProfileArn": "arn:aws:iam::123456789012:instance-profile/my-profile",
+                                            "subnetId": "subnet-12345678",
+                                            "securityGroups": ["sg-12345678", "sg-87654321"],
+                                            "allowBuckets": ["s3://bucket1", "s3://bucket2"]
+                                        },
+                                        "credentialsId": "6XfOhoztUq6de3Dw3X9LSb"
+                                    }
+                                }""")),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}")
+        );
+
+        // when
+        ExecOut out = exec(mock, "compute-envs", "add", "aws-cloud",
+                "-n", "my-aws-cloud-advanced",
+                "--work-dir", "s3://my-bucket",
+                "-r", "eu-west-1",
+                "--allow-buckets", "s3://bucket1,s3://bucket2",
+                "--instance-type", "t3.medium",
+                "--image-id", "ami-12345678",
+                "--arm64",
+                "--ec2-key-pair", "my-key-pair",
+                "--boot-disk-size", "100",
+                "--instance-profile-arn", "arn:aws:iam::123456789012:instance-profile/my-profile",
+                "--subnet-id", "subnet-12345678",
+                "--security-groups", "sg-12345678,sg-87654321"
+        );
+
+        // then
+        var expected = new ComputeEnvAdded("aws-cloud", "isnEDBLvHDAIteOEF44ow", "my-aws-cloud-advanced", null, USER_WORKSPACE_NAME);
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+        assertEquals(expected.toString(), out.stdOut);
+    }
+}

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AzCloudPlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AzCloudPlatformTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.computeenvs.platforms;
+
+import io.seqera.tower.cli.BaseCmdTest;
+import io.seqera.tower.cli.commands.enums.OutputType;
+import io.seqera.tower.cli.responses.computeenvs.ComputeEnvAdded;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.model.MediaType;
+
+import java.io.IOException;
+
+import static io.seqera.tower.cli.commands.AbstractApiCmd.USER_WORKSPACE_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockserver.matchers.Times.exactly;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.model.JsonBody.json;
+
+public class AzCloudPlatformTest extends BaseCmdTest {
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testAdd(OutputType format, MockServerClient mock) {
+        mock.reset();
+
+        // given
+        mock.when(
+                request()
+                        .withMethod("GET")
+                        .withPath("/credentials")
+                        .withQueryStringParameter("platformId", "azure-cloud"),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"credentials\":[{\"id\":\"6XfOhoztUq6de3Dw3X9LSb\",\"name\":\"azure\",\"description\":null,\"discriminator\":\"azure\",\"baseUrl\":null,\"category\":null,\"deleted\":null,\"lastUsed\":\"2021-09-08T18:20:46Z\",\"dateCreated\":\"2021-09-08T12:57:04Z\",\"lastUpdated\":\"2021-09-08T12:57:04Z\"}]}")
+        );
+
+        mock.when(
+                request()
+                        .withMethod("POST")
+                        .withPath("/compute-envs")
+                        .withBody(json("""
+                                {
+                                    "computeEnv": {
+                                        "name": "my-azure-cloud-ce",
+                                        "platform": "azure-cloud",
+                                        "config": {
+                                            "workDir": "az://my-container",
+                                            "region": "eastus",
+                                            "resourceGroup": "my-resource-group",
+                                            "fusion2Enabled": true,
+                                            "waveEnabled": true
+                                        },
+                                        "credentialsId": "6XfOhoztUq6de3Dw3X9LSb"
+                                    }
+                                }""")),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}")
+        );
+
+        // when
+        var out = exec(format, mock, "compute-envs", "add", "azure-cloud",
+                "--name", "my-azure-cloud-ce",
+                "--work-dir", "az://my-container",
+                "--region", "eastus",
+                "--resource-group", "my-resource-group"
+        );
+
+        // then
+        var expected = new ComputeEnvAdded("azure-cloud", "isnEDBLvHDAIteOEF44ow", "my-azure-cloud-ce", null, USER_WORKSPACE_NAME);
+        assertOutput(format, out, expected);
+    }
+
+    @Test
+    void testAddWithAdvancedOptions(MockServerClient mock) throws IOException {
+        mock.reset();
+
+        // given
+        mock.when(
+                request()
+                        .withMethod("GET")
+                        .withPath("/credentials")
+                        .withQueryStringParameter("platformId", "azure-cloud"),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"credentials\":[{\"id\":\"6XfOhoztUq6de3Dw3X9LSb\",\"name\":\"azure\",\"description\":null,\"discriminator\":\"azure\",\"baseUrl\":null,\"category\":null,\"deleted\":null,\"lastUsed\":\"2021-09-08T18:20:46Z\",\"dateCreated\":\"2021-09-08T12:57:04Z\",\"lastUpdated\":\"2021-09-08T12:57:04Z\"}]}")
+        );
+
+        mock.when(
+                request()
+                        .withMethod("POST")
+                        .withPath("/compute-envs")
+                        .withBody(json("""
+                                {
+                                    "computeEnv": {
+                                        "name": "my-azure-cloud-advanced",
+                                        "platform": "azure-cloud",
+                                        "config": {
+                                            "workDir": "az://my-container",
+                                            "region": "westeurope",
+                                            "resourceGroup": "my-resource-group",
+                                            "instanceType": "Standard_D4s_v3",
+                                            "fusion2Enabled": true,
+                                            "waveEnabled": true,
+                                            "subscriptionId": "12345678-1234-1234-1234-123456789012",
+                                            "networkId": "/subscriptions/.../virtualNetworks/my-vnet",
+                                            "managedIdentityId": "/subscriptions/.../userAssignedIdentities/my-identity",
+                                            "managedIdentityClientId": "87654321-4321-4321-4321-210987654321",
+                                            "logWorkspaceId": "log-workspace-id",
+                                            "logTableName": "my-log-table",
+                                            "dataCollectionEndpoint": "https://my-dce.eastus.ingest.monitor.azure.com",
+                                            "dataCollectionRuleId": "/subscriptions/.../dataCollectionRules/my-dcr"
+                                        },
+                                        "credentialsId": "6XfOhoztUq6de3Dw3X9LSb"
+                                    }
+                                }""")),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}")
+        );
+
+        // when
+        ExecOut out = exec(mock, "compute-envs", "add", "azure-cloud",
+                "-n", "my-azure-cloud-advanced",
+                "--work-dir", "az://my-container",
+                "-r", "westeurope",
+                "--resource-group", "my-resource-group",
+                "--instance-type", "Standard_D4s_v3",
+                "--subscription-id", "12345678-1234-1234-1234-123456789012",
+                "--network-id", "/subscriptions/.../virtualNetworks/my-vnet",
+                "--managed-identity-id", "/subscriptions/.../userAssignedIdentities/my-identity",
+                "--managed-identity-client-id", "87654321-4321-4321-4321-210987654321",
+                "--log-workspace-id", "log-workspace-id",
+                "--log-table-name", "my-log-table",
+                "--data-collection-endpoint", "https://my-dce.eastus.ingest.monitor.azure.com",
+                "--data-collection-rule-id", "/subscriptions/.../dataCollectionRules/my-dcr"
+        );
+
+        // then
+        var expected = new ComputeEnvAdded("azure-cloud", "isnEDBLvHDAIteOEF44ow", "my-azure-cloud-advanced", null, USER_WORKSPACE_NAME);
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+        assertEquals(expected.toString(), out.stdOut);
+    }
+}

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/GoogleCloudPlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/GoogleCloudPlatformTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2021-2023, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.seqera.tower.cli.computeenvs.platforms;
+
+import io.seqera.tower.cli.BaseCmdTest;
+import io.seqera.tower.cli.commands.enums.OutputType;
+import io.seqera.tower.cli.responses.computeenvs.ComputeEnvAdded;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.model.MediaType;
+
+import java.io.IOException;
+
+import static io.seqera.tower.cli.commands.AbstractApiCmd.USER_WORKSPACE_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockserver.matchers.Times.exactly;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.model.JsonBody.json;
+
+public class GoogleCloudPlatformTest extends BaseCmdTest {
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testAdd(OutputType format, MockServerClient mock) {
+        mock.reset();
+
+        // given
+        mock.when(
+                request()
+                        .withMethod("GET")
+                        .withPath("/credentials")
+                        .withQueryStringParameter("platformId", "google-cloud"),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"credentials\":[{\"id\":\"6XfOhoztUq6de3Dw3X9LSb\",\"name\":\"google\",\"description\":null,\"discriminator\":\"google\",\"baseUrl\":null,\"category\":null,\"deleted\":null,\"lastUsed\":\"2021-09-08T18:20:46Z\",\"dateCreated\":\"2021-09-08T12:57:04Z\",\"lastUpdated\":\"2021-09-08T12:57:04Z\"}]}")
+        );
+
+        mock.when(
+                request()
+                        .withMethod("POST")
+                        .withPath("/compute-envs")
+                        .withBody(json("""
+                                {
+                                    "computeEnv": {
+                                        "name": "my-google-cloud-ce",
+                                        "platform": "google-cloud",
+                                        "config": {
+                                            "workDir": "gs://my-bucket",
+                                            "region": "us-central1",
+                                            "zone": "us-central1-a",
+                                            "fusion2Enabled": true,
+                                            "waveEnabled": true
+                                        },
+                                        "credentialsId": "6XfOhoztUq6de3Dw3X9LSb"
+                                    }
+                                }""")),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}")
+        );
+
+        // when
+        var out = exec(format, mock, "compute-envs", "add", "google-cloud",
+                "--name", "my-google-cloud-ce",
+                "--work-dir", "gs://my-bucket",
+                "--region", "us-central1",
+                "--zone", "us-central1-a"
+        );
+
+        // then
+        var expected = new ComputeEnvAdded("google-cloud", "isnEDBLvHDAIteOEF44ow", "my-google-cloud-ce", null, USER_WORKSPACE_NAME);
+        assertOutput(format, out, expected);
+    }
+
+    @Test
+    void testAddWithAdvancedOptions(MockServerClient mock) throws IOException {
+        mock.reset();
+
+        // given
+        mock.when(
+                request()
+                        .withMethod("GET")
+                        .withPath("/credentials")
+                        .withQueryStringParameter("platformId", "google-cloud"),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"credentials\":[{\"id\":\"6XfOhoztUq6de3Dw3X9LSb\",\"name\":\"google\",\"description\":null,\"discriminator\":\"google\",\"baseUrl\":null,\"category\":null,\"deleted\":null,\"lastUsed\":\"2021-09-08T18:20:46Z\",\"dateCreated\":\"2021-09-08T12:57:04Z\",\"lastUpdated\":\"2021-09-08T12:57:04Z\"}]}")
+        );
+
+        mock.when(
+                request()
+                        .withMethod("POST")
+                        .withPath("/compute-envs")
+                        .withBody(json("""
+                                {
+                                    "computeEnv": {
+                                        "name": "my-google-cloud-advanced",
+                                        "platform": "google-cloud",
+                                        "config": {
+                                            "workDir": "gs://my-bucket",
+                                            "region": "europe-west1",
+                                            "zone": "europe-west1-b",
+                                            "instanceType": "n2-standard-4",
+                                            "imageId": "projects/my-project/global/images/my-image",
+                                            "fusion2Enabled": true,
+                                            "waveEnabled": true,
+                                            "arm64Enabled": true,
+                                            "bootDiskSizeGb": 100
+                                        },
+                                        "credentialsId": "6XfOhoztUq6de3Dw3X9LSb"
+                                    }
+                                }""")),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}")
+        );
+
+        // when
+        ExecOut out = exec(mock, "compute-envs", "add", "google-cloud",
+                "-n", "my-google-cloud-advanced",
+                "--work-dir", "gs://my-bucket",
+                "-r", "europe-west1",
+                "-z", "europe-west1-b",
+                "--instance-type", "n2-standard-4",
+                "--image-id", "projects/my-project/global/images/my-image",
+                "--arm64",
+                "--boot-disk-size", "100"
+        );
+
+        // then
+        var expected = new ComputeEnvAdded("google-cloud", "isnEDBLvHDAIteOEF44ow", "my-google-cloud-advanced", null, USER_WORKSPACE_NAME);
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+        assertEquals(expected.toString(), out.stdOut);
+    }
+}


### PR DESCRIPTION
## Description

This PR extends the CLI so that single VM CEs (i.e. AWS Cloud, AZure Cloud, and Google Cloud) can be created via the newly added `aws-cloud`, `azure-cloud`, and `google-cloud` arguments for `tw compute-envs add`. The options supported by these commands are aligned with UI conventions and limited to supported fields only.

### Instructions for testing

Run the following command to create an AWS Cloud CE:
```shell
export TOWER_ACCESS_TOKEN="<REPLACE_WITH_YOUR_TOKEN>"
# aws cloud
tw compute-envs add \
    aws-cloud \
    --workspace $ORGANIZATION_NAME/$WORKSPACE_NAME \
    --credentials $AWS_CREDENTIALS \
    --name aws-cloud-test \
    --work-dir $WORKDIR \
    --region $REGION \
    --wait AVAILABLE
```

If no errors occur, the CE should have appear in the UI:
<img width="682" height="426" alt="image" src="https://github.com/user-attachments/assets/457033eb-142d-4851-9101-76c5edfdee26" />

### Related issues
- Closes #544 
- Closes COMP-1053
