### PR TITLE
feat: Add support for instance templates in GCP CEs

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/GoogleBatchPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/GoogleBatchPlatform.java
@@ -68,7 +68,9 @@ public class GoogleBatchPlatform extends AbstractPlatform<GoogleBatchConfig> {
                 .bootDiskSizeGb(adv.bootDiskSizeGb)
                 .headJobCpus(adv.headJobCpus)
                 .headJobMemoryMb(adv.headJobMemoryMb)
-                .serviceAccount(adv.serviceAccountEmail);
+                .serviceAccount(adv.serviceAccountEmail)
+                .headJobInstanceTemplate(adv.headJobInstanceTemplate)
+                .computeJobsInstanceTemplate(adv.computeJobInstanceTemplate);
         }
 
         // Common
@@ -97,5 +99,10 @@ public class GoogleBatchPlatform extends AbstractPlatform<GoogleBatchConfig> {
         @Option(names = {"--service-account-email"}, description = "The service account email address used when deploying pipeline executions with this compute environment.")
         public String serviceAccountEmail;
 
+        @Option(names = {"--head-job-template"}, description = "The name or fully qualified reference of the instance template to use for the head job.")
+        public String headJobInstanceTemplate;
+
+        @Option(names = {"--compute-job-template"}, description = "The name or fully qualified reference of the instance template to use for the compute jobs.")
+        public String computeJobInstanceTemplate;
     }
 }

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/GoogleBatchPlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/GoogleBatchPlatformTest.java
@@ -85,4 +85,76 @@ class GoogleBatchPlatformTest extends BaseCmdTest {
         assertEquals(0, out.exitCode);
     }
 
+    @Test
+    void testAddWithInstanceTemplates(MockServerClient mock) throws IOException {
+
+        mock.reset();
+
+        mock.when(
+                request().withMethod("GET").withPath("/credentials").withQueryStringParameter("platformId", "google-batch"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"credentials\":[{\"id\":\"6XfOhoztUq6de3Dw3X9LSb\",\"name\":\"google\",\"description\":null,\"discriminator\":\"google\",\"baseUrl\":null,\"category\":null,\"deleted\":null,\"lastUsed\":\"2021-09-08T18:20:46Z\",\"dateCreated\":\"2021-09-08T12:57:04Z\",\"lastUpdated\":\"2021-09-08T12:57:04Z\"}]}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("POST").withPath("/compute-envs")
+                        .withBody(JsonBody.json("{\"computeEnv\":{\"credentialsId\":\"6XfOhoztUq6de3Dw3X9LSb\",\"name\":\"google\",\"platform\":\"google-batch\",\"config\":{\"location\":\"europe\",\"workDir\":\"gs://workdir\",\"fusion2Enabled\":false,\"waveEnabled\":false,\"headJobInstanceTemplate\":\"projects/my-project/global/instanceTemplates/head-template\",\"computeJobsInstanceTemplate\":\"projects/my-project/global/instanceTemplates/compute-template\"}}}")), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(mock, "compute-envs", "add", "google-batch", "-n", "google", "--work-dir", "gs://workdir", "-l", "europe", "--head-job-template", "projects/my-project/global/instanceTemplates/head-template", "--compute-job-template", "projects/my-project/global/instanceTemplates/compute-template");
+        assertEquals("", out.stdErr);
+        assertEquals(new ComputeEnvAdded("google-batch", "isnEDBLvHDAIteOEF44ow", "google", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(0, out.exitCode);
+    }
+
+    @Test
+    void testAddWithOnlyHeadJobTemplate(MockServerClient mock) throws IOException {
+
+        mock.reset();
+
+        mock.when(
+                request().withMethod("GET").withPath("/credentials").withQueryStringParameter("platformId", "google-batch"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"credentials\":[{\"id\":\"6XfOhoztUq6de3Dw3X9LSb\",\"name\":\"google\",\"description\":null,\"discriminator\":\"google\",\"baseUrl\":null,\"category\":null,\"deleted\":null,\"lastUsed\":\"2021-09-08T18:20:46Z\",\"dateCreated\":\"2021-09-08T12:57:04Z\",\"lastUpdated\":\"2021-09-08T12:57:04Z\"}]}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("POST").withPath("/compute-envs")
+                        .withBody(JsonBody.json("{\"computeEnv\":{\"credentialsId\":\"6XfOhoztUq6de3Dw3X9LSb\",\"name\":\"google\",\"platform\":\"google-batch\",\"config\":{\"location\":\"europe\",\"workDir\":\"gs://workdir\",\"fusion2Enabled\":false,\"waveEnabled\":false,\"headJobInstanceTemplate\":\"projects/my-project/global/instanceTemplates/head-template\"}}}")), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(mock, "compute-envs", "add", "google-batch", "-n", "google", "--work-dir", "gs://workdir", "-l", "europe", "--head-job-template", "projects/my-project/global/instanceTemplates/head-template");
+        assertEquals("", out.stdErr);
+        assertEquals(new ComputeEnvAdded("google-batch", "isnEDBLvHDAIteOEF44ow", "google", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(0, out.exitCode);
+    }
+
+    @Test
+    void testAddWithOnlyComputeJobTemplate(MockServerClient mock) throws IOException {
+
+        mock.reset();
+
+        mock.when(
+                request().withMethod("GET").withPath("/credentials").withQueryStringParameter("platformId", "google-batch"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"credentials\":[{\"id\":\"6XfOhoztUq6de3Dw3X9LSb\",\"name\":\"google\",\"description\":null,\"discriminator\":\"google\",\"baseUrl\":null,\"category\":null,\"deleted\":null,\"lastUsed\":\"2021-09-08T18:20:46Z\",\"dateCreated\":\"2021-09-08T12:57:04Z\",\"lastUpdated\":\"2021-09-08T12:57:04Z\"}]}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("POST").withPath("/compute-envs")
+                        .withBody(JsonBody.json("{\"computeEnv\":{\"credentialsId\":\"6XfOhoztUq6de3Dw3X9LSb\",\"name\":\"google\",\"platform\":\"google-batch\",\"config\":{\"location\":\"europe\",\"workDir\":\"gs://workdir\",\"fusion2Enabled\":false,\"waveEnabled\":false,\"computeJobsInstanceTemplate\":\"projects/my-project/global/instanceTemplates/compute-template\"}}}")), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(mock, "compute-envs", "add", "google-batch", "-n", "google", "--work-dir", "gs://workdir", "-l", "europe", "--compute-job-template", "projects/my-project/global/instanceTemplates/compute-template");
+        assertEquals("", out.stdErr);
+        assertEquals(new ComputeEnvAdded("google-batch", "isnEDBLvHDAIteOEF44ow", "google", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(0, out.exitCode);
+    }
+
 }


### PR DESCRIPTION
## Description

This PR adds support for two new `google-batch` flags:
- `--head-job-template`: Allows specifying which instance template to use for the head job
- `--compute-job-template`: Allows specifying which instance template to use for compute tasks.

### Usage

#### Simple name (if the CE is in the same project)
```bash
tw compute-envs add google-batch \
    [...] \
    --head-job-template <EXAMPLE_TEMPLATE> \
    --compute-job-template <EXAMPLE_TEMPLATE>
```

#### Fully qualified reference:
```bash
tw compute-envs add google-batch \
    [...] \
    --head-job-template projects/<EXAMPLE_PROJECT>/global/instanceTemplates/<EXAMPLE_TEMPLATE> \
    --compute-job-template projects/<EXAMPLE_PROJECT>/global/instanceTemplates/<EXAMPLE_TEMPLATE>
```

Closes #458 
