### PR TITLE
fix: show actual API error messages for 403 Forbidden responses

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/DeleteCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/DeleteCmd.java
@@ -19,7 +19,6 @@ package io.seqera.tower.cli.commands.computeenvs;
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.enums.OutputType;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
-import io.seqera.tower.cli.exceptions.ComputeEnvNotFoundException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.computeenvs.ComputeEnvDeleted;
 import io.seqera.tower.model.ComputeEnvResponseDto;
@@ -59,16 +58,8 @@ public class DeleteCmd extends AbstractComputeEnvCmd {
             id = computeEnv.getId();
         }
 
-        try {
-            computeEnvsApi().deleteComputeEnv(id, wspId, null);
-            return new ComputeEnvDeleted(id, workspaceRef(wspId), wspId);
-        } catch (ApiException e) {
-            if (e.getCode() == 403) {
-                // Customize the forbidden message
-                throw new ComputeEnvNotFoundException(id, workspaceRef(wspId));
-            }
-            throw e;
-        }
+        computeEnvsApi().deleteComputeEnv(id, wspId, null);
+        return new ComputeEnvDeleted(id, workspaceRef(wspId), wspId);
     }
 
     @Override

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/UpdateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/UpdateCmd.java
@@ -18,7 +18,6 @@ package io.seqera.tower.cli.commands.computeenvs;
 
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
-import io.seqera.tower.cli.exceptions.ComputeEnvNotFoundException;
 import io.seqera.tower.cli.exceptions.InvalidResponseException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.computeenvs.ComputeEnvUpdated;
@@ -73,20 +72,7 @@ public class UpdateCmd extends AbstractComputeEnvCmd {
 
     }
 
-    private ComputeEnvResponseDto describeCE(ComputeEnvRefOptions computeEnvRefOptions, Long wspId) throws ComputeEnvNotFoundException, ApiException {
-        try {
-            return fetchComputeEnv(computeEnvRefOptions, wspId);
-
-        } catch (ApiException e) {
-            if (e.getCode() == 403) {
-                String ref = computeEnvRefOptions.computeEnv.computeEnvId != null
-                        ? computeEnvRefOptions.computeEnv.computeEnvId
-                        : computeEnvRefOptions.computeEnv.computeEnvName;
-                // Customize the forbidden message
-                throw new ComputeEnvNotFoundException(ref, workspaceRef(wspId));
-            }
-
-            throw e;
-        }
+    private ComputeEnvResponseDto describeCE(ComputeEnvRefOptions computeEnvRefOptions, Long wspId) throws ApiException {
+        return fetchComputeEnv(computeEnvRefOptions, wspId);
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/ViewCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/ViewCmd.java
@@ -18,7 +18,6 @@ package io.seqera.tower.cli.commands.computeenvs;
 
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
-import io.seqera.tower.cli.exceptions.ComputeEnvNotFoundException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.computeenvs.ComputeEnvView;
 import io.seqera.tower.model.ComputeEnvResponseDto;
@@ -41,19 +40,8 @@ public class ViewCmd extends AbstractComputeEnvCmd {
     protected Response exec() throws ApiException {
         Long wspId = workspaceId(workspace.workspace);
 
-        try {
-            ComputeEnvResponseDto computeEnv = fetchComputeEnv(computeEnvRefOptions, wspId);
-
-            return new ComputeEnvView(computeEnv.getId(), workspaceRef(wspId), computeEnv, baseWorkspaceUrl(wspId));
-        } catch (ApiException e) {
-            if (e.getCode() == 403) {
-                String ref = computeEnvRefOptions.computeEnv.computeEnvId != null ? computeEnvRefOptions.computeEnv.computeEnvId : computeEnvRefOptions.computeEnv.computeEnvName;
-
-                // Customize the forbidden message
-                throw new ComputeEnvNotFoundException(ref, workspaceRef(wspId));
-            }
-            throw e;
-        }
+        ComputeEnvResponseDto computeEnv = fetchComputeEnv(computeEnvRefOptions, wspId);
+        return new ComputeEnvView(computeEnv.getId(), workspaceRef(wspId), computeEnv, baseWorkspaceUrl(wspId));
     }
 
 }

--- a/src/main/java/io/seqera/tower/cli/commands/credentials/DeleteCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/credentials/DeleteCmd.java
@@ -18,7 +18,6 @@ package io.seqera.tower.cli.commands.credentials;
 
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
-import io.seqera.tower.cli.exceptions.CredentialsNotFoundException;
 import io.seqera.tower.cli.responses.CredentialsDeleted;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.model.Credentials;
@@ -49,15 +48,7 @@ public class DeleteCmd extends AbstractCredentialsCmd {
             id = credentials.getId();
         }
 
-        try {
-            deleteCredentialsById(id, wspId);
-            return new CredentialsDeleted(id, workspaceRef(wspId));
-        } catch (ApiException e) {
-            if (e.getCode() == 403) {
-                // Customize the forbidden message
-                throw new CredentialsNotFoundException(id, workspaceRef(wspId));
-            }
-            throw e;
-        }
+        deleteCredentialsById(id, wspId);
+        return new CredentialsDeleted(id, workspaceRef(wspId));
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/credentials/update/AbstractUpdateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/credentials/update/AbstractUpdateCmd.java
@@ -21,7 +21,6 @@ import io.seqera.tower.cli.commands.credentials.AbstractCredentialsCmd;
 import io.seqera.tower.cli.commands.credentials.CredentialsRefOptions;
 import io.seqera.tower.cli.commands.credentials.providers.CredentialsProvider;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
-import io.seqera.tower.cli.exceptions.CredentialsNotFoundException;
 import io.seqera.tower.cli.responses.CredentialsUpdated;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.model.Credentials;
@@ -47,20 +46,8 @@ public abstract class AbstractUpdateCmd extends AbstractCredentialsCmd {
     protected Response exec() throws ApiException, IOException {
         Long wspId = workspaceId(workspace.workspace);
 
-        // Check that exists
-        try {
-//            DescribeCredentialsResponse response = api().describeCredentials(credentials, wspId);
-            Credentials credentials = fetchCredentials(credentialsRefOptions, wspId);
-            return update(credentials, wspId);
-        } catch (ApiException e) {
-            if (e.getCode() == 403) {
-                String ref = credentialsRefOptions.credentialsRef.credentialsId != null ? credentialsRefOptions.credentialsRef.credentialsId : credentialsRefOptions.credentialsRef.credentialsName;
-
-                // Customize the forbidden message
-                throw new CredentialsNotFoundException(ref, workspaceRef(wspId));
-            }
-            throw e;
-        }
+        Credentials credentials = fetchCredentials(credentialsRefOptions, wspId);
+        return update(credentials, wspId);
     }
 
     protected Response update(Credentials creds, Long wspId) throws ApiException, IOException {

--- a/src/main/java/io/seqera/tower/cli/commands/runs/CancelCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/CancelCmd.java
@@ -18,7 +18,6 @@ package io.seqera.tower.cli.commands.runs;
 
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
-import io.seqera.tower.cli.exceptions.RunNotFoundException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.runs.RunCanceled;
 import picocli.CommandLine;
@@ -41,15 +40,7 @@ public class CancelCmd extends AbstractRunsCmd {
     protected Response exec() throws ApiException, IOException {
         Long wspId = workspaceId(workspace.workspace);
         
-        try {
-            workflowsApi().cancelWorkflow(id, wspId, null, null);
-
-            return new RunCanceled(id, workspaceRef(wspId));
-        } catch (ApiException e) {
-            if (e.getCode() == 403) {
-                throw new RunNotFoundException(id, workspaceRef(wspId));
-            }
-            throw e;
-        }
+        workflowsApi().cancelWorkflow(id, wspId, null, null);
+        return new RunCanceled(id, workspaceRef(wspId));
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/runs/DeleteCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/DeleteCmd.java
@@ -18,7 +18,6 @@ package io.seqera.tower.cli.commands.runs;
 
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
-import io.seqera.tower.cli.exceptions.RunNotFoundException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.runs.RunDeleted;
 import picocli.CommandLine;
@@ -44,15 +43,7 @@ public class DeleteCmd extends AbstractRunsCmd {
     protected Response exec() throws ApiException, IOException {
         Long wspId = workspaceId(workspace.workspace);
         
-        try {
-            workflowsApi().deleteWorkflow(id, wspId, force);
-
-            return new RunDeleted(id, workspaceRef(wspId));
-        } catch (ApiException e) {
-            if (e.getCode() == 403) {
-                throw new RunNotFoundException(id, workspaceRef(wspId));
-            }
-            throw e;
-        }
+        workflowsApi().deleteWorkflow(id, wspId, force);
+        return new RunDeleted(id, workspaceRef(wspId));
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/runs/ViewCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/ViewCmd.java
@@ -67,129 +67,119 @@ public class ViewCmd extends AbstractRunsCmd {
     protected Response exec() throws ApiException {
         Long wspId = workspaceId(workspace.workspace);
 
-        try {
-            String workspaceRef = workspaceRef(wspId);
-            DescribeWorkflowResponse workflowResponse = workflowsApi().describeWorkflow(id, wspId, List.of(WorkflowQueryAttribute.labels));
-            
-            if (workflowResponse == null) {
-                throw new RunNotFoundException(id, workspaceRef(wspId));
-            }
+        String workspaceRef = workspaceRef(wspId);
+        DescribeWorkflowResponse workflowResponse = workflowsApi().describeWorkflow(id, wspId, List.of(WorkflowQueryAttribute.labels));
 
-            WorkflowMaxDbDto workflow = workflowResponse.getWorkflow();
-            WorkflowLoad workflowLoad = workflowLoadByWorkflowId(wspId, id);
-
-            DescribeWorkflowLaunchResponse wfLaunch = workflowsApi().describeWorkflowLaunch(workflow.getId(), wspId);
-            ComputeEnvComputeConfig computeEnv = wfLaunch.getLaunch() != null ? wfLaunch.getLaunch().getComputeEnv() : null;
-
-            ProgressData progress = null;
-            if (opts.processes || opts.stats || opts.load || opts.utilization) {
-                progress = workflowsApi().describeWorkflowProgress(id, wspId).getProgress();
-            }
-
-            Map<String, Object> general = new LinkedHashMap<>();
-            general.put("id", workflow.getId());
-            general.put("operationId", workflowResponse.getJobInfo() != null ? workflowResponse.getJobInfo().getOperationId() : null);
-            general.put("runName", workflow.getRunName());
-            general.put("startingDate", workflow.getStart());
-            general.put("commitId", workflow.getCommitId());
-            general.put("sessionId", workflow.getSessionId());
-            general.put("username", workflow.getUserName());
-            general.put("workdir", workflow.getWorkDir());
-            general.put("container", workflow.getContainer());
-            general.put("executors", workflowLoad.getExecutors() != null ? String.join(", ", workflowLoad.getExecutors()) : null);
-            general.put("computeEnv", computeEnv == null ? '-' : computeEnv.getName());
-            general.put("nextflowVersion", workflow.getNextflow() != null ? workflow.getNextflow().getVersion() : null);
-            general.put("status", workflow.getStatus());
-            general.put("labels", formatLabels(workflowResponse.getLabels()));
-
-            List<String> configFiles = new ArrayList<>();
-            String configText = null;
-            if (opts.config) {
-                configFiles = workflow.getConfigFiles();
-                configText = workflow.getConfigText();
-            }
-
-            Map<String, Object> params = new HashMap<String, Object>();
-            if (opts.params) {
-                params = workflow.getParams();
-            }
-
-            String command = null;
-            if (opts.command) {
-                command = workflow.getCommandLine();
-            }
-
-            Map<String, Object> status = new HashMap<>();
-            if (opts.status) {
-                status.put("pending", workflowLoad.getPending());
-                status.put("submitted", workflowLoad.getSubmitted());
-                status.put("running", workflowLoad.getRunning());
-                status.put("cached", workflowLoad.getCached());
-                status.put("succeeded", workflowLoad.getSucceeded());
-                status.put("failed", workflowLoad.getFailed());
-            }
-
-            final List<Map<String, Object>> processes = new ArrayList<>();
-            if (opts.processes) {
-                progress.getProcessesProgress().forEach(it -> {
-                    Map<String, Object> data = new HashMap<>();
-                    data.put("name", it.getProcess());
-                    data.put("completedTasks", it.getSucceeded() + it.getCached());
-                    data.put("totalTasks", it.getPending() + it.getRunning() + it.getCached() + it.getSubmitted() + it.getSucceeded() + it.getFailed());
-
-                    processes.add(data);
-                });
-            }
-
-            Map<String, Object> stats = new HashMap<>();
-            if (opts.stats) {
-                if( workflow.getDuration() != null )
-                    stats.put("wallTime", TimeUnit.MILLISECONDS.toSeconds(workflow.getDuration()) / 60D);
-                if(progress.getWorkflowProgress() != null) {
-                    stats.put("cpuTime", TimeUnit.MILLISECONDS.toMinutes(progress.getWorkflowProgress().getCpuTime()) / 60D);
-                    stats.put("totalMemory", progress.getWorkflowProgress().getMemoryRss() / 1024 / 1024 / 1024D);
-                    stats.put("read", progress.getWorkflowProgress().getReadBytes() / 1024 / 1024 / 1024D);
-                    stats.put("write", progress.getWorkflowProgress().getWriteBytes() / 1024 / 1024 / 1024D);
-                    stats.put("cost", progress.getWorkflowProgress().getCost());
-                }
-            }
-
-            Map<String, Object> load = new HashMap<>();
-            if (opts.load && progress.getWorkflowProgress() != null) {
-                load.put("peakCpus", progress.getWorkflowProgress().getPeakCpus());
-                load.put("loadCpus", progress.getWorkflowProgress().getLoadCpus());
-                load.put("peakTasks", progress.getWorkflowProgress().getPeakTasks());
-                load.put("loadTasks", progress.getWorkflowProgress().getLoadTasks());
-            }
-
-            Map<String, Object> utilization = new HashMap<>();
-            if (opts.utilization && progress.getWorkflowProgress() != null) {
-                utilization.put("memoryEfficiency", progress.getWorkflowProgress().getMemoryEfficiency());
-                utilization.put("cpuEfficiency", progress.getWorkflowProgress().getCpuEfficiency());
-            }
-
-            return new RunView(
-                    workspaceRef,
-                    general,
-                    configFiles,
-                    configText,
-                    params,
-                    command,
-                    status,
-                    processes,
-                    stats,
-                    load,
-                    utilization,
-                    baseWorkspaceUrl(wspId)
-            );
-
-        } catch (ApiException e) {
-            if (e.getCode() == 403) {
-                // Customize the forbidden message
-                throw new RunNotFoundException(id, workspaceRef(wspId));
-            }
-
-            throw e;
+        if (workflowResponse == null) {
+            throw new RunNotFoundException(id, workspaceRef(wspId));
         }
+
+        WorkflowMaxDbDto workflow = workflowResponse.getWorkflow();
+        WorkflowLoad workflowLoad = workflowLoadByWorkflowId(wspId, id);
+
+        DescribeWorkflowLaunchResponse wfLaunch = workflowsApi().describeWorkflowLaunch(workflow.getId(), wspId);
+        ComputeEnvComputeConfig computeEnv = wfLaunch.getLaunch() != null ? wfLaunch.getLaunch().getComputeEnv() : null;
+
+        ProgressData progress = null;
+        if (opts.processes || opts.stats || opts.load || opts.utilization) {
+            progress = workflowsApi().describeWorkflowProgress(id, wspId).getProgress();
+        }
+
+        Map<String, Object> general = new LinkedHashMap<>();
+        general.put("id", workflow.getId());
+        general.put("operationId", workflowResponse.getJobInfo() != null ? workflowResponse.getJobInfo().getOperationId() : null);
+        general.put("runName", workflow.getRunName());
+        general.put("startingDate", workflow.getStart());
+        general.put("commitId", workflow.getCommitId());
+        general.put("sessionId", workflow.getSessionId());
+        general.put("username", workflow.getUserName());
+        general.put("workdir", workflow.getWorkDir());
+        general.put("container", workflow.getContainer());
+        general.put("executors", workflowLoad.getExecutors() != null ? String.join(", ", workflowLoad.getExecutors()) : null);
+        general.put("computeEnv", computeEnv == null ? '-' : computeEnv.getName());
+        general.put("nextflowVersion", workflow.getNextflow() != null ? workflow.getNextflow().getVersion() : null);
+        general.put("status", workflow.getStatus());
+        general.put("labels", formatLabels(workflowResponse.getLabels()));
+
+        List<String> configFiles = new ArrayList<>();
+        String configText = null;
+        if (opts.config) {
+            configFiles = workflow.getConfigFiles();
+            configText = workflow.getConfigText();
+        }
+
+        Map<String, Object> params = new HashMap<String, Object>();
+        if (opts.params) {
+            params = workflow.getParams();
+        }
+
+        String command = null;
+        if (opts.command) {
+            command = workflow.getCommandLine();
+        }
+
+        Map<String, Object> status = new HashMap<>();
+        if (opts.status) {
+            status.put("pending", workflowLoad.getPending());
+            status.put("submitted", workflowLoad.getSubmitted());
+            status.put("running", workflowLoad.getRunning());
+            status.put("cached", workflowLoad.getCached());
+            status.put("succeeded", workflowLoad.getSucceeded());
+            status.put("failed", workflowLoad.getFailed());
+        }
+
+        final List<Map<String, Object>> processes = new ArrayList<>();
+        if (opts.processes) {
+            progress.getProcessesProgress().forEach(it -> {
+                Map<String, Object> data = new HashMap<>();
+                data.put("name", it.getProcess());
+                data.put("completedTasks", it.getSucceeded() + it.getCached());
+                data.put("totalTasks", it.getPending() + it.getRunning() + it.getCached() + it.getSubmitted() + it.getSucceeded() + it.getFailed());
+
+                processes.add(data);
+            });
+        }
+
+        Map<String, Object> stats = new HashMap<>();
+        if (opts.stats) {
+            if( workflow.getDuration() != null )
+                stats.put("wallTime", TimeUnit.MILLISECONDS.toSeconds(workflow.getDuration()) / 60D);
+            if(progress.getWorkflowProgress() != null) {
+                stats.put("cpuTime", TimeUnit.MILLISECONDS.toMinutes(progress.getWorkflowProgress().getCpuTime()) / 60D);
+                stats.put("totalMemory", progress.getWorkflowProgress().getMemoryRss() / 1024 / 1024 / 1024D);
+                stats.put("read", progress.getWorkflowProgress().getReadBytes() / 1024 / 1024 / 1024D);
+                stats.put("write", progress.getWorkflowProgress().getWriteBytes() / 1024 / 1024 / 1024D);
+                stats.put("cost", progress.getWorkflowProgress().getCost());
+            }
+        }
+
+        Map<String, Object> load = new HashMap<>();
+        if (opts.load && progress.getWorkflowProgress() != null) {
+            load.put("peakCpus", progress.getWorkflowProgress().getPeakCpus());
+            load.put("loadCpus", progress.getWorkflowProgress().getLoadCpus());
+            load.put("peakTasks", progress.getWorkflowProgress().getPeakTasks());
+            load.put("loadTasks", progress.getWorkflowProgress().getLoadTasks());
+        }
+
+        Map<String, Object> utilization = new HashMap<>();
+        if (opts.utilization && progress.getWorkflowProgress() != null) {
+            utilization.put("memoryEfficiency", progress.getWorkflowProgress().getMemoryEfficiency());
+            utilization.put("cpuEfficiency", progress.getWorkflowProgress().getCpuEfficiency());
+        }
+
+        return new RunView(
+                workspaceRef,
+                general,
+                configFiles,
+                configText,
+                params,
+                command,
+                status,
+                processes,
+                stats,
+                load,
+                utilization,
+                baseWorkspaceUrl(wspId)
+        );
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/studios/AddAsNewCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/studios/AddAsNewCmd.java
@@ -76,24 +76,17 @@ public class AddAsNewCmd extends AbstractStudiosCmd{
     protected Response exec() throws ApiException {
         Long wspId = workspaceId(workspace.workspace);
 
-        try {
-            String parentStudioSessionId = getParentStudioSessionId(parentStudioRefOptions, wspId);
-            DataStudioDto parentStudio = studiosApi().describeDataStudio(parentStudioSessionId, wspId);
-            if (parentStudio == null) {
-                throw new TowerException(String.format("Parent Studio %s not found at %s workspace", parentStudioSessionId, wspId));
-            }
-
-            DataStudioCreateRequest request = prepareRequest(parentStudio, parentCheckpointId, wspId);
-            DataStudioCreateResponse response = studiosApi().createDataStudio(request, wspId, autoStart);
-            DataStudioDto studioDto = response.getStudio();
-            assert studioDto != null;
-            return new StudiosCreated(studioDto.getSessionId(), wspId, workspaceRef(wspId), baseWorkspaceUrl(wspId), autoStart);
-        } catch (ApiException e) {
-            if (e.getCode() == 403) {
-                throw new TowerException(String.format("User not entitled to create studio at %s workspace", wspId));
-            }
-            throw e;
+        String parentStudioSessionId = getParentStudioSessionId(parentStudioRefOptions, wspId);
+        DataStudioDto parentStudio = studiosApi().describeDataStudio(parentStudioSessionId, wspId);
+        if (parentStudio == null) {
+            throw new TowerException(String.format("Parent Studio %s not found at %s workspace", parentStudioSessionId, wspId));
         }
+
+        DataStudioCreateRequest request = prepareRequest(parentStudio, parentCheckpointId, wspId);
+        DataStudioCreateResponse response = studiosApi().createDataStudio(request, wspId, autoStart);
+        DataStudioDto studioDto = response.getStudio();
+        assert studioDto != null;
+        return new StudiosCreated(studioDto.getSessionId(), wspId, workspaceRef(wspId), baseWorkspaceUrl(wspId), autoStart);
     }
 
     DataStudioCreateRequest prepareRequest(DataStudioDto parentDataStudio, String parentCheckpointId, Long wspId) throws ApiException {

--- a/src/main/java/io/seqera/tower/cli/commands/studios/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/studios/AddCmd.java
@@ -83,19 +83,12 @@ public class AddCmd extends AbstractStudiosCmd{
     protected Response exec() throws ApiException {
         Long wspId = workspaceId(workspace.workspace);
 
-        try {
-            templateValidation(templateOptions, condaEnv, wspId);
-            DataStudioCreateRequest request = prepareRequest(wspId);
-            DataStudioCreateResponse response = studiosApi().createDataStudio(request, wspId, autoStart);
-            DataStudioDto studioDto = response.getStudio();
-            assert studioDto != null;
-            return new StudiosCreated(studioDto.getSessionId(), wspId, workspaceRef(wspId), baseWorkspaceUrl(wspId), autoStart);
-        } catch (ApiException e) {
-            if (e.getCode() == 403) {
-                throw new TowerException(String.format("User not entitled to create studio at %s workspace", wspId));
-            }
-            throw e;
-        }
+        templateValidation(templateOptions, condaEnv, wspId);
+        DataStudioCreateRequest request = prepareRequest(wspId);
+        DataStudioCreateResponse response = studiosApi().createDataStudio(request, wspId, autoStart);
+        DataStudioDto studioDto = response.getStudio();
+        assert studioDto != null;
+        return new StudiosCreated(studioDto.getSessionId(), wspId, workspaceRef(wspId), baseWorkspaceUrl(wspId), autoStart);
     }
 
     private void templateValidation(StudioTemplateOptions templateOptions, Path condaEnv, Long wspId) throws ApiException {

--- a/src/main/java/io/seqera/tower/cli/commands/studios/CheckpointsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/studios/CheckpointsCmd.java
@@ -19,7 +19,6 @@ package io.seqera.tower.cli.commands.studios;
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.global.PaginationOptions;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
-import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.exceptions.WorkspaceNotFoundException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.studios.StudioCheckpointsList;
@@ -68,9 +67,6 @@ public class CheckpointsCmd extends AbstractStudiosCmd {
         } catch (ApiException e) {
             if (e.getCode() == 404){
                 throw new WorkspaceNotFoundException(wspId);
-            }
-            if (e.getCode() == 403) {
-                throw new TowerException(String.format("User not entitled to %s workspace", wspId));
             }
             throw e;
         }

--- a/src/main/java/io/seqera/tower/cli/commands/studios/DeleteCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/studios/DeleteCmd.java
@@ -19,7 +19,6 @@ package io.seqera.tower.cli.commands.studios;
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
 import io.seqera.tower.cli.exceptions.StudioNotFoundException;
-import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.studios.StudioDeleted;
 import picocli.CommandLine;
@@ -49,9 +48,6 @@ public class DeleteCmd extends AbstractStudiosCmd {
         } catch (ApiException e) {
             if (e.getCode() == 404) {
                 throw new StudioNotFoundException(studioRefOptions.getStudioIdentifier(), workspace.workspace);
-            }
-            if (e.getCode() == 403) {
-                throw new TowerException(String.format("User not entitled to view studio '%s' at %s workspace", studioRefOptions.getStudioIdentifier(), workspace.workspace));
             }
             throw e;
         }

--- a/src/main/java/io/seqera/tower/cli/commands/studios/ListCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/studios/ListCmd.java
@@ -20,7 +20,6 @@ import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.global.PaginationOptions;
 import io.seqera.tower.cli.commands.global.ShowLabelsOption;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
-import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.exceptions.WorkspaceNotFoundException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.studios.StudiosList;
@@ -68,9 +67,6 @@ public class ListCmd extends AbstractStudiosCmd {
         } catch (ApiException e) {
             if (e.getCode() == 404){
                 throw new WorkspaceNotFoundException(wspId);
-            }
-            if (e.getCode() == 403) {
-                throw new TowerException(String.format("User not entitled to %s workspace", wspId));
             }
             throw e;
         }

--- a/src/main/java/io/seqera/tower/cli/commands/studios/StartCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/studios/StartCmd.java
@@ -23,7 +23,6 @@ import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
 import io.seqera.tower.cli.commands.labels.Label;
 import io.seqera.tower.cli.commands.labels.LabelsOptionalOptions;
 import io.seqera.tower.cli.exceptions.StudioNotFoundException;
-import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.studios.StudioStartSubmitted;
 import io.seqera.tower.model.DataStudioConfiguration;
@@ -74,9 +73,6 @@ public class StartCmd extends AbstractStudiosCmd {
         } catch (ApiException e) {
             if (e.getCode() == 404) {
                 throw new StudioNotFoundException(studioRefOptions.getStudioIdentifier(), workspace.workspace);
-            }
-            if (e.getCode() == 403) {
-                throw new TowerException(String.format("User not entitled to view studio '%s' at %s workspace", studioRefOptions.getStudioIdentifier(), workspace.workspace));
             }
             throw e;
         }

--- a/src/main/java/io/seqera/tower/cli/commands/studios/StopCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/studios/StopCmd.java
@@ -19,7 +19,6 @@ package io.seqera.tower.cli.commands.studios;
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
 import io.seqera.tower.cli.exceptions.StudioNotFoundException;
-import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.studios.StudioStopSubmitted;
 import io.seqera.tower.model.DataStudioStatus;
@@ -56,9 +55,6 @@ public class StopCmd extends AbstractStudiosCmd {
         } catch (ApiException e) {
             if (e.getCode() == 404) {
                 throw new StudioNotFoundException(studioRefOptions.getStudioIdentifier(), workspace.workspace);
-            }
-            if (e.getCode() == 403) {
-                throw new TowerException(String.format("User not entitled to view studio '%s' at %s workspace", studioRefOptions.getStudioIdentifier(), workspace.workspace));
             }
             throw e;
         }

--- a/src/main/java/io/seqera/tower/cli/commands/studios/TemplatesCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/studios/TemplatesCmd.java
@@ -18,7 +18,6 @@ package io.seqera.tower.cli.commands.studios;
 
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
-import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.studios.StudiosTemplatesList;
 import picocli.CommandLine;
@@ -39,13 +38,6 @@ public class TemplatesCmd extends AbstractStudiosCmd {
     protected Response exec() throws ApiException {
         Long wspId = workspaceId(workspace.workspace);
 
-        try {
-            return new StudiosTemplatesList(fetchStudioTemplates(wspId, max));
-        } catch (ApiException e) {
-            if (e.getCode() == 403) {
-                throw new TowerException("User not entitled to list studio templates");
-            }
-            throw e;
-        }
+        return new StudiosTemplatesList(fetchStudioTemplates(wspId, max));
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/studios/ViewCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/studios/ViewCmd.java
@@ -19,7 +19,6 @@ package io.seqera.tower.cli.commands.studios;
 import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
 import io.seqera.tower.cli.exceptions.StudioNotFoundException;
-import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.studios.StudiosView;
 import io.seqera.tower.model.DataStudioDto;
@@ -48,9 +47,6 @@ public class ViewCmd extends AbstractStudiosCmd {
         } catch (ApiException e) {
             if (e.getCode() == 404) {
                 throw new StudioNotFoundException(studioRefOptions.getStudioIdentifier(), workspace.workspace);
-            }
-            if (e.getCode() == 403) {
-                throw new TowerException(String.format("User not entitled to view studio '%s' at %s workspace", studioRefOptions.getStudioIdentifier(), workspace.workspace));
             }
             throw e;
         }

--- a/src/main/java/io/seqera/tower/cli/utils/ResponseHelper.java
+++ b/src/main/java/io/seqera/tower/cli/utils/ResponseHelper.java
@@ -95,8 +95,7 @@ public class ResponseHelper {
                     break;
 
                 case 403:
-                    String errorMessage = decodeMessage(ex);
-                    print(err, (errorMessage == null ? "Forbidden" : errorMessage) + ".");
+                    print(err, decodeMessage(ex));
                     break;
 
                 default:

--- a/src/main/java/io/seqera/tower/cli/utils/ResponseHelper.java
+++ b/src/main/java/io/seqera/tower/cli/utils/ResponseHelper.java
@@ -95,7 +95,8 @@ public class ResponseHelper {
                     break;
 
                 case 403:
-                    print(err, decodeMessage(ex));
+                    String forbiddenMessage = decodeMessage(ex);
+                    print(err, forbiddenMessage == null ? "Forbidden" : forbiddenMessage);
                     break;
 
                 default:

--- a/src/test/java/io/seqera/tower/cli/computeenvs/ComputeEnvsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/ComputeEnvsCmdTest.java
@@ -99,12 +99,12 @@ class ComputeEnvsCmdTest extends BaseCmdTest {
         mock.when(
                 request().withMethod("DELETE").withPath("/compute-envs/vYOK4vn7spw7bHHWBDXZ3"), exactly(1)
         ).respond(
-                response().withStatusCode(403)
+                response().withStatusCode(403).withBody("{\"message\":\"Forbidden\"}").withContentType(MediaType.APPLICATION_JSON)
         );
 
         ExecOut out = exec(mock, "compute-envs", "delete", "-i", "vYOK4vn7spw7bHHWBDXZ3");
 
-        assertEquals(errorMessage(out.app, new ComputeEnvNotFoundException("vYOK4vn7spw7bHHWBDXZ3", USER_WORKSPACE_NAME)), out.stdErr);
+        assertEquals(errorMessage(out.app, new ApiException(403, "", null, "{\"message\":\"Forbidden\"}")), out.stdErr);
         assertEquals("", out.stdOut);
         assertEquals(1, out.exitCode);
     }
@@ -257,12 +257,12 @@ class ComputeEnvsCmdTest extends BaseCmdTest {
         mock.when(
                 request().withMethod("GET").withPath("/compute-envs/isnEDBLvHDAIteOEF44or"), exactly(1)
         ).respond(
-                response().withStatusCode(403)
+                response().withStatusCode(403).withBody("{\"message\":\"Forbidden\"}").withContentType(MediaType.APPLICATION_JSON)
         );
 
         ExecOut out = exec(mock, "compute-envs", "view", "-i", "isnEDBLvHDAIteOEF44or");
 
-        assertEquals(errorMessage(out.app, new TowerException(String.format("Compute environment '%s' not found at user workspace", "isnEDBLvHDAIteOEF44or"))), out.stdErr);
+        assertEquals(errorMessage(out.app, new ApiException(403, "", null, "{\"message\":\"Forbidden\"}")), out.stdErr);
         assertEquals("", out.stdOut);
         assertEquals(1, out.exitCode);
     }

--- a/src/test/java/io/seqera/tower/cli/computeenvs/ComputeEnvsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/ComputeEnvsCmdTest.java
@@ -95,7 +95,7 @@ class ComputeEnvsCmdTest extends BaseCmdTest {
     }
 
     @Test
-    void testDeleteNotFound(MockServerClient mock) {
+    void testDeleteForbidden(MockServerClient mock) {
         mock.when(
                 request().withMethod("DELETE").withPath("/compute-envs/vYOK4vn7spw7bHHWBDXZ3"), exactly(1)
         ).respond(
@@ -252,7 +252,7 @@ class ComputeEnvsCmdTest extends BaseCmdTest {
     }
 
     @Test
-    void testViewNotFound(MockServerClient mock) {
+    void testViewForbidden(MockServerClient mock) {
 
         mock.when(
                 request().withMethod("GET").withPath("/compute-envs/isnEDBLvHDAIteOEF44or"), exactly(1)

--- a/src/test/java/io/seqera/tower/cli/credentials/CredentialsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/credentials/CredentialsCmdTest.java
@@ -64,7 +64,7 @@ class CredentialsCmdTest extends BaseCmdTest {
     }
 
     @Test
-    void testDeleteNotFound(MockServerClient mock) {
+    void testDeleteForbidden(MockServerClient mock) {
         mock.when(
                 request().withMethod("DELETE").withPath("/credentials/1cz5A8cuBkB5iKKiCwJCFU"), exactly(1)
         ).respond(

--- a/src/test/java/io/seqera/tower/cli/credentials/CredentialsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/credentials/CredentialsCmdTest.java
@@ -68,12 +68,12 @@ class CredentialsCmdTest extends BaseCmdTest {
         mock.when(
                 request().withMethod("DELETE").withPath("/credentials/1cz5A8cuBkB5iKKiCwJCFU"), exactly(1)
         ).respond(
-                response().withStatusCode(403)
+                response().withStatusCode(403).withBody("{\"message\":\"Forbidden\"}").withContentType(MediaType.APPLICATION_JSON)
         );
 
         ExecOut out = exec(mock, "credentials", "delete", "-i", "1cz5A8cuBkB5iKKiCwJCFU");
 
-        assertEquals(errorMessage(out.app, new CredentialsNotFoundException("1cz5A8cuBkB5iKKiCwJCFU", USER_WORKSPACE_NAME)), out.stdErr);
+        assertEquals(errorMessage(out.app, new ApiException(403, "", null, "{\"message\":\"Forbidden\"}")), out.stdErr);
         assertEquals("", out.stdOut);
         assertEquals(1, out.exitCode);
     }

--- a/src/test/java/io/seqera/tower/cli/credentials/providers/AwsProviderTest.java
+++ b/src/test/java/io/seqera/tower/cli/credentials/providers/AwsProviderTest.java
@@ -243,12 +243,12 @@ class AwsProviderTest extends BaseCmdTest {
         mock.when(
                 request().withMethod("GET").withPath("/credentials/kfKx9xRgzpIIZrbCMOcU5"), exactly(1)
         ).respond(
-                response().withStatusCode(403)
+                response().withStatusCode(403).withBody("{\"message\":\"Forbidden\"}").withContentType(MediaType.APPLICATION_JSON)
         );
 
         ExecOut out = exec(mock, "credentials", "update", "aws", "-i", "kfKx9xRgzpIIZrbCMOcU5", "-r", "changeAssumeRole");
 
-        assertEquals(errorMessage(out.app, new CredentialsNotFoundException("kfKx9xRgzpIIZrbCMOcU5", USER_WORKSPACE_NAME)), out.stdErr);
+        assertEquals(errorMessage(out.app, new ApiException(403, "", null, "{\"message\":\"Forbidden\"}")), out.stdErr);
         assertEquals("", out.stdOut);
         assertEquals(1, out.exitCode);
     }

--- a/src/test/java/io/seqera/tower/cli/runs/RunsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/runs/RunsCmdTest.java
@@ -93,7 +93,7 @@ class RunsCmdTest extends BaseCmdTest {
     }
 
     @Test
-    void testDeleteNotFound(MockServerClient mock) {
+    void testDeleteForbidden(MockServerClient mock) {
         mock.when(
                 request().withMethod("DELETE").withPath("/workflow/5dAZoXrcmZXRO4"), exactly(1)
         ).respond(
@@ -121,7 +121,7 @@ class RunsCmdTest extends BaseCmdTest {
     }
 
     @Test
-    void testCancelNotFound(MockServerClient mock) {
+    void testCancelForbidden(MockServerClient mock) {
         mock.when(
                 request().withMethod("POST").withPath("/workflow/5dAZoXrcmZXRO4/cancel"), exactly(1)
         ).respond(
@@ -482,7 +482,7 @@ class RunsCmdTest extends BaseCmdTest {
     }
 
     @Test
-    void testViewNotFound(MockServerClient mock) {
+    void testViewForbidden(MockServerClient mock) {
         mock.when(
                 request().withMethod("GET").withPath("/workflow/5dAZoXrcmZXRO4"), exactly(1)
         ).respond(

--- a/src/test/java/io/seqera/tower/cli/runs/RunsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/runs/RunsCmdTest.java
@@ -97,12 +97,12 @@ class RunsCmdTest extends BaseCmdTest {
         mock.when(
                 request().withMethod("DELETE").withPath("/workflow/5dAZoXrcmZXRO4"), exactly(1)
         ).respond(
-                response().withStatusCode(403)
+                response().withStatusCode(403).withBody("{\"message\":\"Forbidden\"}").withContentType(MediaType.APPLICATION_JSON)
         );
 
         ExecOut out = exec(mock, "runs", "delete", "-i", "5dAZoXrcmZXRO4");
 
-        assertEquals(errorMessage(out.app, new RunNotFoundException("5dAZoXrcmZXRO4", USER_WORKSPACE_NAME)), out.stdErr);
+        assertEquals(errorMessage(out.app, new ApiException(403, "", null, "{\"message\":\"Forbidden\"}")), out.stdErr);
         assertEquals("", out.stdOut);
         assertEquals(1, out.exitCode);
     }
@@ -125,12 +125,12 @@ class RunsCmdTest extends BaseCmdTest {
         mock.when(
                 request().withMethod("POST").withPath("/workflow/5dAZoXrcmZXRO4/cancel"), exactly(1)
         ).respond(
-                response().withStatusCode(403)
+                response().withStatusCode(403).withBody("{\"message\":\"Forbidden\"}").withContentType(MediaType.APPLICATION_JSON)
         );
 
         ExecOut out = exec(mock, "runs", "cancel", "-i", "5dAZoXrcmZXRO4");
 
-        assertEquals(errorMessage(out.app, new RunNotFoundException("5dAZoXrcmZXRO4", USER_WORKSPACE_NAME)), out.stdErr);
+        assertEquals(errorMessage(out.app, new ApiException(403, "", null, "{\"message\":\"Forbidden\"}")), out.stdErr);
         assertEquals("", out.stdOut);
         assertEquals(1, out.exitCode);
     }
@@ -486,12 +486,12 @@ class RunsCmdTest extends BaseCmdTest {
         mock.when(
                 request().withMethod("GET").withPath("/workflow/5dAZoXrcmZXRO4"), exactly(1)
         ).respond(
-                response().withStatusCode(403)
+                response().withStatusCode(403).withBody("{\"message\":\"Forbidden\"}").withContentType(MediaType.APPLICATION_JSON)
         );
 
         ExecOut out = exec(mock, "runs", "view", "-i", "5dAZoXrcmZXRO4");
 
-        assertEquals(errorMessage(out.app, new RunNotFoundException("5dAZoXrcmZXRO4", USER_WORKSPACE_NAME)), out.stdErr);
+        assertEquals(errorMessage(out.app, new ApiException(403, "", null, "{\"message\":\"Forbidden\"}")), out.stdErr);
         assertEquals("", out.stdOut);
         assertEquals(1, out.exitCode);
     }

--- a/src/test/java/io/seqera/tower/cli/studios/StudiosCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/studios/StudiosCmdTest.java
@@ -17,6 +17,7 @@
 package io.seqera.tower.cli.studios;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.BaseCmdTest;
 import io.seqera.tower.cli.commands.enums.OutputType;
 import io.seqera.tower.cli.exceptions.StudiosCustomTemplateWithCondaException;
@@ -38,6 +39,7 @@ import io.seqera.tower.model.DataStudioCheckpointDto;
 import io.seqera.tower.model.DataStudioDto;
 import io.seqera.tower.model.DataStudioTemplatesListResponse;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -150,6 +152,33 @@ public class StudiosCmdTest extends BaseCmdTest {
                     }
                   ]
                 }""", DataStudioDto.class), "[organization1 / workspace1]" ));
+    }
+
+    @Test
+    void testViewForbidden(MockServerClient mock) {
+        mock.when(
+                request().withMethod("GET").withPath("/user-info"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/user/1264/workspaces"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workspaces/workspaces_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/studios/3e8370e7").withQueryStringParameter("workspaceId", "75887156211589"), exactly(1)
+        ).respond(
+                response().withStatusCode(403).withBody("{\"message\":\"Forbidden. Missing permission(s): \\\"studio:view\\\"\"}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(mock, "studios", "view", "-w", "75887156211589", "-i", "3e8370e7");
+
+        assertEquals(errorMessage(out.app, new ApiException(403, "", null, "{\"message\":\"Forbidden. Missing permission(s): \\\"studio:view\\\"\"}")), out.stdErr);
+        assertEquals("", out.stdOut);
+        assertEquals(1, out.exitCode);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Summary
- Fix `ResponseHelper.java` to display actual API error messages for 403 responses instead of generic "Unknown. Check that the provided identifier is correct."
- Remove misleading 403→NotFoundException conversions from 17 command files (credentials, runs, computeenvs, studios)
- Users now see helpful messages like `Forbidden. Missing permission(s): "organization:write"` instead of confusing "not found" errors

## Test Plan
- [ ] Run `tw -v credentials delete <id>` with insufficient permissions and verify actual permission error is shown
- [ ] Run `tw -v studios view -i <id>` with insufficient permissions and verify actual permission error is shown
- [ ] Verify 404 errors still show appropriate "not found" messages (unchanged behavior)


This resolves some misleading responses. For example, if a Platform org with insuffficient permissions tried to list all org members, we would respond with:

```
$ tw members list -o $ORG_ID
 ERROR: Unknown. Check that the provided identifier is correct.
```

but these changes now adjust that message to the more helpful:

```
$ tw members list -o $ORG_ID
 ERROR: Forbidden. Missing permission(s): "organization:write"
```