### PR TITLE
fix: download content from datalinks with nested folders [PLAT-4489]

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/data/links/DownloadCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/DownloadCmd.java
@@ -88,8 +88,9 @@ public class DownloadCmd extends AbstractDataLinksCmd {
                 pathInfo.add(new DataLinkFileTransferResult.SimplePathInfo(DataLinkItemType.FILE, path, 1));
             }
             else {
-                // Download each file for that prefix
+                // Download each file for that prefix (skip folder entries which end with '/')
                 for (DataLinkSimpleItem item : browseTreeResponse.getItems()) {
+                    if (item.getPath().endsWith("/")) continue;
 
                     Path targetPath = outputDir == null
                             ? Paths.get(item.getPath())

--- a/src/main/java/io/seqera/tower/cli/commands/data/links/DownloadCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/data/links/DownloadCmd.java
@@ -99,7 +99,8 @@ public class DownloadCmd extends AbstractDataLinksCmd {
 
                     downloadFile(item.getPath(), id, credId, wspId, targetPath);
                 }
-                pathInfo.add(new DataLinkFileTransferResult.SimplePathInfo(DataLinkItemType.FOLDER, path, browseTreeResponse.getItems().size()));
+                long fileCount = browseTreeResponse.getItems().stream().filter(i -> !i.getPath().endsWith("/")).count();
+                pathInfo.add(new DataLinkFileTransferResult.SimplePathInfo(DataLinkItemType.FOLDER, path, (int) fileCount));
             }
 
         }

--- a/src/test/java/io/seqera/tower/cli/data/DataLinksCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/data/DataLinksCmdTest.java
@@ -683,9 +683,16 @@ public class DataLinksCmdTest extends BaseCmdTest {
 
         assertOutput(format, out, DataLinkFileTransferResult.donwloaded(List.of(new DataLinkFileTransferResult.SimplePathInfo(DataLinkItemType.FOLDER, "directory/", 2))));
 
-        // verify the API has been polled additionally for the status
+        // verify files were downloaded
         mock.verify(request().withMethod("GET").withPath("/download/directory/"+filename1), VerificationTimes.exactly(1));
         mock.verify(request().withMethod("GET").withPath("/download/directory/subdirectory/"+filename2), VerificationTimes.exactly(1));
+
+        // verify folder entry was not attempted to be downloaded
+        mock.verify(
+                request().withMethod("GET").withPath("/data-links/v1-cloud-c2875f38a7b5c8fe34a5b382b5f9e0c4/generate-download-url")
+                        .withQueryStringParameter("filePath", "directory/empty-dir/"),
+                VerificationTimes.exactly(0)
+        );
 
         Path outputPath1 = tempDir().resolve("directory/"+filename1);
         Path outputPath2 = tempDir().resolve("directory/subdirectory/"+filename2);

--- a/src/test/java/io/seqera/tower/cli/data/DataLinksCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/data/DataLinksCmdTest.java
@@ -612,6 +612,10 @@ public class DataLinksCmdTest extends BaseCmdTest {
                                          {
                                              "path": "directory/subdirectory/filename2.txt",
                                              "size": 106421
+                                         },
+                                         {
+                                             "path": "directory/empty-dir/",
+                                             "size": 0
                                          }
                                  ]
                              }"""


### PR DESCRIPTION
# Description

https://seqera.atlassian.net/browse/PLAT-4489

`browse-tree` returns the full recursive tree of a given folder, including empty folders, ex:                                                                    
- data-explorer-integration-test/some-empty-folder/ ← folder, should be ignored
- data-explorer-integration-test/first-lvl-nested/file.txt ← file, should be downloaded                                                                                                                                                
                                                        
Folder entries (paths ending with `/`) are not downloadable and were causing a "File not found" error. Fix skips them during iteration.
