### PR TITLE
chore: pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,10 @@ jobs:
         run: env | sort
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
 
       - name: Setup Graalvm
-        uses: graalvm/setup-graalvm@v1
+        uses: graalvm/setup-graalvm@03e8abf916fd0e281b2efe7b2da3378bb0a1d085 # ratchet:graalvm/setup-graalvm@v1
         with:
           java-version: '21'
           distribution: 'graalvm'
@@ -43,7 +43,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Tests reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         if: failure()
         with:
           name: linux-test-reports
@@ -53,7 +53,7 @@ jobs:
         run: ./gradlew shadowJar
 
       - name: Upload fat JAR artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         with:
           name: tw-jar
           path: build/libs/tw.jar
@@ -66,7 +66,7 @@ jobs:
           PLATFORM: linux-x86_64
 
       - name: Upload linux native image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         with:
           name: tw-linux
           path: build/native/nativeCompile/tw
@@ -79,7 +79,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Binary tests reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         if: failure()
         with:
           name: linux-binary-test-reports
@@ -95,10 +95,10 @@ jobs:
         run: env | sort
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
 
       - name: Setup Graalvm
-        uses: graalvm/setup-graalvm@v1
+        uses: graalvm/setup-graalvm@03e8abf916fd0e281b2efe7b2da3378bb0a1d085 # ratchet:graalvm/setup-graalvm@v1
         with:
           java-version: '21'
           distribution: 'graalvm'
@@ -111,7 +111,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Tests reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         if: failure()
         with:
           name: mac-test-reports
@@ -152,7 +152,7 @@ jobs:
           xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
 
       - name: Upload Mac native image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         with:
           name: tw-mac
           path: build/native/nativeCompile/tw
@@ -165,7 +165,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Binary tests reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         if: failure()
         with:
           name: mac-binary-test-reports
@@ -181,10 +181,10 @@ jobs:
         run: env | sort
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
 
       - name: Setup Graalvm
-        uses: graalvm/setup-graalvm@v1
+        uses: graalvm/setup-graalvm@03e8abf916fd0e281b2efe7b2da3378bb0a1d085 # ratchet:graalvm/setup-graalvm@v1
         with:
           version: 'latest'
           java-version: '21'
@@ -205,7 +205,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Tests reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         if: failure()
         with:
           name: mac-arm64-test-reports
@@ -246,7 +246,7 @@ jobs:
           xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
 
       - name: Upload Mac arm64 native image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         with:
           name: tw-mac-arm64
           path: build/native/nativeCompile/tw
@@ -259,7 +259,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Binary tests reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         if: failure()
         with:
           name: mac-arm64-binary-test-reports
@@ -275,10 +275,10 @@ jobs:
         run: env | sort
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
 
       - name: Setup Graalvm
-        uses: graalvm/setup-graalvm@v1
+        uses: graalvm/setup-graalvm@03e8abf916fd0e281b2efe7b2da3378bb0a1d085 # ratchet:graalvm/setup-graalvm@v1
         with:
           java-version: '21'
           distribution: 'graalvm'
@@ -291,7 +291,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Tests reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         if: failure()
         with:
           name: windows-test-reports
@@ -305,7 +305,7 @@ jobs:
           PLATFORM: windows-x86_64
 
       - name: Upload Windows native image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         with:
           name: tw-windows
           path: build/native/nativeCompile/tw.exe
@@ -318,7 +318,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Binary tests reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         if: failure()
         with:
           name: windows-binary-test-reports
@@ -335,15 +335,15 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
 
       - name: Setup Java for JReleaser
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # ratchet:actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'adopt'
@@ -356,7 +356,7 @@ jobs:
             echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Run JReleaser
-        uses: jreleaser/release-action@v2
+        uses: jreleaser/release-action@90ac653bb9c79d11179e65d81499f3f34527dcd5 # ratchet:jreleaser/release-action@2.5.0
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JRELEASER_HOMEBREW_GITHUB_TOKEN: ${{secrets.GH_JRELEASER_TOKEN}}
@@ -364,7 +364,7 @@ jobs:
 
       - name: JReleaser release output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # ratchet:actions/upload-artifact@v4
         with:
           name: jreleaser-release
           path: |

--- a/.github/workflows/label-notifier.yml
+++ b/.github/workflows/label-notifier.yml
@@ -10,7 +10,7 @@ jobs:
   notify:
     runs-on: tower-cli
     steps:
-        - uses: jenschelkopf/issue-label-notification-action@1.3
+        - uses: jenschelkopf/issue-label-notification-action@f7d2363e5efa18b8aeea671ca8093e183ae8f218 # ratchet:jenschelkopf/issue-label-notification-action@1.3
           with:
             recipients:
               squad-core=@squad-core

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -8,9 +8,9 @@ jobs:
       actions: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # ratchet:actions/checkout@v2
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # ratchet:actions/setup-node@v2
 
       - name: Install markdownlint
         run: npm install -g markdownlint-cli

--- a/.github/workflows/rich-codex-screenshot.yml
+++ b/.github/workflows/rich-codex-screenshot.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
 
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         
       - name: Install latest version of Tower-CLI 
         run: |
@@ -20,7 +20,7 @@ jobs:
         
 
       - name: Generate terminal images with rich-codex
-        uses: ewels/rich-codex@v1
+        uses: ewels/rich-codex@80de9de011c994f32274bb4cffee140567621d8e # ratchet:ewels/rich-codex@v1
         env:
           TOWER_ACCESS_TOKEN: ${{ secrets.TOWER_ACCESS_TOKEN }}
         with:

--- a/.github/workflows/security-submit-dependencies.yml
+++ b/.github/workflows/security-submit-dependencies.yml
@@ -11,8 +11,8 @@ jobs:
   dependency-submission:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: graalvm/setup-graalvm@v1
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
+    - uses: graalvm/setup-graalvm@03e8abf916fd0e281b2efe7b2da3378bb0a1d085 # ratchet:graalvm/setup-graalvm@v1
       with:
         java-version: '21'
         distribution: 'graalvm'
@@ -21,7 +21,7 @@ jobs:
 
 
     - name: Generate and submit dependency graph for tower-cli
-      uses: gradle/actions/dependency-submission@v4
+      uses: gradle/actions/dependency-submission@ed408507eac070d1f99cc633dbcf757c94c7933a # ratchet:gradle/actions/dependency-submission@v4
       with:
         dependency-resolution-task: ":dependencies"
         additional-arguments: "--configuration runtimeClasspath"


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions references across 5 workflow files to full commit SHAs instead of mutable tags
- Follows supply chain security best practices for GitHub Actions
- Includes `# ratchet:` comments for automated version tracking (compatible with Dependabot/Renovate)

## Notes
- `jreleaser/release-action@v2` was pointing to a mutable **branch**, now pinned to tag `2.5.0`
- `jenschelkopf/issue-label-notification-action` and `ewels/rich-codex` are unverified third-party actions — may need review by the security team