### PR TITLE
feat: update CLI to support new Azure Batch features [COMP-1464]

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ mockserverVersion = "5.15.0"
 picocliVersion = "4.6.3"
 shadowVersion = "9.3.1"
 slf4jVersion = "2.0.17"
-towerJavaSdkVersion = "1.114.0"
+towerJavaSdkVersion = "1.133.0"
 xzVersion = "1.10"
 
 [libraries]

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchForgePlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchForgePlatform.java
@@ -21,9 +21,9 @@ import io.seqera.tower.api.CredentialsApi;
 import io.seqera.tower.cli.exceptions.CredentialsNotFoundException;
 import io.seqera.tower.model.AzBatchConfig;
 import io.seqera.tower.model.AzBatchForgeConfig;
+import io.seqera.tower.model.AzBatchPoolConfig;
 import io.seqera.tower.model.ComputeEnvComputeConfig.PlatformEnum;
 import io.seqera.tower.model.Credentials;
-import io.seqera.tower.model.JobCleanupPolicy;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Option;
 
@@ -40,14 +40,23 @@ public class AzBatchForgePlatform extends AbstractPlatform<AzBatchConfig> {
     @Option(names = {"-l", "--location"}, description = "Azure region where compute resources will be deployed (e.g., eastus, westeurope).", required = true)
     public String location;
 
-    @Option(names = {"--vm-type"}, description = "Azure VM size for compute pool. Must be a valid Azure Batch VM type. If absent, Platform defaults to Standard_D4_v3.")
+    @Option(names = {"--dual-pool"}, description = "Enable dual pool mode with separate head and worker pools. Head pool runs the Nextflow launcher on a small VM; worker pool scales independently for pipeline tasks.")
+    public boolean dualPool;
+
+    @Option(names = {"--vm-type"}, description = "Azure VM size for compute pool (single pool mode). Must be a valid Azure Batch VM type. If absent, Platform defaults to Standard_D4_v3.")
     public String vmType;
 
-    @Option(names = {"--vm-count"}, description = "Number of VMs in the Batch pool. With autoscaling enabled, this is the maximum capacity. Pool scales to zero when unused.", required = true)
+    @Option(names = {"--vm-count"}, description = "Number of VMs in the Batch pool (single pool mode). With autoscaling enabled, this is the maximum capacity. Pool scales to zero when unused.")
     public Integer vmCount;
 
-    @Option(names = {"--no-auto-scale"}, description = "Disable pool autoscaling. When disabled, pool maintains fixed VM count and does not scale based on workload.")
+    @Option(names = {"--no-auto-scale"}, description = "Disable pool autoscaling (single pool mode). When disabled, pool maintains fixed VM count and does not scale based on workload.")
     public boolean noAutoScale;
+
+    @ArgGroup(heading = "%nDual pool options (head pool):%n", validate = false)
+    public HeadPoolOptions headPoolOpts;
+
+    @ArgGroup(heading = "%nDual pool options (worker pool):%n", validate = false)
+    public WorkerPoolOptions workerPoolOpts;
 
     @Option(names = {"--preserve-resources"}, description = "Preserve Azure Batch pool resources on deletion. Keeps the compute pool and related resources when the compute environment is deleted from Seqera Platform.")
     public boolean preserveResources;
@@ -60,6 +69,12 @@ public class AzBatchForgePlatform extends AbstractPlatform<AzBatchConfig> {
 
     @Option(names = {"--wave"}, description = "Enable Wave containers. Allows access to private container repositories and on-demand container provisioning.")
     public boolean wave;
+
+    @Option(names = {"--subnet-id"}, description = "Azure VNet subnet resource ID for private network isolation. Requires Entra (service principal) credentials. Format: /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/virtualNetworks/{vnet}/subnets/{subnet}")
+    public String subnetId;
+
+    @ArgGroup(heading = "%nManaged identity options:%n", validate = false)
+    public ManagedIdentityOptions managedIdentity;
 
     @ArgGroup(heading = "%nAdvanced options:%n", validate = false)
     public AdvancedOptions adv;
@@ -86,16 +101,39 @@ public class AzBatchForgePlatform extends AbstractPlatform<AzBatchConfig> {
 
         if (adv != null) {
             config
-                    .deleteJobsOnCompletion(adv.jobsCleanup)
-                    .tokenDuration(adv.tokenDuration);
+                    .deleteJobsOnCompletion(adv.deleteJobsOnCompletion)
+                    .deleteTasksOnCompletion(adv.deleteTasksOnCompletion)
+                    .terminateJobsOnCompletion(adv.terminateJobsOnCompletion)
+                    .tokenDuration(adv.tokenDuration)
+                    .jobMaxWallClockTime(adv.jobMaxWallClockTime);
         }
 
 
         AzBatchForgeConfig forge = new AzBatchForgeConfig()
-                .vmType(vmType)
-                .vmCount(vmCount)
-                .autoScale(!noAutoScale)
                 .disposeOnDeletion(!preserveResources);
+
+        if (dualPool) {
+            AzBatchPoolConfig headPool = new AzBatchPoolConfig();
+            if (headPoolOpts != null) {
+                headPool.vmType(headPoolOpts.headVmType);
+                headPool.vmCount(headPoolOpts.headVmCount);
+                headPool.autoScale(headPoolOpts.headNoAutoScale != null ? !headPoolOpts.headNoAutoScale : null);
+            }
+
+            AzBatchPoolConfig workerPool = new AzBatchPoolConfig();
+            if (workerPoolOpts != null) {
+                workerPool.vmType(workerPoolOpts.workerVmType);
+                workerPool.vmCount(workerPoolOpts.workerVmCount);
+                workerPool.autoScale(workerPoolOpts.workerNoAutoScale != null ? !workerPoolOpts.workerNoAutoScale : null);
+            }
+
+            forge.headPool(headPool);
+            forge.workerPool(workerPool);
+        } else {
+            forge.vmType(vmType)
+                    .vmCount(vmCount)
+                    .autoScale(!noAutoScale);
+        }
 
         if (registryCredentials != null && registryCredentials.size() > 0) {
 
@@ -119,17 +157,76 @@ public class AzBatchForgePlatform extends AbstractPlatform<AzBatchConfig> {
         }
 
         config.forge(forge);
+        config.subnetId(subnetId);
+
+        if (managedIdentity != null) {
+            config.managedIdentityClientId(managedIdentity.managedIdentityClientId);
+            config.managedIdentityPoolClientId(managedIdentity.managedIdentityPoolClientId);
+            config.managedIdentityHeadResourceId(managedIdentity.managedIdentityHeadResourceId);
+            config.managedIdentityPoolResourceId(managedIdentity.managedIdentityPoolResourceId);
+        }
 
         return config;
     }
 
+    public static class HeadPoolOptions {
+
+        @Option(names = {"--head-vm-type"}, description = "Azure VM size for the head pool (dual pool mode). If absent, defaults to Standard_D2s_v3.")
+        public String headVmType;
+
+        @Option(names = {"--head-vm-count"}, description = "Number of VMs in the head pool (dual pool mode). If absent, defaults to 1.")
+        public Integer headVmCount;
+
+        @Option(names = {"--head-no-auto-scale"}, description = "Disable autoscaling for the head pool (dual pool mode).")
+        public Boolean headNoAutoScale;
+
+    }
+
+    public static class WorkerPoolOptions {
+
+        @Option(names = {"--worker-vm-type"}, description = "Azure VM size for the worker pool (dual pool mode). If absent, defaults to Standard_D4s_v3.")
+        public String workerVmType;
+
+        @Option(names = {"--worker-vm-count"}, description = "Max number of VMs in the worker pool (dual pool mode).")
+        public Integer workerVmCount;
+
+        @Option(names = {"--worker-no-auto-scale"}, description = "Disable autoscaling for the worker pool (dual pool mode).")
+        public Boolean workerNoAutoScale;
+
+    }
+
+    public static class ManagedIdentityOptions {
+
+        @Option(names = {"--managed-identity-client-id"}, description = "Head job managed identity client ID (UUID). The user-assigned managed identity used by the Nextflow launcher (head job).")
+        public String managedIdentityClientId;
+
+        @Option(names = {"--managed-identity-pool-client-id"}, description = "Compute job managed identity client ID (UUID). The user-assigned managed identity used by compute tasks running on Batch pool nodes.")
+        public String managedIdentityPoolClientId;
+
+        @Option(names = {"--managed-identity-head-resource-id"}, description = "Head job managed identity resource ID. Full Azure resource ID of the user-assigned managed identity for the head job. Required in Forge mode when head job managed identity client ID is specified. Format: /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{name}")
+        public String managedIdentityHeadResourceId;
+
+        @Option(names = {"--managed-identity-pool-resource-id"}, description = "Compute job managed identity resource ID. Full Azure resource ID of the user-assigned managed identity for compute jobs. Required in Forge mode when compute job managed identity client ID is specified. Format: /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{name}")
+        public String managedIdentityPoolResourceId;
+
+    }
+
     public static class AdvancedOptions {
 
-        @Option(names = {"--jobs-cleanup"}, description = "Automatic deletion of Azure Batch jobs after pipeline execution. ON_SUCCESS deletes only successful jobs. ALWAYS deletes all jobs. NEVER keeps all jobs.")
-        public JobCleanupPolicy jobsCleanup;
+        @Option(names = {"--delete-jobs-on-completion"}, description = "Delete Azure Batch jobs when the workflow completes successfully. Failed jobs are always preserved. Default: false.")
+        public Boolean deleteJobsOnCompletion;
+
+        @Option(names = {"--delete-tasks-on-completion"}, description = "Delete individual Azure Batch tasks when they complete successfully. Failed tasks are preserved. Default: true.")
+        public Boolean deleteTasksOnCompletion;
+
+        @Option(names = {"--terminate-jobs-on-completion"}, description = "Terminate Azure Batch jobs when all tasks complete. Default: true.")
+        public Boolean terminateJobsOnCompletion;
 
         @Option(names = {"--token-duration"}, description = "Duration of the SAS (shared access signature) token for Azure Blob Storage access. If absent, Platform defaults to 12h.")
         public String tokenDuration;
+
+        @Option(names = {"--job-max-wall-clock-time"}, description = "Maximum elapsed time for an Azure Batch job before automatic termination. Accepts duration syntax (e.g., '7d', '1d12h', '168h'). Defaults to 7d. Maximum: 180 days.")
+        public String jobMaxWallClockTime;
 
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchManualPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchManualPlatform.java
@@ -19,7 +19,6 @@ package io.seqera.tower.cli.commands.computeenvs.platforms;
 import io.seqera.tower.ApiException;
 import io.seqera.tower.model.AzBatchConfig;
 import io.seqera.tower.model.ComputeEnvComputeConfig.PlatformEnum;
-import io.seqera.tower.model.JobCleanupPolicy;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Option;
 
@@ -33,14 +32,23 @@ public class AzBatchManualPlatform extends AbstractPlatform<AzBatchConfig> {
     @Option(names = {"-l", "--location"}, description = "Azure region where compute resources will be deployed (e.g., eastus, westeurope).", required = true)
     public String location;
 
-    @Option(names = {"--compute-pool-name"}, description = "Pre-configured Azure Batch compute pool for running Nextflow jobs. Must include azcopy command-line tool. See Nextflow documentation for pool requirements.", required = true)
+    @Option(names = {"--compute-pool-name"}, description = "Pre-configured Azure Batch pool for the Nextflow head job. When used with --worker-pool, this pool handles only the launcher. Must include azcopy command-line tool.", required = true)
     public String computePoolName;
+
+    @Option(names = {"--worker-pool"}, description = "Pre-configured Azure Batch pool for pipeline worker tasks. When specified, the head job runs on --compute-pool-name and worker tasks run on this pool. Must be different from the head pool.")
+    public String workerPool;
 
     @Option(names = {"--fusion-v2"}, description = "Enable Fusion file system. Provides native access to Azure Blob Storage with low-latency I/O. Requires Wave containers.")
     public boolean fusionV2;
 
     @Option(names = {"--wave"}, description = "Enable Wave containers. Allows access to private container repositories and on-demand container provisioning.")
     public boolean wave;
+
+    @Option(names = {"--subnet-id"}, description = "Azure VNet subnet resource ID for private network isolation. Requires Entra (service principal) credentials. Format: /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/virtualNetworks/{vnet}/subnets/{subnet}")
+    public String subnetId;
+
+    @ArgGroup(heading = "%nManaged identity options:%n", validate = false)
+    public ManagedIdentityOptions managedIdentity;
 
     @ArgGroup(heading = "%nAdvanced options:%n", validate = false)
     public AdvancedOptions adv;
@@ -57,12 +65,16 @@ public class AzBatchManualPlatform extends AbstractPlatform<AzBatchConfig> {
                 .fusion2Enabled(fusionV2)
                 .waveEnabled(wave)
                 .region(location)
-                .headPool(computePoolName);
+                .headPool(computePoolName)
+                .workerPool(workerPool);
 
         if (adv != null) {
             config
-                    .deleteJobsOnCompletion(adv.jobsCleanup)
-                    .tokenDuration(adv.tokenDuration);
+                    .deleteJobsOnCompletion(adv.deleteJobsOnCompletion)
+                    .deleteTasksOnCompletion(adv.deleteTasksOnCompletion)
+                    .terminateJobsOnCompletion(adv.terminateJobsOnCompletion)
+                    .tokenDuration(adv.tokenDuration)
+                    .jobMaxWallClockTime(adv.jobMaxWallClockTime);
         }
 
         // Common
@@ -72,16 +84,42 @@ public class AzBatchManualPlatform extends AbstractPlatform<AzBatchConfig> {
                 .nextflowConfig(nextflowConfigString())
                 .environment(environmentVariables());
 
+        config.subnetId(subnetId);
+
+        if (managedIdentity != null) {
+            config.managedIdentityClientId(managedIdentity.managedIdentityClientId);
+            config.managedIdentityPoolClientId(managedIdentity.managedIdentityPoolClientId);
+        }
+
         return config;
+    }
+
+    public static class ManagedIdentityOptions {
+
+        @Option(names = {"--managed-identity-client-id"}, description = "Head job managed identity client ID (UUID). The user-assigned managed identity used by the Nextflow launcher (head job).")
+        public String managedIdentityClientId;
+
+        @Option(names = {"--managed-identity-pool-client-id"}, description = "Compute job managed identity client ID (UUID). The user-assigned managed identity used by compute tasks running on Batch pool nodes.")
+        public String managedIdentityPoolClientId;
+
     }
 
     public static class AdvancedOptions {
 
-        @Option(names = {"--jobs-cleanup"}, description = "Automatic deletion of Azure Batch jobs after pipeline execution. ON_SUCCESS deletes only successful jobs. ALWAYS deletes all jobs. NEVER keeps all jobs.")
-        public JobCleanupPolicy jobsCleanup;
+        @Option(names = {"--delete-jobs-on-completion"}, description = "Delete Azure Batch jobs when the workflow completes successfully. Failed jobs are always preserved. Default: false.")
+        public Boolean deleteJobsOnCompletion;
+
+        @Option(names = {"--delete-tasks-on-completion"}, description = "Delete individual Azure Batch tasks when they complete successfully. Failed tasks are preserved. Default: true.")
+        public Boolean deleteTasksOnCompletion;
+
+        @Option(names = {"--terminate-jobs-on-completion"}, description = "Terminate Azure Batch jobs when all tasks complete. Default: true.")
+        public Boolean terminateJobsOnCompletion;
 
         @Option(names = {"--token-duration"}, description = "Duration of the SAS (shared access signature) token for Azure Blob Storage access. If absent, Platform defaults to 12h.")
         public String tokenDuration;
+
+        @Option(names = {"--job-max-wall-clock-time"}, description = "Maximum elapsed time for an Azure Batch job before automatic termination. Accepts duration syntax (e.g., '7d', '1d12h', '168h'). Defaults to 7d. Maximum: 180 days.")
+        public String jobMaxWallClockTime;
 
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/credentials/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/credentials/AddCmd.java
@@ -20,6 +20,7 @@ import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.credentials.add.AddAgentCmd;
 import io.seqera.tower.cli.commands.credentials.add.AddAwsCmd;
 import io.seqera.tower.cli.commands.credentials.add.AddAzureCmd;
+import io.seqera.tower.cli.commands.credentials.add.AddAzureEntraCmd;
 import io.seqera.tower.cli.commands.credentials.add.AddBitbucketCmd;
 import io.seqera.tower.cli.commands.credentials.add.AddCodeCommitCmd;
 import io.seqera.tower.cli.commands.credentials.add.AddContainerRegistryCmd;
@@ -49,6 +50,7 @@ import java.io.IOException;
                 AddSshCmd.class,
                 AddK8sCmd.class,
                 AddAzureCmd.class,
+                AddAzureEntraCmd.class,
                 AddAgentCmd.class,
                 AddContainerRegistryCmd.class
         }

--- a/src/main/java/io/seqera/tower/cli/commands/credentials/UpdateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/credentials/UpdateCmd.java
@@ -20,6 +20,7 @@ import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.credentials.update.UpdateAgentCmd;
 import io.seqera.tower.cli.commands.credentials.update.UpdateAwsCmd;
 import io.seqera.tower.cli.commands.credentials.update.UpdateAzureCmd;
+import io.seqera.tower.cli.commands.credentials.update.UpdateAzureEntraCmd;
 import io.seqera.tower.cli.commands.credentials.update.UpdateBitbucketCmd;
 import io.seqera.tower.cli.commands.credentials.update.UpdateCodeCommitCmd;
 import io.seqera.tower.cli.commands.credentials.update.UpdateContainerRegistryCmd;
@@ -47,6 +48,7 @@ import java.io.IOException;
                 UpdateSshCmd.class,
                 UpdateK8sCmd.class,
                 UpdateAzureCmd.class,
+                UpdateAzureEntraCmd.class,
                 UpdateContainerRegistryCmd.class,
                 UpdateAgentCmd.class
         }

--- a/src/main/java/io/seqera/tower/cli/commands/credentials/add/AddAzureEntraCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/credentials/add/AddAzureEntraCmd.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.commands.credentials.add;
+
+import io.seqera.tower.cli.commands.credentials.providers.AzureEntraProvider;
+import io.seqera.tower.cli.commands.credentials.providers.CredentialsProvider;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+
+@Command(
+        name = "azure-entra",
+        description = "Add Azure Entra service principal credentials"
+)
+public class AddAzureEntraCmd extends AbstractAddCmd {
+
+    @Mixin
+    AzureEntraProvider provider;
+
+    @Override
+    protected CredentialsProvider getProvider() {
+        return provider;
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/credentials/providers/AzureEntraProvider.java
+++ b/src/main/java/io/seqera/tower/cli/commands/credentials/providers/AzureEntraProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.commands.credentials.providers;
+
+import io.seqera.tower.model.AzureEntraKeys;
+import io.seqera.tower.model.Credentials.ProviderEnum;
+import picocli.CommandLine.Option;
+
+import java.io.IOException;
+
+public class AzureEntraProvider extends AbstractProvider<AzureEntraKeys> {
+
+    @Option(names = {"--batch-name"}, description = "Azure Batch account name. The name of the Azure Batch account used for workflow execution.", required = true)
+    public String batchName;
+
+    @Option(names = {"--storage-name"}, description = "Azure Storage account name. The name of the Azure Storage account used for workflow data and logs.", required = true)
+    public String storageName;
+
+    @Option(names = {"--tenant-id"}, description = "Azure Entra tenant ID. The directory (tenant) ID of the Entra application.", required = true)
+    public String tenantId;
+
+    @Option(names = {"--client-id"}, description = "Azure Entra client ID. The application (client) ID of the Entra service principal.", required = true)
+    public String clientId;
+
+    @Option(names = {"--client-secret"}, description = "Azure Entra client secret. The secret value of the Entra service principal.", required = true)
+    public String clientSecret;
+
+    public AzureEntraProvider() {
+        super(ProviderEnum.AZURE_ENTRA);
+    }
+
+    @Override
+    public AzureEntraKeys securityKeys() throws IOException {
+        AzureEntraKeys keys = new AzureEntraKeys();
+        keys.setBatchName(batchName);
+        keys.setStorageName(storageName);
+        keys.setTenantId(tenantId);
+        keys.setClientId(clientId);
+        keys.setClientSecret(clientSecret);
+        return keys;
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/credentials/update/UpdateAzureEntraCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/credentials/update/UpdateAzureEntraCmd.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.commands.credentials.update;
+
+import io.seqera.tower.cli.commands.credentials.providers.AzureEntraProvider;
+import io.seqera.tower.cli.commands.credentials.providers.CredentialsProvider;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+
+@Command(
+        name = "azure-entra",
+        description = "Update Azure Entra service principal credentials"
+)
+public class UpdateAzureEntraCmd extends AbstractUpdateCmd {
+
+    @Mixin
+    protected AzureEntraProvider provider;
+
+    @Override
+    protected CredentialsProvider getProvider() {
+        return provider;
+    }
+}

--- a/src/test/java/io/seqera/tower/cli/credentials/providers/AzureEntraProviderTest.java
+++ b/src/test/java/io/seqera/tower/cli/credentials/providers/AzureEntraProviderTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.credentials.providers;
+
+import io.seqera.tower.cli.BaseCmdTest;
+import io.seqera.tower.cli.commands.enums.OutputType;
+import io.seqera.tower.cli.responses.CredentialsAdded;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.model.MediaType;
+
+import static io.seqera.tower.cli.commands.AbstractApiCmd.USER_WORKSPACE_NAME;
+import static org.mockserver.matchers.Times.exactly;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.model.JsonBody.json;
+
+class AzureEntraProviderTest extends BaseCmdTest {
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testAdd(OutputType format, MockServerClient mock) {
+
+        mock.when(
+                request()
+                        .withMethod("POST")
+                        .withPath("/credentials")
+                        .withBody(json("{\"credentials\":{\"keys\":{\"batchName\":\"batchName\",\"storageName\":\"storageName\",\"tenantId\":\"tenantId\",\"clientId\":\"clientId\",\"clientSecret\":\"clientSecret\"},\"name\":\"azure-entra\",\"provider\":\"azure_entra\"}}")),
+                exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"credentialsId\":\"1cz5A8cuBkB5iJliCwJCFU\"}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(format, mock, "credentials", "add", "azure-entra", "--name=azure-entra", "--batch-name=batchName", "--storage-name=storageName", "--tenant-id=tenantId", "--client-id=clientId", "--client-secret=clientSecret");
+        assertOutput(format, out, new CredentialsAdded("AZURE_ENTRA", "1cz5A8cuBkB5iJliCwJCFU", "azure-entra", USER_WORKSPACE_NAME));
+    }
+
+}

--- a/src/test/resources/scripts/test-azure-batch-features.sh
+++ b/src/test/resources/scripts/test-azure-batch-features.sh
@@ -1,0 +1,421 @@
+#!/usr/bin/env bash
+#
+# Integration test script for Azure Batch CLI features (COMP-1464)
+#
+# Prerequisites:
+#   - TOWER_ACCESS_TOKEN set
+#   - TOWER_API_ENDPOINT set (or defaults to api.cloud.seqera.io)
+#   - tw CLI binary on PATH
+#   - A workspace with Azure Entra credentials configured
+#
+# Usage:
+#   export TOWER_ACCESS_TOKEN=<token>
+#   export TOWER_API_ENDPOINT=<endpoint>
+#   ./test-azure-batch-features.sh [--workspace <workspace>]
+#
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration - override via environment variables
+# ---------------------------------------------------------------------------
+WORKSPACE="${WORKSPACE:-}"
+TW="${TW:-tw}"
+
+# Azure resource placeholders - override with real values for live testing
+BATCH_NAME="${BATCH_NAME:-my-batch-account}"
+STORAGE_NAME="${STORAGE_NAME:-my-storage-account}"
+TENANT_ID="${TENANT_ID:-00000000-0000-0000-0000-000000000001}"
+CLIENT_ID="${CLIENT_ID:-00000000-0000-0000-0000-000000000002}"
+CLIENT_SECRET="${CLIENT_SECRET:-test-client-secret}"
+WORK_DIR="${WORK_DIR:-az://container/work}"
+LOCATION="${LOCATION:-eastus}"
+
+MI_HEAD_CLIENT_ID="${MI_HEAD_CLIENT_ID:-11111111-1111-1111-1111-111111111111}"
+MI_POOL_CLIENT_ID="${MI_POOL_CLIENT_ID:-22222222-2222-2222-2222-222222222222}"
+MI_HEAD_RESOURCE_ID="${MI_HEAD_RESOURCE_ID:-/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/headIdentity}"
+MI_POOL_RESOURCE_ID="${MI_POOL_RESOURCE_ID:-/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/poolIdentity}"
+SUBNET_ID="${SUBNET_ID:-/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRg/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet}"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+PASS=0
+FAIL=0
+SKIP=0
+CLEANUP_IDS=()
+
+ws_flag() {
+    if [[ -n "$WORKSPACE" ]]; then
+        echo "--workspace=$WORKSPACE"
+    fi
+}
+
+run_tw() {
+    local description="$1"
+    shift
+    echo -n "  TEST: $description ... "
+    if output=$("$TW" $(ws_flag) "$@" 2>&1); then
+        echo "PASS"
+        ((PASS++))
+        return 0
+    else
+        echo "FAIL"
+        echo "    Command: $TW $(ws_flag) $*"
+        echo "    Output: $output"
+        ((FAIL++))
+        return 1
+    fi
+}
+
+run_tw_expect_fail() {
+    local description="$1"
+    shift
+    echo -n "  TEST: $description ... "
+    if output=$("$TW" $(ws_flag) "$@" 2>&1); then
+        echo "FAIL (expected failure but succeeded)"
+        echo "    Command: $TW $(ws_flag) $*"
+        echo "    Output: $output"
+        ((FAIL++))
+        return 1
+    else
+        echo "PASS (failed as expected)"
+        ((PASS++))
+        return 0
+    fi
+}
+
+cleanup_credential() {
+    local name="$1"
+    "$TW" $(ws_flag) credentials delete --name="$name" 2>/dev/null || true
+}
+
+cleanup_ce() {
+    local name="$1"
+    "$TW" $(ws_flag) compute-envs delete --name="$name" 2>/dev/null || true
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --workspace)
+            WORKSPACE="$2"
+            shift 2
+            ;;
+        --workspace=*)
+            WORKSPACE="${1#*=}"
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+echo "============================================================"
+echo " Azure Batch CLI Features Test Suite (COMP-1464)"
+echo "============================================================"
+echo ""
+echo "Endpoint:  ${TOWER_API_ENDPOINT:-api.cloud.seqera.io}"
+echo "Workspace: ${WORKSPACE:-<user default>}"
+echo ""
+
+# ===================================================================
+# 1. Azure Entra Credentials
+# ===================================================================
+echo "--- 1. Azure Entra Credentials ---"
+
+CRED_NAME="test-entra-cred-$$"
+
+run_tw "Add Entra credentials" \
+    credentials add azure-entra \
+    --name="$CRED_NAME" \
+    --batch-name="$BATCH_NAME" \
+    --storage-name="$STORAGE_NAME" \
+    --tenant-id="$TENANT_ID" \
+    --client-id="$CLIENT_ID" \
+    --client-secret="$CLIENT_SECRET"
+
+run_tw "Update Entra credentials" \
+    credentials update azure-entra \
+    --name="$CRED_NAME" \
+    --batch-name="$BATCH_NAME" \
+    --storage-name="$STORAGE_NAME" \
+    --tenant-id="$TENANT_ID" \
+    --client-id="$CLIENT_ID" \
+    --client-secret="new-secret-value"
+
+run_tw_expect_fail "Add Entra credentials missing required --tenant-id" \
+    credentials add azure-entra \
+    --name="should-fail-$$" \
+    --batch-name="$BATCH_NAME" \
+    --storage-name="$STORAGE_NAME" \
+    --client-id="$CLIENT_ID" \
+    --client-secret="$CLIENT_SECRET"
+
+echo ""
+
+# ===================================================================
+# 2. Forge CE - Single Pool (backward compat)
+# ===================================================================
+echo "--- 2. Forge CE - Single Pool ---"
+
+CE_FORGE_SINGLE="test-forge-single-$$"
+
+run_tw "Create Forge CE (single pool, basic)" \
+    compute-envs add azure-batch forge \
+    -n "$CE_FORGE_SINGLE" \
+    --credentials="$CRED_NAME" \
+    -l "$LOCATION" \
+    --work-dir="$WORK_DIR" \
+    --vm-count=5
+
+cleanup_ce "$CE_FORGE_SINGLE"
+echo ""
+
+# ===================================================================
+# 3. Forge CE - Single Pool with all new options
+# ===================================================================
+echo "--- 3. Forge CE - Single Pool with new options ---"
+
+CE_FORGE_FULL="test-forge-full-$$"
+
+run_tw "Create Forge CE (single pool, all options)" \
+    compute-envs add azure-batch forge \
+    -n "$CE_FORGE_FULL" \
+    --credentials="$CRED_NAME" \
+    -l "$LOCATION" \
+    --work-dir="$WORK_DIR" \
+    --vm-type=Standard_D4s_v3 \
+    --vm-count=10 \
+    --no-auto-scale \
+    --fusion-v2 \
+    --wave \
+    --subnet-id="$SUBNET_ID" \
+    --managed-identity-client-id="$MI_HEAD_CLIENT_ID" \
+    --managed-identity-pool-client-id="$MI_POOL_CLIENT_ID" \
+    --managed-identity-head-resource-id="$MI_HEAD_RESOURCE_ID" \
+    --managed-identity-pool-resource-id="$MI_POOL_RESOURCE_ID" \
+    --delete-jobs-on-completion=true \
+    --delete-tasks-on-completion=true \
+    --terminate-jobs-on-completion=true \
+    --token-duration=24h \
+    --job-max-wall-clock-time=7d
+
+cleanup_ce "$CE_FORGE_FULL"
+echo ""
+
+# ===================================================================
+# 4. Forge CE - Dual Pool
+# ===================================================================
+echo "--- 4. Forge CE - Dual Pool ---"
+
+CE_FORGE_DUAL="test-forge-dual-$$"
+
+run_tw "Create Forge CE (dual pool, defaults)" \
+    compute-envs add azure-batch forge \
+    -n "$CE_FORGE_DUAL" \
+    --credentials="$CRED_NAME" \
+    -l "$LOCATION" \
+    --work-dir="$WORK_DIR" \
+    --dual-pool \
+    --worker-vm-count=8
+
+cleanup_ce "$CE_FORGE_DUAL"
+
+CE_FORGE_DUAL_FULL="test-forge-dual-full-$$"
+
+run_tw "Create Forge CE (dual pool, all options)" \
+    compute-envs add azure-batch forge \
+    -n "$CE_FORGE_DUAL_FULL" \
+    --credentials="$CRED_NAME" \
+    -l "$LOCATION" \
+    --work-dir="$WORK_DIR" \
+    --dual-pool \
+    --head-vm-type=Standard_D2s_v3 \
+    --head-vm-count=1 \
+    --head-no-auto-scale=true \
+    --worker-vm-type=Standard_D8s_v3 \
+    --worker-vm-count=16 \
+    --worker-no-auto-scale=false \
+    --subnet-id="$SUBNET_ID" \
+    --delete-tasks-on-completion=false \
+    --terminate-jobs-on-completion=false \
+    --job-max-wall-clock-time=14d
+
+cleanup_ce "$CE_FORGE_DUAL_FULL"
+echo ""
+
+# ===================================================================
+# 5. Manual CE - Single Pool (backward compat)
+# ===================================================================
+echo "--- 5. Manual CE - Single Pool ---"
+
+CE_MANUAL_SINGLE="test-manual-single-$$"
+
+run_tw "Create Manual CE (single pool)" \
+    compute-envs add azure-batch manual \
+    -n "$CE_MANUAL_SINGLE" \
+    --credentials="$CRED_NAME" \
+    -l "$LOCATION" \
+    --work-dir="$WORK_DIR" \
+    --compute-pool-name=my-pool
+
+cleanup_ce "$CE_MANUAL_SINGLE"
+echo ""
+
+# ===================================================================
+# 6. Manual CE - Dual Pool (head + worker)
+# ===================================================================
+echo "--- 6. Manual CE - Dual Pool ---"
+
+CE_MANUAL_DUAL="test-manual-dual-$$"
+
+run_tw "Create Manual CE (separate head and worker pools)" \
+    compute-envs add azure-batch manual \
+    -n "$CE_MANUAL_DUAL" \
+    --credentials="$CRED_NAME" \
+    -l "$LOCATION" \
+    --work-dir="$WORK_DIR" \
+    --compute-pool-name=my-head-pool \
+    --worker-pool=my-worker-pool
+
+cleanup_ce "$CE_MANUAL_DUAL"
+echo ""
+
+# ===================================================================
+# 7. Manual CE - All new options
+# ===================================================================
+echo "--- 7. Manual CE - All new options ---"
+
+CE_MANUAL_FULL="test-manual-full-$$"
+
+run_tw "Create Manual CE (all new options)" \
+    compute-envs add azure-batch manual \
+    -n "$CE_MANUAL_FULL" \
+    --credentials="$CRED_NAME" \
+    -l "$LOCATION" \
+    --work-dir="$WORK_DIR" \
+    --compute-pool-name=my-head-pool \
+    --worker-pool=my-worker-pool \
+    --fusion-v2 \
+    --wave \
+    --subnet-id="$SUBNET_ID" \
+    --managed-identity-client-id="$MI_HEAD_CLIENT_ID" \
+    --managed-identity-pool-client-id="$MI_POOL_CLIENT_ID" \
+    --delete-jobs-on-completion=false \
+    --delete-tasks-on-completion=true \
+    --terminate-jobs-on-completion=true \
+    --token-duration=24h \
+    --job-max-wall-clock-time=3d
+
+cleanup_ce "$CE_MANUAL_FULL"
+echo ""
+
+# ===================================================================
+# 8. Cleanup toggles combinations
+# ===================================================================
+echo "--- 8. Cleanup toggle combinations ---"
+
+CE_CLEANUP="test-cleanup-$$"
+
+run_tw "Create CE with all cleanup toggles off" \
+    compute-envs add azure-batch forge \
+    -n "$CE_CLEANUP" \
+    --credentials="$CRED_NAME" \
+    -l "$LOCATION" \
+    --work-dir="$WORK_DIR" \
+    --vm-count=1 \
+    --delete-jobs-on-completion=false \
+    --delete-tasks-on-completion=false \
+    --terminate-jobs-on-completion=false
+
+cleanup_ce "$CE_CLEANUP"
+echo ""
+
+# ===================================================================
+# 9. Job max wall clock time edge cases
+# ===================================================================
+echo "--- 9. Job max wall clock time ---"
+
+CE_WALLCLOCK="test-wallclock-$$"
+
+run_tw "Create CE with 1d wall clock time" \
+    compute-envs add azure-batch forge \
+    -n "$CE_WALLCLOCK" \
+    --credentials="$CRED_NAME" \
+    -l "$LOCATION" \
+    --work-dir="$WORK_DIR" \
+    --vm-count=1 \
+    --job-max-wall-clock-time=1d
+
+cleanup_ce "$CE_WALLCLOCK"
+
+run_tw "Create CE with 180d wall clock time (max)" \
+    compute-envs add azure-batch forge \
+    -n "$CE_WALLCLOCK" \
+    --credentials="$CRED_NAME" \
+    -l "$LOCATION" \
+    --work-dir="$WORK_DIR" \
+    --vm-count=1 \
+    --job-max-wall-clock-time=180d
+
+cleanup_ce "$CE_WALLCLOCK"
+
+run_tw_expect_fail "Reject wall clock time > 180d" \
+    compute-envs add azure-batch forge \
+    -n "$CE_WALLCLOCK" \
+    --credentials="$CRED_NAME" \
+    -l "$LOCATION" \
+    --work-dir="$WORK_DIR" \
+    --vm-count=1 \
+    --job-max-wall-clock-time=181d
+
+run_tw_expect_fail "Reject invalid wall clock time format" \
+    compute-envs add azure-batch forge \
+    -n "$CE_WALLCLOCK" \
+    --credentials="$CRED_NAME" \
+    -l "$LOCATION" \
+    --work-dir="$WORK_DIR" \
+    --vm-count=1 \
+    --job-max-wall-clock-time=abc
+
+echo ""
+
+# ===================================================================
+# 10. Subnet validation
+# ===================================================================
+echo "--- 10. Subnet validation ---"
+
+CE_SUBNET="test-subnet-$$"
+
+run_tw_expect_fail "Reject invalid subnet ID format" \
+    compute-envs add azure-batch forge \
+    -n "$CE_SUBNET" \
+    --credentials="$CRED_NAME" \
+    -l "$LOCATION" \
+    --work-dir="$WORK_DIR" \
+    --vm-count=1 \
+    --subnet-id="invalid-subnet-id"
+
+echo ""
+
+# ===================================================================
+# Cleanup
+# ===================================================================
+echo "--- Cleanup ---"
+cleanup_credential "$CRED_NAME"
+echo "  Cleaned up test credential: $CRED_NAME"
+echo ""
+
+# ===================================================================
+# Summary
+# ===================================================================
+echo "============================================================"
+echo " Results: $PASS passed, $FAIL failed, $SKIP skipped"
+echo "============================================================"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Add Azure Entra (service principal) credentials support (`tw credentials add azure-entra`)
- Add managed identity options for head/pool client IDs and resource IDs in Forge and Manual Azure Batch CEs
- Add VNet/subnet support (`--subnet-id`) for private network isolation
- Add dual pool mode (`--dual-pool`) with separate head and worker pool configuration for Forge, and `--worker-pool` for Manual mode
- Add job max wall clock time (`--job-max-wall-clock-time`)
- Replace `JobCleanupPolicy` enum with 3 boolean toggles: `--delete-jobs-on-completion`, `--delete-tasks-on-completion`, `--terminate-jobs-on-completion`

**Note:** Requires tower-java-sdk bump to >= 1.133.0 for new model fields. Code will not compile until the SDK is updated.

### Platform PRs implemented
- [#10519](https://github.com/seqeralabs/platform/pull/10519) — Entra credentials for Azure Batch Forge and Fusion v2
- [#10577](https://github.com/seqeralabs/platform/pull/10577) — Separate Azure managed identities for head and compute jobs
- [#10541](https://github.com/seqeralabs/platform/pull/10541) — Private VNet/subnet support for Azure Batch CEs
- [#10636](https://github.com/seqeralabs/platform/pull/10636) — Separate head and worker pools for Azure Batch
- [#10708](https://github.com/seqeralabs/platform/pull/10708) — jobMaxWallClockTime for Azure Batch CEs
- [#10681](https://github.com/seqeralabs/platform/pull/10681) — Replace JobCleanupPolicy enum with boolean toggles

## Test plan
- [x] `AzureEntraProviderTest` — credential add flow verified
- [ ] Full test suite after SDK bump
- [ ] Manual verification of all new CLI options

🤖 Generated with [Claude Code](https://claude.com/claude-code)