### PR TITLE
feat: Group scheduler options and add --provisioning-model to AwsCloudPlatform

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AwsCloudPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AwsCloudPlatform.java
@@ -19,6 +19,7 @@ package io.seqera.tower.cli.commands.computeenvs.platforms;
 import io.seqera.tower.ApiException;
 import io.seqera.tower.model.AwsCloudConfig;
 import io.seqera.tower.model.ComputeEnvComputeConfig.PlatformEnum;
+import io.seqera.tower.model.SchedConfig;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Option;
 
@@ -36,8 +37,8 @@ public class AwsCloudPlatform extends AbstractPlatform<AwsCloudConfig> {
     @Option(names = {"--allow-buckets"}, description = "S3 buckets that the compute environment can access. Comma-separated list of S3 bucket names or paths to grant read-write permissions for workflow data.", split = ",")
     public List<String> allowBuckets;
 
-    @Option(names = {"--sched-enabled"}, description = "Enable the Seqera scheduler for this compute environment. Defaults to false if not specified.")
-    public boolean schedEnabled;
+    @ArgGroup(heading = "%nScheduler options:%n", validate = false)
+    public SchedOptions sched;
 
     @ArgGroup(heading = "%nAdvanced options:%n", validate = false)
     public AdvancedOptions adv;
@@ -53,11 +54,15 @@ public class AwsCloudPlatform extends AbstractPlatform<AwsCloudConfig> {
         config
                 .waveEnabled(true)
                 .fusion2Enabled(true)
-                .schedEnabled(schedEnabled)
+                .schedEnabled(sched != null && sched.schedEnabled)
 
                 // Main
                 .region(region)
                 .allowBuckets(allowBuckets);
+
+        if (sched != null && sched.provisioningModel != null) {
+            config.schedConfig(new SchedConfig().provisioningModel(sched.provisioningModel));
+        }
 
         // Advanced
         if (adv != null) {
@@ -80,6 +85,14 @@ public class AwsCloudPlatform extends AbstractPlatform<AwsCloudConfig> {
                 .environment(environmentVariables());
 
         return config;
+    }
+
+    public static class SchedOptions {
+        @Option(names = {"--sched-enabled"}, description = "Enable the Seqera scheduler for this compute environment. Defaults to false if not specified.")
+        public Boolean schedEnabled;
+
+        @Option(names = {"--provisioning-model"}, description = "Instance provisioning model used by the Seqera scheduler. Valid values: SPOT, SPOT_FIRST, ONDEMAND.")
+        public SchedConfig.ProvisioningModelEnum provisioningModel;
     }
 
     public static class AdvancedOptions {

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AwsCloudPlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AwsCloudPlatformTest.java
@@ -233,6 +233,70 @@ public class AwsCloudPlatformTest extends BaseCmdTest {
     }
 
     @Test
+    void testAddWithProvisioningModel(MockServerClient mock) throws IOException {
+        mock.reset();
+
+        // given
+        mock.when(
+                request()
+                        .withMethod("GET")
+                        .withPath("/credentials")
+                        .withQueryStringParameter("platformId", "aws-cloud"),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"credentials\":[{\"id\":\"6XfOhoztUq6de3Dw3X9LSb\",\"name\":\"aws\",\"description\":null,\"discriminator\":\"aws\",\"baseUrl\":null,\"category\":null,\"deleted\":null,\"lastUsed\":\"2021-09-08T18:20:46Z\",\"dateCreated\":\"2021-09-08T12:57:04Z\",\"lastUpdated\":\"2021-09-08T12:57:04Z\"}]}")
+        );
+
+        mock.when(
+                request()
+                        .withMethod("POST")
+                        .withPath("/compute-envs")
+                        .withBody(json("""
+                                {
+                                    "computeEnv": {
+                                        "name": "my-aws-cloud-sched-pm",
+                                        "platform": "aws-cloud",
+                                        "config": {
+                                            "workDir": "s3://my-bucket",
+                                            "region": "us-east-1",
+                                            "fusion2Enabled": true,
+                                            "waveEnabled": true,
+                                            "schedEnabled": true,
+                                            "schedConfig": {
+                                                "provisioningModel": "spot"
+                                            }
+                                        },
+                                        "credentialsId": "6XfOhoztUq6de3Dw3X9LSb"
+                                    }
+                                }""")),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}")
+        );
+
+        // when
+        ExecOut out = exec(mock, "compute-envs", "add", "aws-cloud",
+                "-n", "my-aws-cloud-sched-pm",
+                "--work-dir", "s3://my-bucket",
+                "-r", "us-east-1",
+                "--sched-enabled",
+                "--provisioning-model", "SPOT"
+        );
+
+        // then
+        var expected = new ComputeEnvAdded("aws-cloud", "isnEDBLvHDAIteOEF44ow", "my-aws-cloud-sched-pm", null, USER_WORKSPACE_NAME);
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+        assertEquals(expected.toString(), out.stdOut);
+    }
+
+    @Test
     void testAddWithSchedEnabledForbidden(MockServerClient mock) throws IOException {
         mock.reset();
 


### PR DESCRIPTION
Move --sched-enabled into a new SchedOptions ArgGroup and add --provisioning-model (SPOT, SPOT_FIRST, ONDEMAND) wired via SchedConfig, preparing the group for additional scheduler options in future iterations.

Contributes to [COMP-1588](https://seqera.atlassian.net/browse/COMP-1588)

[COMP-1588]: https://seqera.atlassian.net/browse/COMP-1588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ