### PR TITLE
Soften API version mismatch from error to warning in tw info

### DIFF
--- a/src/main/java/io/seqera/tower/cli/responses/InfoResponse.java
+++ b/src/main/java/io/seqera/tower/cli/responses/InfoResponse.java
@@ -95,7 +95,6 @@ public class InfoResponse extends Response {
 
     @Override
     public int getExitCode() {
-        // versionCheck == 0 is a warning, not a failure — don't fail the command for it
-        return (connectionCheck != 0 && credentialsCheck != 0) ? CommandLine.ExitCode.OK : CommandLine.ExitCode.SOFTWARE;
+        return (connectionCheck + versionCheck + credentialsCheck == 3) ? CommandLine.ExitCode.OK : CommandLine.ExitCode.SOFTWARE;
     }
 }

--- a/src/main/java/io/seqera/tower/cli/responses/InfoResponse.java
+++ b/src/main/java/io/seqera/tower/cli/responses/InfoResponse.java
@@ -41,6 +41,7 @@ public class InfoResponse extends Response {
     public void toString(PrintWriter out) {
         String ok = ansi("@|fg(green) OK|@");
         String fail = ansi("@|fg(red) FAILED|@");
+        String warn = ansi("@|fg(yellow) WARNING|@");
         String undefined = ansi("@|fg(yellow) UNDEFINED|@");
         String skipped = ansi("@|fg(yellow) SKIPPED|@");
 
@@ -59,7 +60,7 @@ public class InfoResponse extends Response {
         TableList healthTable = new TableList(out, 2);
         healthTable.setPrefix("    ");
         healthTable.addRow("Remote API server connection check", connectionCheck == 1 ? ok : connectionCheck == 0 ? fail : skipped);
-        healthTable.addRow("Tower API version check", versionCheck == 1 ? ok : versionCheck == 0 ? fail : skipped);
+        healthTable.addRow("Tower API version check", versionCheck == 1 ? ok : versionCheck == 0 ? warn : skipped);
         healthTable.addRow("Authentication API credential's token", credentialsCheck == 1 ? ok : credentialsCheck == 0 ? fail : skipped);
         healthTable.print();
 
@@ -72,7 +73,9 @@ public class InfoResponse extends Response {
         }
 
         if (versionCheck == 0) {
-            out.println(ansi(String.format("%n    @|bold,fg(red) Tower API version is %s while the minimum required version to be fully compatible is %s|@%n", opts.get("towerApiVersion"), opts.get("cliApiVersion"))));
+            out.println(ansi(String.format("%n    @|bold,fg(yellow) Warning:|@ Platform API version %s is older than this CLI's minimum (%s).", opts.get("towerApiVersion"), opts.get("cliApiVersion"))));
+            out.println(ansi("    Some tw commands may fail or return incomplete results."));
+            out.println(ansi(String.format("    To ensure full compatibility, upgrade Seqera Platform, or install a tw release matching your Platform version:%n    https://github.com/seqeralabs/tower-cli/releases%n")));
         }
 
         if (credentialsCheck == 0) {
@@ -92,6 +95,7 @@ public class InfoResponse extends Response {
 
     @Override
     public int getExitCode() {
-        return (connectionCheck + versionCheck + credentialsCheck == 3) ? CommandLine.ExitCode.OK : CommandLine.ExitCode.SOFTWARE;
+        // versionCheck == 0 is a warning, not a failure — don't fail the command for it
+        return (connectionCheck != 0 && credentialsCheck != 0) ? CommandLine.ExitCode.OK : CommandLine.ExitCode.SOFTWARE;
     }
 }

--- a/src/test/java/io/seqera/tower/cli/InfoCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/InfoCmdTest.java
@@ -122,8 +122,7 @@ public class InfoCmdTest extends BaseCmdTest {
         opts.put("userName", "jordi");
 
         assertEquals("", out.stdErr);
-        // Version mismatch is a warning, not a failure — see InfoResponse.getExitCode()
-        assertEquals(0, out.exitCode);
+        assertEquals(1, out.exitCode);
         assertEquals(chop(new InfoResponse(1,0,1, opts).toString()), out.stdOut);
     }
 

--- a/src/test/java/io/seqera/tower/cli/InfoCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/InfoCmdTest.java
@@ -122,7 +122,8 @@ public class InfoCmdTest extends BaseCmdTest {
         opts.put("userName", "jordi");
 
         assertEquals("", out.stdErr);
-        assertEquals(1, out.exitCode);
+        // Version mismatch is a warning, not a failure — see InfoResponse.getExitCode()
+        assertEquals(0, out.exitCode);
         assertEquals(chop(new InfoResponse(1,0,1, opts).toString()), out.stdOut);
     }
 


### PR DESCRIPTION
## Summary

Originating from FD-7550: the `tw info` API-version check currently renders as a red `FAILED` with the message *"Tower API version is X while the minimum required version to be fully compatible is Y"*, and exits non-zero. Customers read this as a blocking incompatibility, even though the CLI still works for most operations against the older Platform.

This PR reframes the check as a compatibility warning:

- Health table shows yellow `WARNING` instead of red `FAILED` for the version row.
- New message states the mismatch, the practical impact, and the two remediations (upgrade Platform, or install an older `tw` matching the Platform version).
- `getExitCode()` no longer fails on a version mismatch — only connection or auth failures produce a non-zero exit. Scripts running `tw info` as a health check no longer break for a non-fatal condition.

Example output:

```
Tower API version check                              WARNING

    Warning: Platform API version 1.20 is older than this CLI's minimum (1.30).
    Some tw commands may fail or return incomplete results.
    To ensure full compatibility, upgrade Seqera Platform, or install a tw
    release matching your Platform version:
    https://github.com/seqeralabs/tower-cli/releases
```

## Test plan

- [x] `./gradlew test` passes (existing `InfoCmdTest` does not assert on the warning text)
- [ ] Manually run `tw info` against a Platform older than the CLI's `versionApi` and confirm yellow WARNING + new message
- [x] Manually run `tw info` against a compatible Platform and confirm green OK
- [ ] Confirm `tw info` exit code is 0 when only the version check warns, non-zero on connection/auth failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)