### PR TITLE
fix: resolve dependabot security alerts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,32 @@
+// yumi-gradle-licenser is loaded via buildscript so we can constrain its
+// vulnerable transitive dependencies (log4j-core, plexus-utils). Keep the
+// version aligned with libs.versions.toml#licenserVersion.
+buildscript {
+    repositories {
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath 'dev.yumi:yumi-gradle-licenser:4.0.0'
+        constraints {
+            classpath('org.apache.logging.log4j:log4j-core:2.25.4') {
+                because 'GHSA-445c-vh5m-36rj, GHSA-6hg6-v5c8-fphq, GHSA-3pxv-7cmr-fjr4'
+            }
+            classpath('org.codehaus.plexus:plexus-utils:4.0.3') {
+                because 'GHSA-6fmv-xxpf-w3cw'
+            }
+        }
+    }
+}
+
 plugins {
     id 'java'
     id 'application'
     id 'jacoco'
-    alias(libs.plugins.yumiLicenser)
     alias(libs.plugins.graalvmNative)
     alias(libs.plugins.shadow)
 }
+
+apply plugin: 'dev.yumi.gradle.licenser'
 
 // define these in the `gradle.properties` file
 ext.githubUser = project.findProperty('github.packages.user')
@@ -23,6 +44,10 @@ repositories {
 }
 
 dependencies {
+    // Align all Jackson modules to a non-vulnerable version (GHSA-72hv-8253-57qq)
+    implementation(platform(libs.jacksonBom))
+    testImplementation(platform(libs.jacksonBom))
+
     implementation(libs.javaxAnnotation)
     implementation(libs.jakartaAnnotation)
     implementation(libs.slf4jApi)
@@ -59,6 +84,10 @@ license {
     rule(file('HEADER.txt'))
     exclude('**/*.properties')
     exclude('**/*.xml')
+    exclude('**/*.json')
+    exclude('**/*.csv')
+    exclude('**/*.txt')
+    exclude('**/*.sh')
     exclude('gradlew')
     exclude('conf/**')
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,12 +3,13 @@ classgraphVersion = "4.8.180"
 commonsCompressVersion = "1.28.0"
 commonsIoVersion = "2.22.0"
 graalvmNativeVersion = "0.10.6"
+jacksonBomVersion = "2.18.6"
 jacksonDatabindNullableVersion = "0.2.10"
 jakartaAnnotationVersion = "3.0.0"
 javaxAnnotationVersion = "1.3.2"
 jerseyVersion = "2.47"
 junitVersion = "5.12.2"
-licenserVersion = "3.0.1"
+licenserVersion = "4.0.0"
 logbackVersion = "1.5.32"
 mockserverVersion = "5.15.0"
 picocliVersion = "4.6.3"
@@ -21,6 +22,7 @@ xzVersion = "1.10"
 classgraph = { group = "io.github.classgraph", name = "classgraph", version.ref = "classgraphVersion" }
 commonsCompress = { group = "org.apache.commons", name = "commons-compress", version.ref = "commonsCompressVersion" }
 commonsIo = { group = "commons-io", name = "commons-io", version.ref = "commonsIoVersion" }
+jacksonBom = { group = "com.fasterxml.jackson", name = "jackson-bom", version.ref = "jacksonBomVersion" }
 jacksonDatabindNullable = { group = "org.openapitools", name = "jackson-databind-nullable", version.ref = "jacksonDatabindNullableVersion" }
 jakartaAnnotation = { group = "jakarta.annotation", name = "jakarta.annotation-api", version.ref = "jakartaAnnotationVersion" }
 javaxAnnotation = { group = "javax.annotation", name = "javax.annotation-api", version.ref = "javaxAnnotationVersion" }
@@ -44,6 +46,8 @@ towerJavaSdk = { group = "io.seqera.tower", name = "tower-java-sdk", version.ref
 xz = { group = "org.tukaani", name = "xz", version.ref = "xzVersion" }
 
 [plugins]
-yumiLicenser = { id = "dev.yumi.gradle.licenser", version.ref = "licenserVersion" }
+# yumi-gradle-licenser is applied via the buildscript {} block in build.gradle so
+# we can constrain its transitive dependencies. Keep build.gradle's classpath
+# coordinate aligned with the version declared above (licenserVersion).
 graalvmNative = { id = "org.graalvm.buildtools.native", version.ref = "graalvmNativeVersion" }
 shadow = { id = "com.gradleup.shadow", version.ref = "shadowVersion" }


### PR DESCRIPTION
## Summary

Fixes all 6 open Dependabot alerts on the repository.

| Alert | Dep | Was | Now | Path |
|---|---|---|---|---|
| #19/#18/#17 | log4j-core | 2.25.3 | **2.25.4** | buildscript (yumi licenser) |
| #16 (high) | plexus-utils | 4.0.2 | **4.0.3** | buildscript (yumi licenser) |
| #14 | jackson-core | 2.18.0 | **2.18.6** | runtimeClasspath (jersey) |
| #13 | jgit | 6.7.0 | **6.10.1** | buildscript (yumi licenser) |

## Changes

- **`dev.yumi.gradle.licenser` 3.0.1 → 4.0.0** — picks up jgit 6.10.1.
- **Licenser moved from `plugins {}` to `buildscript { dependencies { constraints { ... } } }`** so we can override its still-vulnerable transitives (log4j-core 2.25.3, plexus-utils 4.0.2). Once yumi 4.0.1+ ships with those bumps the buildscript block can be reverted to plain `plugins { alias(libs.plugins.yumiLicenser) }`.
- **Jackson BOM 2.18.6** added as a platform on both `implementation` and `testImplementation` — aligns `jackson-core`/`jackson-databind`/`jackson-annotations`/`jackson-module-jaxb-annotations` to 2.18.6.
- **Licenser 4.0.0 is stricter** about files without a registered header handler (failed on `.csv` in `src/test/resources`). Added excludes for `json`, `csv`, `txt`, `sh`.

## Verification

- `./gradlew buildEnvironment` → buildscript classpath shows `log4j-core 2.25.4`, `plexus-utils 4.0.3`, `jgit 6.10.1`.
- `./gradlew :dependencyInsight --dependency jackson-core --configuration runtimeClasspath` → 2.18.6 (by constraint).
- `./gradlew checkLicenses` → passes (60 test files scanned).
- Full `compileJava` not run locally (PAT lacks `read:packages` scope for `tower-java-sdk`); CI will validate.

## Test plan

- [ ] CI build passes
- [ ] CI unit tests pass
- [ ] Confirm Dependabot alerts close after merge / `security-submit-dependencies` workflow runs on master