### PR TITLE
feat: extend datasets commands visibility, labels, filter support

### DIFF
--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -1201,6 +1201,18 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"io.seqera.tower.cli.commands.datasets.DatasetMultiRefOptions",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"io.seqera.tower.cli.commands.datasets.DatasetMultiRefOptions$DatasetMultiRef",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"io.seqera.tower.cli.commands.datasets.DatasetRefOptions",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
@@ -1225,7 +1237,25 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"io.seqera.tower.cli.commands.datasets.HideCmd",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"io.seqera.tower.cli.commands.datasets.LabelsCmd",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"io.seqera.tower.cli.commands.datasets.ListCmd",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"io.seqera.tower.cli.commands.datasets.ShowCmd",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "methods":[{"name":"<init>","parameterTypes":[] }]
@@ -2149,6 +2179,12 @@
 },
 {
   "name":"io.seqera.tower.cli.responses.datasets.DatasetView",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "name":"io.seqera.tower.cli.responses.datasets.DatasetsVisibility",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true

--- a/src/main/java/io/seqera/tower/cli/commands/DatasetsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/DatasetsCmd.java
@@ -20,7 +20,10 @@ package io.seqera.tower.cli.commands;
 import io.seqera.tower.cli.commands.datasets.AddCmd;
 import io.seqera.tower.cli.commands.datasets.DeleteCmd;
 import io.seqera.tower.cli.commands.datasets.DownloadCmd;
+import io.seqera.tower.cli.commands.datasets.HideCmd;
+import io.seqera.tower.cli.commands.datasets.LabelsCmd;
 import io.seqera.tower.cli.commands.datasets.ListCmd;
+import io.seqera.tower.cli.commands.datasets.ShowCmd;
 import io.seqera.tower.cli.commands.datasets.UpdateCmd;
 import io.seqera.tower.cli.commands.datasets.UrlCmd;
 import io.seqera.tower.cli.commands.datasets.ViewCmd;
@@ -33,7 +36,10 @@ import picocli.CommandLine;
                 AddCmd.class,
                 DeleteCmd.class,
                 DownloadCmd.class,
+                HideCmd.class,
+                LabelsCmd.class,
                 ListCmd.class,
+                ShowCmd.class,
                 ViewCmd.class,
                 UpdateCmd.class,
                 UrlCmd.class,

--- a/src/main/java/io/seqera/tower/cli/commands/datasets/AbstractDatasetsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datasets/AbstractDatasetsCmd.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 public abstract class AbstractDatasetsCmd extends AbstractApiCmd {
 
     protected DatasetDto datasetByName(Long workspaceId, String datasetName) throws ApiException {
-        ListDatasetsResponse listDatasetsResponse = datasetsApi().listDatasets(workspaceId);
+        ListDatasetsResponse listDatasetsResponse = datasetsApi().listDatasetsV2(workspaceId, null, null, datasetName, null, null, null, List.of());
 
         if (listDatasetsResponse == null || listDatasetsResponse.getDatasets() == null) {
             throw new DatasetNotFoundException(workspaceRef(workspaceId));
@@ -57,7 +57,7 @@ public abstract class AbstractDatasetsCmd extends AbstractApiCmd {
         DatasetDto response;
 
         if (datasetRefOptions.dataset.datasetId != null) {
-            response = datasetsApi().describeDataset(wspId, datasetRefOptions.dataset.datasetId, List.of()).getDataset();
+            response = datasetsApi().describeDatasetV2(datasetRefOptions.dataset.datasetId, wspId, List.of()).getDataset();
         } else {
             response = datasetByName(wspId, datasetRefOptions.dataset.datasetName);
         }
@@ -68,7 +68,7 @@ public abstract class AbstractDatasetsCmd extends AbstractApiCmd {
     protected DatasetVersionDto fetchDatasetVersion(Long wspId, String datasetId, String datasetMediaType, Long version) throws ApiException {
         DatasetVersionDto datasetVersion;
 
-        ListDatasetVersionsResponse listDatasetVersionsResponse = datasetsApi().listDatasetVersions(wspId, datasetId, datasetMediaType);
+        ListDatasetVersionsResponse listDatasetVersionsResponse = datasetsApi().listDatasetVersionsV2(datasetId, wspId, datasetMediaType);
 
         if (listDatasetVersionsResponse == null || listDatasetVersionsResponse.getVersions() == null) {
             throw new TowerException(String.format("No versions were found for dataset %s", datasetId));
@@ -127,7 +127,7 @@ public abstract class AbstractDatasetsCmd extends AbstractApiCmd {
     }
 
     protected void deleteDatasetById(String datasetId, Long wspId) throws DatasetNotFoundException, ApiException {
-        datasetsApi().deleteDataset(wspId, datasetId);
+        datasetsApi().deleteDatasetV2(datasetId, wspId);
     }
 
 

--- a/src/main/java/io/seqera/tower/cli/commands/datasets/AbstractDatasetsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datasets/AbstractDatasetsCmd.java
@@ -26,6 +26,7 @@ import io.seqera.tower.model.ListDatasetVersionsResponse;
 import io.seqera.tower.model.ListDatasetsResponse;
 import picocli.CommandLine;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -49,29 +50,7 @@ public abstract class AbstractDatasetsCmd extends AbstractApiCmd {
             throw new DatasetNotFoundException(datasetName, workspaceRef(workspaceId));
         }
 
-        return datasetList.stream().findFirst().orElse(null);
-    }
-
-    protected List<DatasetDto> searchByName(Long workspaceId, String datasetName) throws ApiException {
-        ListDatasetsResponse listDatasetsResponse = datasetsApi().listDatasets(workspaceId);
-
-        if (datasetName == null) {
-            return listDatasetsResponse.getDatasets();
-        }
-
-        if (listDatasetsResponse == null || listDatasetsResponse.getDatasets() == null) {
-            throw new DatasetNotFoundException(workspaceRef(workspaceId));
-        }
-
-        List<DatasetDto> datasetList = listDatasetsResponse.getDatasets().stream()
-                .filter(it -> it.getName().startsWith(datasetName))
-                .collect(Collectors.toList());
-
-        if (datasetList.isEmpty()) {
-            throw new DatasetNotFoundException(datasetName, workspaceRef(workspaceId));
-        }
-
-        return datasetList;
+        return datasetList.get(0);
     }
 
     protected DatasetDto fetchDescribeDatasetResponse(DatasetRefOptions datasetRefOptions, Long wspId) throws ApiException {
@@ -127,6 +106,19 @@ public abstract class AbstractDatasetsCmd extends AbstractApiCmd {
 
     protected String getDatasetRef(DatasetRefOptions datasetRefOptions) {
         return datasetRefOptions.dataset.datasetName != null ? datasetRefOptions.dataset.datasetName : datasetRefOptions.dataset.datasetId;
+    }
+
+    protected List<String> resolveDatasetIds(DatasetMultiRefOptions options, Long wspId) throws ApiException {
+        List<String> ids = new ArrayList<>();
+        if (options.dataset.datasetIds != null) {
+            ids.addAll(options.dataset.datasetIds);
+        }
+        if (options.dataset.datasetNames != null) {
+            for (String name : options.dataset.datasetNames) {
+                ids.add(datasetByName(wspId, name).getId());
+            }
+        }
+        return ids;
     }
 
     protected void deleteDatasetByName(String datasetName, Long wspId) throws DatasetNotFoundException, ApiException {

--- a/src/main/java/io/seqera/tower/cli/commands/datasets/AbstractDatasetsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datasets/AbstractDatasetsCmd.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 public abstract class AbstractDatasetsCmd extends AbstractApiCmd {
 
     protected DatasetDto datasetByName(Long workspaceId, String datasetName) throws ApiException {
-        ListDatasetsResponse listDatasetsResponse = datasetsApi().listDatasetsV2(workspaceId, null, null, datasetName, null, null, null, List.of());
+        ListDatasetsResponse listDatasetsResponse = datasetsApi().listDatasetsV2(workspaceId, null, null, datasetName, null, null, "all", List.of());
 
         if (listDatasetsResponse == null || listDatasetsResponse.getDatasets() == null) {
             throw new DatasetNotFoundException(workspaceRef(workspaceId));

--- a/src/main/java/io/seqera/tower/cli/commands/datasets/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datasets/AddCmd.java
@@ -72,9 +72,9 @@ public class AddCmd extends AbstractDatasetsCmd {
 
         if (overwrite) tryDeleteDataset(name, wspId);
 
-        CreateDatasetResponse response = datasetsApi().createDataset(wspId, request);
+        CreateDatasetResponse response = datasetsApi().createDatasetV2(request, wspId);
 
-        datasetsApi().uploadDataset(wspId, response.getDataset().getId(), header, fileName.toFile());
+        datasetsApi().uploadDatasetV2(response.getDataset().getId(), wspId, header, fileName.toFile());
 
         return new DatasetCreate(response.getDataset().getName(), workspace.workspace, response.getDataset().getId());
     }

--- a/src/main/java/io/seqera/tower/cli/commands/datasets/DatasetMultiRefOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datasets/DatasetMultiRefOptions.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.commands.datasets;
+
+import picocli.CommandLine;
+
+import java.util.List;
+
+public class DatasetMultiRefOptions {
+
+    @CommandLine.ArgGroup(multiplicity = "1")
+    public DatasetMultiRef dataset;
+
+    public static class DatasetMultiRef {
+
+        @CommandLine.Option(names = {"-i", "--id"}, arity = "1..*", description = "Dataset unique identifier(s). May be combined with --name.")
+        public List<String> datasetIds;
+
+        @CommandLine.Option(names = {"-n", "--name"}, arity = "1..*", description = "Dataset name(s). May be combined with --id.")
+        public List<String> datasetNames;
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/datasets/DatasetsLabelsManager.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datasets/DatasetsLabelsManager.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.commands.datasets;
+
+import io.seqera.tower.ApiException;
+import io.seqera.tower.api.LabelsApi;
+import io.seqera.tower.cli.commands.labels.BaseLabelsManager;
+import io.seqera.tower.model.AssociateDatasetsLabelsRequest;
+
+import java.util.List;
+
+public class DatasetsLabelsManager extends BaseLabelsManager<AssociateDatasetsLabelsRequest, String> {
+
+    public DatasetsLabelsManager(LabelsApi api) {
+        super(api, "dataset");
+    }
+
+    @Override
+    protected AssociateDatasetsLabelsRequest getRequest(List<Long> labelsIds, String entityId) {
+        return new AssociateDatasetsLabelsRequest().labelIds(labelsIds).datasetIds(List.of(entityId));
+    }
+
+    @Override
+    protected void apply(AssociateDatasetsLabelsRequest request, Long wspId) throws ApiException {
+        api.applyLabelsToDatasets(request, wspId);
+    }
+
+    @Override
+    protected void remove(AssociateDatasetsLabelsRequest request, Long wspId) throws ApiException {
+        api.removeLabelsFromDatasets(request, wspId);
+    }
+
+    @Override
+    protected void append(AssociateDatasetsLabelsRequest request, Long wspId) throws ApiException {
+        api.addLabelsToDatasets(request, wspId);
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/datasets/HideCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datasets/HideCmd.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.commands.datasets;
+
+import io.seqera.tower.ApiException;
+import io.seqera.tower.cli.commands.global.WorkspaceRequiredOptions;
+import io.seqera.tower.cli.responses.Response;
+import io.seqera.tower.cli.responses.datasets.DatasetsVisibility;
+import io.seqera.tower.model.ChangeDatasetVisibilityRequest;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.util.List;
+
+@CommandLine.Command(
+        name = "hide",
+        description = "Hide one or more datasets"
+)
+public class HideCmd extends AbstractDatasetsCmd {
+
+    @CommandLine.Mixin
+    public DatasetMultiRefOptions datasetMultiRefOptions;
+
+    @CommandLine.Mixin
+    public WorkspaceRequiredOptions workspace;
+
+    @Override
+    protected Response exec() throws ApiException, IOException {
+        Long wspId = workspaceId(workspace.workspace);
+        List<String> ids = resolveDatasetIds(datasetMultiRefOptions, wspId);
+
+        ChangeDatasetVisibilityRequest request = new ChangeDatasetVisibilityRequest().datasetIds(ids);
+        datasetsApi().hideDatasets(request, wspId);
+
+        return new DatasetsVisibility(ids, workspace.workspace, true);
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/datasets/LabelsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datasets/LabelsCmd.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.commands.datasets;
+
+import io.seqera.tower.ApiException;
+import io.seqera.tower.cli.commands.labels.LabelsSubcmdOptions;
+import io.seqera.tower.cli.responses.Response;
+import picocli.CommandLine;
+
+import java.io.IOException;
+
+@CommandLine.Command(name = "labels", description = "Manage dataset labels")
+public class LabelsCmd extends AbstractDatasetsCmd {
+
+    @CommandLine.Mixin
+    public DatasetRefOptions datasetRefOptions;
+
+    @CommandLine.Mixin
+    public LabelsSubcmdOptions labelsSubcmdOptions;
+
+    @Override
+    protected Response exec() throws ApiException, IOException {
+        Long wspId = workspaceId(labelsSubcmdOptions.workspace.workspace);
+        String datasetId = fetchDescribeDatasetResponse(datasetRefOptions, wspId).getId();
+
+        DatasetsLabelsManager manager = new DatasetsLabelsManager(labelsApi());
+        return manager.execute(wspId, datasetId, labelsSubcmdOptions);
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/datasets/ListCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datasets/ListCmd.java
@@ -40,7 +40,8 @@ public class ListCmd extends AbstractDatasetsCmd {
     @CommandLine.Mixin
     public WorkspaceRequiredOptions workspace;
 
-    @CommandLine.Option(names = {"-f", "--filter"}, description = "Search expression passed to the server. Matches dataset name and other server-supported keys.")
+    @CommandLine.Option(names = {"-f", "--filter"}, description = "\"Optional filter criteria, allowing free text search on name or ID \" +\n" +
+            "            \"and keywords: `username`, `label`, `visibility`, `createdAfter`, `createdBefore`, `usedAfter`, `usedBefore`. Example keyword usage: -f label:custom-label.\".")
     public String filter;
 
     @CommandLine.Option(names = {"--show-hidden"}, description = "Include datasets marked as hidden in the results.", defaultValue = "false")

--- a/src/main/java/io/seqera/tower/cli/commands/datasets/ListCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datasets/ListCmd.java
@@ -40,8 +40,8 @@ public class ListCmd extends AbstractDatasetsCmd {
     @CommandLine.Mixin
     public WorkspaceRequiredOptions workspace;
 
-    @CommandLine.Option(names = {"-f", "--filter"}, description = "\"Optional filter criteria, allowing free text search on name or ID \" +\n" +
-            "            \"and keywords: `username`, `label`, `visibility`, `createdAfter`, `createdBefore`, `usedAfter`, `usedBefore`. Example keyword usage: -f label:custom-label.\".")
+    @CommandLine.Option(names = {"-f", "--filter"}, description = "Optional filter criteria, allowing free text search on name or ID " +
+            "and keywords: `username`, `label`, `visibility`, `createdAfter`, `createdBefore`, `usedAfter`, `usedBefore`. Example keyword usage: -f label:custom-label.")
     public String filter;
 
     @CommandLine.Option(names = {"--show-hidden"}, description = "Include datasets marked as hidden in the results.", defaultValue = "false")
@@ -74,6 +74,7 @@ public class ListCmd extends AbstractDatasetsCmd {
                 response.getDatasets(),
                 workspace.workspace,
                 Boolean.TRUE.equals(showLabelsOption.showLabels),
+                showHidden,
                 PaginationInfo.from(paginationOptions, response.getTotalSize())
         );
     }

--- a/src/main/java/io/seqera/tower/cli/commands/datasets/ListCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datasets/ListCmd.java
@@ -17,13 +17,18 @@
 package io.seqera.tower.cli.commands.datasets;
 
 import io.seqera.tower.ApiException;
+import io.seqera.tower.cli.commands.global.PaginationOptions;
+import io.seqera.tower.cli.commands.global.ShowLabelsOption;
 import io.seqera.tower.cli.commands.global.WorkspaceRequiredOptions;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.datasets.DatasetList;
-import io.seqera.tower.model.DatasetDto;
+import io.seqera.tower.cli.utils.PaginationInfo;
+import io.seqera.tower.model.DatasetQueryAttribute;
+import io.seqera.tower.model.ListDatasetsResponse;
 import picocli.CommandLine;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
 @CommandLine.Command(
@@ -35,14 +40,40 @@ public class ListCmd extends AbstractDatasetsCmd {
     @CommandLine.Mixin
     public WorkspaceRequiredOptions workspace;
 
-    @CommandLine.Option(names = {"-f", "--filter"}, description = "Filter datasets by name substring")
+    @CommandLine.Option(names = {"-f", "--filter"}, description = "Search expression passed to the server. Matches dataset name and other server-supported keys.")
     public String filter;
+
+    @CommandLine.Option(names = {"--show-hidden"}, description = "Include datasets marked as hidden in the results.", defaultValue = "false")
+    public boolean showHidden;
+
+    @CommandLine.Mixin
+    ShowLabelsOption showLabelsOption;
+
+    @CommandLine.Mixin
+    PaginationOptions paginationOptions;
 
     @Override
     protected Response exec() throws ApiException, IOException {
         Long wspId = workspaceId(workspace.workspace);
-        List<DatasetDto> response = searchByName(wspId, filter);
 
-        return new DatasetList(response, workspace.workspace);
+        Integer max = PaginationOptions.getMax(paginationOptions);
+        Integer offset = PaginationOptions.getOffset(paginationOptions, max);
+
+        List<DatasetQueryAttribute> attributes = Boolean.TRUE.equals(showLabelsOption.showLabels)
+                ? List.of(DatasetQueryAttribute.labels)
+                : Collections.emptyList();
+
+        String visibility = showHidden ? "all" : null;
+
+        ListDatasetsResponse response = datasetsApi().listDatasetsV2(
+                wspId, max, offset, filter, null, null, visibility, attributes
+        );
+
+        return new DatasetList(
+                response.getDatasets(),
+                workspace.workspace,
+                Boolean.TRUE.equals(showLabelsOption.showLabels),
+                PaginationInfo.from(paginationOptions, response.getTotalSize())
+        );
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/datasets/ShowCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datasets/ShowCmd.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.commands.datasets;
+
+import io.seqera.tower.ApiException;
+import io.seqera.tower.cli.commands.global.WorkspaceRequiredOptions;
+import io.seqera.tower.cli.responses.Response;
+import io.seqera.tower.cli.responses.datasets.DatasetsVisibility;
+import io.seqera.tower.model.ChangeDatasetVisibilityRequest;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.util.List;
+
+@CommandLine.Command(
+        name = "show",
+        description = "Make one or more hidden datasets visible"
+)
+public class ShowCmd extends AbstractDatasetsCmd {
+
+    @CommandLine.Mixin
+    public DatasetMultiRefOptions datasetMultiRefOptions;
+
+    @CommandLine.Mixin
+    public WorkspaceRequiredOptions workspace;
+
+    @Override
+    protected Response exec() throws ApiException, IOException {
+        Long wspId = workspaceId(workspace.workspace);
+        List<String> ids = resolveDatasetIds(datasetMultiRefOptions, wspId);
+
+        ChangeDatasetVisibilityRequest request = new ChangeDatasetVisibilityRequest().datasetIds(ids);
+        datasetsApi().showDatasets(request, wspId);
+
+        return new DatasetsVisibility(ids, workspace.workspace, false);
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/datasets/UpdateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datasets/UpdateCmd.java
@@ -64,10 +64,10 @@ public class UpdateCmd extends AbstractDatasetsCmd {
         request.setName(newName != null ? newName : dataset.getName());
         request.setDescription(description != null ? description : dataset.getDescription());
 
-        datasetsApi().updateDataset(wspId, dataset.getId(), request);
+        datasetsApi().updateDatasetV2(dataset.getId(), request, wspId);
 
         if (fileName != null) {
-            datasetsApi().uploadDataset(wspId, dataset.getId(), header, fileName.toFile());
+            datasetsApi().uploadDatasetV2(dataset.getId(), wspId, header, fileName.toFile());
         }
 
         return new DatasetUpdate(dataset.getName(), workspace.workspace, dataset.getId());

--- a/src/main/java/io/seqera/tower/cli/commands/datasets/versions/VersionsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/datasets/versions/VersionsCmd.java
@@ -42,7 +42,7 @@ public class VersionsCmd extends AbstractDatasetsCmd {
         DatasetDto dataset = fetchDescribeDatasetResponse(parentCommand.datasetRefOptions, wspId);
         String datasetRef = parentCommand.datasetRefOptions.dataset.datasetName != null ? parentCommand.datasetRefOptions.dataset.datasetName : parentCommand.datasetRefOptions.dataset.datasetId;
 
-        ListDatasetVersionsResponse response = datasetsApi().listDatasetVersions(wspId, dataset.getId(), dataset.getMediaType());
+        ListDatasetVersionsResponse response = datasetsApi().listDatasetVersionsV2(dataset.getId(), wspId, dataset.getMediaType());
 
         return new DatasetVersionsList(response.getVersions(), datasetRef, parentCommand.workspace.workspace);
     }

--- a/src/main/java/io/seqera/tower/cli/commands/runs/ListCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/ListCmd.java
@@ -40,7 +40,7 @@ public class ListCmd extends AbstractRunsCmd {
     @CommandLine.Mixin
     public WorkspaceOptionalOptions workspace;
 
-    @CommandLine.Option(names = {"-f", "--filter"}, description = "Filter pipeline runs by run name. Performs case-insensitive substring matching on the runName field.")
+    @CommandLine.Option(names = {"-f", "--filter"}, description = "Filter pipeline runs using the server search syntax. A bare value matches the run name substring; key:value pairs filter on supported keys (e.g. datasetId:<id>, runName:<name>, status:<status>, after:<date>, before:<date>).")
     public String filter;
 
     @CommandLine.Mixin

--- a/src/main/java/io/seqera/tower/cli/responses/datasets/DatasetList.java
+++ b/src/main/java/io/seqera/tower/cli/responses/datasets/DatasetList.java
@@ -33,19 +33,21 @@ public class DatasetList extends Response {
     public final List<DatasetDto> datasetList;
     public final String workspace;
     public final boolean showLabels;
+    public final boolean showHidden;
 
     @JsonIgnore
     @Nullable
     private final PaginationInfo paginationInfo;
 
     public DatasetList(List<DatasetDto> datasetList, String workspace) {
-        this(datasetList, workspace, false, null);
+        this(datasetList, workspace, false, false, null);
     }
 
-    public DatasetList(List<DatasetDto> datasetList, String workspace, boolean showLabels, @Nullable PaginationInfo paginationInfo) {
+    public DatasetList(List<DatasetDto> datasetList, String workspace, boolean showLabels, boolean showHidden, @Nullable PaginationInfo paginationInfo) {
         this.datasetList = datasetList;
         this.workspace = workspace;
         this.showLabels = showLabels;
+        this.showHidden = showHidden;
         this.paginationInfo = paginationInfo;
     }
 
@@ -58,7 +60,8 @@ public class DatasetList extends Response {
             return;
         }
 
-        List<String> desc = new ArrayList<>(List.of("ID", "Name", "Created", "Hidden"));
+        List<String> desc = new ArrayList<>(List.of("ID", "Name", "Created"));
+        if (showHidden) desc.add("Hidden");
         if (showLabels) desc.add("Labels");
 
         TableList table = new TableList(out, desc.size(), desc.toArray(new String[0])).sortBy(0);
@@ -67,9 +70,9 @@ public class DatasetList extends Response {
             List<String> row = new ArrayList<>(List.of(
                     ds.getId(),
                     ds.getName(),
-                    FormatHelper.formatDate(ds.getDateCreated()),
-                    Boolean.TRUE.equals(ds.getHidden()) ? "yes" : "no"
+                    FormatHelper.formatDate(ds.getDateCreated())
             ));
+            if (showHidden) row.add(Boolean.TRUE.equals(ds.getHidden()) ? "yes" : "no");
             if (showLabels) row.add(FormatHelper.formatLabels(ds.getLabels()));
             table.addRow(row.toArray(new String[0]));
         });

--- a/src/main/java/io/seqera/tower/cli/responses/datasets/DatasetList.java
+++ b/src/main/java/io/seqera/tower/cli/responses/datasets/DatasetList.java
@@ -16,37 +16,66 @@
 
 package io.seqera.tower.cli.responses.datasets;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.utils.FormatHelper;
+import io.seqera.tower.cli.utils.PaginationInfo;
 import io.seqera.tower.cli.utils.TableList;
 import io.seqera.tower.model.DatasetDto;
 
+import jakarta.annotation.Nullable;
 import java.io.PrintWriter;
+import java.util.ArrayList;
 import java.util.List;
 
 public class DatasetList extends Response {
 
     public final List<DatasetDto> datasetList;
     public final String workspace;
+    public final boolean showLabels;
+
+    @JsonIgnore
+    @Nullable
+    private final PaginationInfo paginationInfo;
 
     public DatasetList(List<DatasetDto> datasetList, String workspace) {
+        this(datasetList, workspace, false, null);
+    }
+
+    public DatasetList(List<DatasetDto> datasetList, String workspace, boolean showLabels, @Nullable PaginationInfo paginationInfo) {
         this.datasetList = datasetList;
         this.workspace = workspace;
+        this.showLabels = showLabels;
+        this.paginationInfo = paginationInfo;
     }
 
     @Override
     public void toString(PrintWriter out) {
         out.println(ansi(String.format("%n  @|bold Datasets at %s workspace:|@%n", workspace)));
 
-        if (datasetList.isEmpty()) {
+        if (datasetList == null || datasetList.isEmpty()) {
             out.println(ansi("    @|yellow No datasets found|@"));
             return;
         }
 
-        TableList table = new TableList(out, 3, "ID", "Name", "Created").sortBy(0);
+        List<String> desc = new ArrayList<>(List.of("ID", "Name", "Created", "Hidden"));
+        if (showLabels) desc.add("Labels");
+
+        TableList table = new TableList(out, desc.size(), desc.toArray(new String[0])).sortBy(0);
         table.setPrefix("    ");
-        datasetList.forEach(ds -> table.addRow(ds.getId(), ds.getName(), FormatHelper.formatDate(ds.getDateCreated())));
+        datasetList.forEach(ds -> {
+            List<String> row = new ArrayList<>(List.of(
+                    ds.getId(),
+                    ds.getName(),
+                    FormatHelper.formatDate(ds.getDateCreated()),
+                    Boolean.TRUE.equals(ds.getHidden()) ? "yes" : "no"
+            ));
+            if (showLabels) row.add(FormatHelper.formatLabels(ds.getLabels()));
+            table.addRow(row.toArray(new String[0]));
+        });
         table.print();
+
+        PaginationInfo.addFooter(out, paginationInfo);
 
         out.println("");
     }

--- a/src/main/java/io/seqera/tower/cli/responses/datasets/DatasetsVisibility.java
+++ b/src/main/java/io/seqera/tower/cli/responses/datasets/DatasetsVisibility.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.responses.datasets;
+
+import io.seqera.tower.cli.responses.Response;
+
+import java.io.PrintWriter;
+import java.util.List;
+
+public class DatasetsVisibility extends Response {
+
+    public final List<String> datasetIds;
+    public final String workspace;
+    public final boolean hidden;
+
+    public DatasetsVisibility(List<String> datasetIds, String workspace, boolean hidden) {
+        this.datasetIds = datasetIds;
+        this.workspace = workspace;
+        this.hidden = hidden;
+    }
+
+    @Override
+    public void toString(PrintWriter out) {
+        String action = hidden ? "hidden" : "shown";
+        out.println(ansi(String.format("%n  @|yellow Datasets %s at %s workspace:|@", action, workspace)));
+        datasetIds.forEach(id -> out.println(ansi(String.format("    - %s", id))));
+        out.println("");
+    }
+}

--- a/src/test/java/io/seqera/tower/cli/datasets/DatasetsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/datasets/DatasetsCmdTest.java
@@ -279,7 +279,8 @@ public class DatasetsCmdTest extends BaseCmdTest {
         mock.when(
                 request().withMethod("GET").withPath("/datasets")
                         .withQueryStringParameter("workspaceId", "249664655368293")
-                        .withQueryStringParameter("search", "dataset2"), exactly(1)
+                        .withQueryStringParameter("search", "dataset2")
+                        .withQueryStringParameter("visibility", "all"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("datasets/datasets_list")).withContentType(MediaType.APPLICATION_JSON)
         );
@@ -488,7 +489,8 @@ public class DatasetsCmdTest extends BaseCmdTest {
         mock.when(
                 request().withMethod("GET").withPath("/datasets")
                         .withQueryStringParameter("workspaceId", "249664655368293")
-                        .withQueryStringParameter("search", "dataset1"), exactly(1)
+                        .withQueryStringParameter("search", "dataset1")
+                        .withQueryStringParameter("visibility", "all"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("datasets/datasets_list")).withContentType(MediaType.APPLICATION_JSON)
         );
@@ -518,7 +520,8 @@ public class DatasetsCmdTest extends BaseCmdTest {
         mock.when(
                 request().withMethod("GET").withPath("/datasets")
                         .withQueryStringParameter("workspaceId", "249664655368293")
-                        .withQueryStringParameter("search", "dataset1"), exactly(1)
+                        .withQueryStringParameter("search", "dataset1")
+                        .withQueryStringParameter("visibility", "all"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("datasets/datasets_list")).withContentType(MediaType.APPLICATION_JSON)
         );

--- a/src/test/java/io/seqera/tower/cli/datasets/DatasetsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/datasets/DatasetsCmdTest.java
@@ -28,6 +28,8 @@ import io.seqera.tower.cli.responses.datasets.DatasetUpdate;
 import io.seqera.tower.cli.responses.datasets.DatasetUrl;
 import io.seqera.tower.cli.responses.datasets.DatasetVersionsList;
 import io.seqera.tower.cli.responses.datasets.DatasetView;
+import io.seqera.tower.cli.responses.datasets.DatasetsVisibility;
+import io.seqera.tower.cli.responses.labels.ManageLabels;
 import io.seqera.tower.model.DatasetDto;
 import io.seqera.tower.model.DatasetVersionDto;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -41,12 +43,14 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.List;
 
 import static io.seqera.tower.cli.utils.JsonHelper.parseJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockserver.matchers.Times.exactly;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.model.JsonBody.json;
 
 public class DatasetsCmdTest extends BaseCmdTest {
 
@@ -55,7 +59,8 @@ public class DatasetsCmdTest extends BaseCmdTest {
     void testList(OutputType format, MockServerClient mock) throws JsonProcessingException {
 
         mock.when(
-                request().withMethod("GET").withPath("/workspaces/249664655368293/datasets"), exactly(1)
+                request().withMethod("GET").withPath("/datasets")
+                        .withQueryStringParameter("workspaceId", "249664655368293"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("datasets/datasets_list")).withContentType(MediaType.APPLICATION_JSON)
         );
@@ -372,5 +377,183 @@ public class DatasetsCmdTest extends BaseCmdTest {
         assertEquals(errorMessage(out.app, new TowerException(String.format("File path '%s' do not exists.", Path.of("path/that/do/not/exist/file.tsv")))), out.stdErr);
         assertEquals("", out.stdOut);
         assertEquals(1, out.exitCode);
+    }
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testListWithFilter(OutputType format, MockServerClient mock) throws JsonProcessingException {
+
+        mock.when(
+                request().withMethod("GET").withPath("/datasets")
+                        .withQueryStringParameter("workspaceId", "249664655368293")
+                        .withQueryStringParameter("search", "data"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("datasets/datasets_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(format, mock, "datasets", "list", "-w", "249664655368293", "--filter", "data");
+
+        assertOutput(format, out, new DatasetList(Arrays.asList(
+                parseJson("{\"id\":\"4D9TP0w2pM0qmwqVHgrgBK\",\"name\":\"dataset1\",\"description\":null,\"mediaType\":null,\"deleted\":false,\"dateCreated\":\"2021-11-26T14:51:20+01:00\",\"lastUpdated\":\"2021-11-26T14:51:20+01:00\"}", DatasetDto.class),
+                parseJson("{\"id\":\"1W2FqBiI6WoNokQTkPkEzo\",\"name\":\"dataset2\",\"description\":null,\"mediaType\":null,\"deleted\":false,\"dateCreated\":\"2021-11-29T08:05:44+01:00\",\"lastUpdated\":\"2021-11-29T08:05:44+01:00\"}", DatasetDto.class)
+        ), "249664655368293"));
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+    }
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testListShowHidden(OutputType format, MockServerClient mock) throws JsonProcessingException {
+
+        mock.when(
+                request().withMethod("GET").withPath("/datasets")
+                        .withQueryStringParameter("workspaceId", "249664655368293")
+                        .withQueryStringParameter("visibility", "all"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("datasets/datasets_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(format, mock, "datasets", "list", "-w", "249664655368293", "--show-hidden");
+
+        assertOutput(format, out, new DatasetList(Arrays.asList(
+                parseJson("{\"id\":\"4D9TP0w2pM0qmwqVHgrgBK\",\"name\":\"dataset1\",\"description\":null,\"mediaType\":null,\"deleted\":false,\"dateCreated\":\"2021-11-26T14:51:20+01:00\",\"lastUpdated\":\"2021-11-26T14:51:20+01:00\"}", DatasetDto.class),
+                parseJson("{\"id\":\"1W2FqBiI6WoNokQTkPkEzo\",\"name\":\"dataset2\",\"description\":null,\"mediaType\":null,\"deleted\":false,\"dateCreated\":\"2021-11-29T08:05:44+01:00\",\"lastUpdated\":\"2021-11-29T08:05:44+01:00\"}", DatasetDto.class)
+        ), "249664655368293"));
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+    }
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testHideById(OutputType format, MockServerClient mock) {
+        mock.when(
+                request().withMethod("POST").withPath("/datasets/hide")
+                        .withQueryStringParameter("workspaceId", "249664655368293")
+                        .withBody(json("{\"datasetIds\":[\"4D9TP0w2pM0qmwqVHgrgBK\",\"1W2FqBiI6WoNokQTkPkEzo\"]}")),
+                exactly(1)
+        ).respond(
+                response().withStatusCode(204)
+        );
+
+        ExecOut out = exec(format, mock, "datasets", "hide", "-w", "249664655368293",
+                "-i", "4D9TP0w2pM0qmwqVHgrgBK", "-i", "1W2FqBiI6WoNokQTkPkEzo");
+
+        assertOutput(format, out, new DatasetsVisibility(
+                List.of("4D9TP0w2pM0qmwqVHgrgBK", "1W2FqBiI6WoNokQTkPkEzo"),
+                "249664655368293", true));
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+    }
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testShowById(OutputType format, MockServerClient mock) {
+        mock.when(
+                request().withMethod("POST").withPath("/datasets/show")
+                        .withQueryStringParameter("workspaceId", "249664655368293")
+                        .withBody(json("{\"datasetIds\":[\"4D9TP0w2pM0qmwqVHgrgBK\"]}")),
+                exactly(1)
+        ).respond(
+                response().withStatusCode(204)
+        );
+
+        ExecOut out = exec(format, mock, "datasets", "show", "-w", "249664655368293",
+                "-i", "4D9TP0w2pM0qmwqVHgrgBK");
+
+        assertOutput(format, out, new DatasetsVisibility(
+                List.of("4D9TP0w2pM0qmwqVHgrgBK"),
+                "249664655368293", false));
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+    }
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testHideByName(OutputType format, MockServerClient mock) {
+        mock.when(
+                request().withMethod("GET").withPath("/workspaces/249664655368293/datasets"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("datasets/datasets_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("POST").withPath("/datasets/hide")
+                        .withQueryStringParameter("workspaceId", "249664655368293")
+                        .withBody(json("{\"datasetIds\":[\"4D9TP0w2pM0qmwqVHgrgBK\"]}")),
+                exactly(1)
+        ).respond(
+                response().withStatusCode(204)
+        );
+
+        ExecOut out = exec(format, mock, "datasets", "hide", "-w", "249664655368293",
+                "-n", "dataset1");
+
+        assertOutput(format, out, new DatasetsVisibility(
+                List.of("4D9TP0w2pM0qmwqVHgrgBK"),
+                "249664655368293", true));
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+    }
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testShowByName(OutputType format, MockServerClient mock) {
+        mock.when(
+                request().withMethod("GET").withPath("/workspaces/249664655368293/datasets"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("datasets/datasets_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("POST").withPath("/datasets/show")
+                        .withQueryStringParameter("workspaceId", "249664655368293")
+                        .withBody(json("{\"datasetIds\":[\"4D9TP0w2pM0qmwqVHgrgBK\"]}")),
+                exactly(1)
+        ).respond(
+                response().withStatusCode(204)
+        );
+
+        ExecOut out = exec(format, mock, "datasets", "show", "-w", "249664655368293",
+                "-n", "dataset1");
+
+        assertOutput(format, out, new DatasetsVisibility(
+                List.of("4D9TP0w2pM0qmwqVHgrgBK"),
+                "249664655368293", false));
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+    }
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testLabelsApply(OutputType format, MockServerClient mock) {
+        mock.when(
+                request().withMethod("GET").withPath("/workspaces/249664655368293/datasets/4D9TP0w2pM0qmwqVHgrgBK/metadata"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("datasets/dataset_metadata")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/labels")
+                        .withQueryStringParameter("search", "foo"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"labels\":[{\"id\":111,\"name\":\"foo\",\"value\":null,\"resource\":false,\"isDefault\":false}],\"totalSize\":1}")
+        );
+
+        mock.when(
+                request().withMethod("POST").withPath("/datasets/labels/apply")
+                        .withQueryStringParameter("workspaceId", "249664655368293")
+                        .withBody(json("{\"datasetIds\":[\"4D9TP0w2pM0qmwqVHgrgBK\"],\"labelIds\":[111]}")),
+                exactly(1)
+        ).respond(
+                response().withStatusCode(204)
+        );
+
+        ExecOut out = exec(format, mock, "datasets", "labels", "-w", "249664655368293",
+                "-i", "4D9TP0w2pM0qmwqVHgrgBK", "foo");
+
+        assertOutput(format, out, new ManageLabels("set", "dataset", "4D9TP0w2pM0qmwqVHgrgBK", 249664655368293L));
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
     }
 }

--- a/src/test/java/io/seqera/tower/cli/datasets/DatasetsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/datasets/DatasetsCmdTest.java
@@ -434,7 +434,7 @@ public class DatasetsCmdTest extends BaseCmdTest {
         assertOutput(format, out, new DatasetList(Arrays.asList(
                 parseJson("{\"id\":\"4D9TP0w2pM0qmwqVHgrgBK\",\"name\":\"dataset1\",\"description\":null,\"mediaType\":null,\"deleted\":false,\"dateCreated\":\"2021-11-26T14:51:20+01:00\",\"lastUpdated\":\"2021-11-26T14:51:20+01:00\"}", DatasetDto.class),
                 parseJson("{\"id\":\"1W2FqBiI6WoNokQTkPkEzo\",\"name\":\"dataset2\",\"description\":null,\"mediaType\":null,\"deleted\":false,\"dateCreated\":\"2021-11-29T08:05:44+01:00\",\"lastUpdated\":\"2021-11-29T08:05:44+01:00\"}", DatasetDto.class)
-        ), "249664655368293"));
+        ), "249664655368293", false, true, null));
         assertEquals("", out.stdErr);
         assertEquals(0, out.exitCode);
     }

--- a/src/test/java/io/seqera/tower/cli/datasets/DatasetsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/datasets/DatasetsCmdTest.java
@@ -95,7 +95,8 @@ public class DatasetsCmdTest extends BaseCmdTest {
     @EnumSource(OutputType.class)
     void testView(OutputType format, MockServerClient mock) throws JsonProcessingException {
         mock.when(
-                request().withMethod("GET").withPath("/workspaces/249664655368293/datasets/4D9TP0w2pM0qmwqVHgrgBK/metadata"), exactly(1)
+                request().withMethod("GET").withPath("/datasets/4D9TP0w2pM0qmwqVHgrgBK/metadata")
+                        .withQueryStringParameter("workspaceId", "249664655368293"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("datasets/dataset_metadata")).withContentType(MediaType.APPLICATION_JSON)
         );
@@ -119,13 +120,15 @@ public class DatasetsCmdTest extends BaseCmdTest {
     @EnumSource(OutputType.class)
     void testVersions(OutputType format, MockServerClient mock) throws JsonProcessingException {
         mock.when(
-                request().withMethod("GET").withPath("/workspaces/249664655368293/datasets/4D9TP0w2pM0qmwqVHgrgBK/metadata"), exactly(1)
+                request().withMethod("GET").withPath("/datasets/4D9TP0w2pM0qmwqVHgrgBK/metadata")
+                        .withQueryStringParameter("workspaceId", "249664655368293"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("datasets/dataset_metadata")).withContentType(MediaType.APPLICATION_JSON)
         );
 
         mock.when(
-                request().withMethod("GET").withPath("/workspaces/249664655368293/datasets/4D9TP0w2pM0qmwqVHgrgBK/versions"), exactly(1)
+                request().withMethod("GET").withPath("/datasets/4D9TP0w2pM0qmwqVHgrgBK/versions")
+                        .withQueryStringParameter("workspaceId", "249664655368293"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("datasets/dataset_versions")).withContentType(MediaType.APPLICATION_JSON)
         );
@@ -162,13 +165,15 @@ public class DatasetsCmdTest extends BaseCmdTest {
     @EnumSource(OutputType.class)
     void testDelete(OutputType format, MockServerClient mock) {
         mock.when(
-                request().withMethod("GET").withPath("/workspaces/249664655368293/datasets/4D9TP0w2pM0qmwqVHgrgBK/metadata"), exactly(1)
+                request().withMethod("GET").withPath("/datasets/4D9TP0w2pM0qmwqVHgrgBK/metadata")
+                        .withQueryStringParameter("workspaceId", "249664655368293"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("datasets/dataset_metadata")).withContentType(MediaType.APPLICATION_JSON)
         );
 
         mock.when(
-                request().withMethod("DELETE").withPath("/workspaces/249664655368293/datasets/4D9TP0w2pM0qmwqVHgrgBK"), exactly(1)
+                request().withMethod("DELETE").withPath("/datasets/4D9TP0w2pM0qmwqVHgrgBK")
+                        .withQueryStringParameter("workspaceId", "249664655368293"), exactly(1)
         ).respond(
                 response().withStatusCode(204)
         );
@@ -185,13 +190,15 @@ public class DatasetsCmdTest extends BaseCmdTest {
     void testUrl(OutputType format, MockServerClient mock) throws JsonProcessingException {
 
         mock.when(
-                request().withMethod("GET").withPath("/workspaces/249664655368293/datasets/4D9TP0w2pM0qmwqVHgrgBK/metadata"), exactly(1)
+                request().withMethod("GET").withPath("/datasets/4D9TP0w2pM0qmwqVHgrgBK/metadata")
+                        .withQueryStringParameter("workspaceId", "249664655368293"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("datasets/dataset_metadata")).withContentType(MediaType.APPLICATION_JSON)
         );
 
         mock.when(
-                request().withMethod("GET").withPath("/workspaces/249664655368293/datasets/4D9TP0w2pM0qmwqVHgrgBK/versions"), exactly(1)
+                request().withMethod("GET").withPath("/datasets/4D9TP0w2pM0qmwqVHgrgBK/versions")
+                        .withQueryStringParameter("workspaceId", "249664655368293"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("datasets/dataset_versions")).withContentType(MediaType.APPLICATION_JSON)
         );
@@ -208,13 +215,15 @@ public class DatasetsCmdTest extends BaseCmdTest {
     @EnumSource(OutputType.class)
     void testDownload(OutputType format, MockServerClient mock) throws IOException {
         mock.when(
-                request().withMethod("GET").withPath("/workspaces/249664655368293/datasets/4D9TP0w2pM0qmwqVHgrgBK/metadata"), exactly(1)
+                request().withMethod("GET").withPath("/datasets/4D9TP0w2pM0qmwqVHgrgBK/metadata")
+                        .withQueryStringParameter("workspaceId", "249664655368293"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("datasets/dataset_metadata")).withContentType(MediaType.APPLICATION_JSON)
         );
 
         mock.when(
-                request().withMethod("GET").withPath("/workspaces/249664655368293/datasets/4D9TP0w2pM0qmwqVHgrgBK/versions"), exactly(1)
+                request().withMethod("GET").withPath("/datasets/4D9TP0w2pM0qmwqVHgrgBK/versions")
+                        .withQueryStringParameter("workspaceId", "249664655368293"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("datasets/dataset_versions")).withContentType(MediaType.APPLICATION_JSON)
         );
@@ -240,14 +249,16 @@ public class DatasetsCmdTest extends BaseCmdTest {
     @EnumSource(OutputType.class)
     void testAdd(OutputType format, MockServerClient mock) throws IOException {
         mock.when(
-                request().withMethod("POST").withPath("/workspaces/249664655368293/datasets"), exactly(1)
+                request().withMethod("POST").withPath("/datasets")
+                        .withQueryStringParameter("workspaceId", "249664655368293"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("datasets/dataset_created_response")).withContentType(MediaType.APPLICATION_JSON)
         );
 
         mock.when(
                 request().withMethod("POST")
-                        .withPath("/workspaces/249664655368293/datasets/1W3BTHWgRH71OJmOPMdG7S/upload")
+                        .withPath("/datasets/1W3BTHWgRH71OJmOPMdG7S/upload")
+                        .withQueryStringParameter("workspaceId", "249664655368293")
                         .withQueryStringParameter("header", "false")
                 , exactly(1)
         ).respond(
@@ -266,19 +277,16 @@ public class DatasetsCmdTest extends BaseCmdTest {
     void testAddWithOverwrite(OutputType format, MockServerClient mock) throws IOException {
 
         mock.when(
-                request().withMethod("GET").withPath("/workspaces/249664655368293/datasets/4D9TP0w2pM0qmwqVHgrgBK/metadata"), exactly(1)
-        ).respond(
-                response().withStatusCode(200).withBody(loadResource("datasets/dataset_metadata")).withContentType(MediaType.APPLICATION_JSON)
-        );
-
-        mock.when(
-                request().withMethod("GET").withPath("/workspaces/249664655368293/datasets"), exactly(1)
+                request().withMethod("GET").withPath("/datasets")
+                        .withQueryStringParameter("workspaceId", "249664655368293")
+                        .withQueryStringParameter("search", "dataset2"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("datasets/datasets_list")).withContentType(MediaType.APPLICATION_JSON)
         );
 
         mock.when(
-                request().withMethod("POST").withPath("/workspaces/249664655368293/datasets"), exactly(1)
+                request().withMethod("POST").withPath("/datasets")
+                        .withQueryStringParameter("workspaceId", "249664655368293"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(JsonBody.json("{\n" +
                         "  \"dataset\": {\n" +
@@ -295,7 +303,8 @@ public class DatasetsCmdTest extends BaseCmdTest {
 
         mock.when(
                 request().withMethod("POST")
-                        .withPath("/workspaces/249664655368293/datasets/1W3BTHWgRH71OJmOPMdG7S/upload")
+                        .withPath("/datasets/1W3BTHWgRH71OJmOPMdG7S/upload")
+                        .withQueryStringParameter("workspaceId", "249664655368293")
                         .withQueryStringParameter("header", "false")
                 , exactly(1)
         ).respond(
@@ -303,7 +312,8 @@ public class DatasetsCmdTest extends BaseCmdTest {
         );
 
         mock.when(
-                request().withMethod("DELETE").withPath("/workspaces/249664655368293/datasets/1W2FqBiI6WoNokQTkPkEzo"), exactly(1)
+                request().withMethod("DELETE").withPath("/datasets/1W2FqBiI6WoNokQTkPkEzo")
+                        .withQueryStringParameter("workspaceId", "249664655368293"), exactly(1)
         ).respond(
                 response().withStatusCode(204)
         );
@@ -319,13 +329,15 @@ public class DatasetsCmdTest extends BaseCmdTest {
     @EnumSource(OutputType.class)
     void testUpdate(OutputType format, MockServerClient mock) {
         mock.when(
-                request().withMethod("GET").withPath("/workspaces/249664655368293/datasets/4D9TP0w2pM0qmwqVHgrgBK/metadata"), exactly(1)
+                request().withMethod("GET").withPath("/datasets/4D9TP0w2pM0qmwqVHgrgBK/metadata")
+                        .withQueryStringParameter("workspaceId", "249664655368293"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("datasets/dataset_metadata")).withContentType(MediaType.APPLICATION_JSON)
         );
 
         mock.when(
-                request().withMethod("PUT").withPath("/workspaces/249664655368293/datasets/4D9TP0w2pM0qmwqVHgrgBK"), exactly(1)
+                request().withMethod("PUT").withPath("/datasets/4D9TP0w2pM0qmwqVHgrgBK")
+                        .withQueryStringParameter("workspaceId", "249664655368293"), exactly(1)
         ).respond(
                 response().withStatusCode(204)
         );
@@ -341,20 +353,23 @@ public class DatasetsCmdTest extends BaseCmdTest {
     @EnumSource(OutputType.class)
     void testUpdateWithFile(OutputType format, MockServerClient mock) throws IOException {
         mock.when(
-                request().withMethod("GET").withPath("/workspaces/249664655368293/datasets/4D9TP0w2pM0qmwqVHgrgBK/metadata"), exactly(1)
+                request().withMethod("GET").withPath("/datasets/4D9TP0w2pM0qmwqVHgrgBK/metadata")
+                        .withQueryStringParameter("workspaceId", "249664655368293"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("datasets/dataset_metadata")).withContentType(MediaType.APPLICATION_JSON)
         );
 
         mock.when(
-                request().withMethod("PUT").withPath("/workspaces/249664655368293/datasets/4D9TP0w2pM0qmwqVHgrgBK"), exactly(1)
+                request().withMethod("PUT").withPath("/datasets/4D9TP0w2pM0qmwqVHgrgBK")
+                        .withQueryStringParameter("workspaceId", "249664655368293"), exactly(1)
         ).respond(
                 response().withStatusCode(204)
         );
 
         mock.when(
                 request().withMethod("POST")
-                        .withPath("/workspaces/249664655368293/datasets/4D9TP0w2pM0qmwqVHgrgBK/upload")
+                        .withPath("/datasets/4D9TP0w2pM0qmwqVHgrgBK/upload")
+                        .withQueryStringParameter("workspaceId", "249664655368293")
                         .withQueryStringParameter("header", "false")
                 , exactly(1)
         ).respond(
@@ -471,7 +486,9 @@ public class DatasetsCmdTest extends BaseCmdTest {
     @EnumSource(OutputType.class)
     void testHideByName(OutputType format, MockServerClient mock) {
         mock.when(
-                request().withMethod("GET").withPath("/workspaces/249664655368293/datasets"), exactly(1)
+                request().withMethod("GET").withPath("/datasets")
+                        .withQueryStringParameter("workspaceId", "249664655368293")
+                        .withQueryStringParameter("search", "dataset1"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("datasets/datasets_list")).withContentType(MediaType.APPLICATION_JSON)
         );
@@ -499,7 +516,9 @@ public class DatasetsCmdTest extends BaseCmdTest {
     @EnumSource(OutputType.class)
     void testShowByName(OutputType format, MockServerClient mock) {
         mock.when(
-                request().withMethod("GET").withPath("/workspaces/249664655368293/datasets"), exactly(1)
+                request().withMethod("GET").withPath("/datasets")
+                        .withQueryStringParameter("workspaceId", "249664655368293")
+                        .withQueryStringParameter("search", "dataset1"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("datasets/datasets_list")).withContentType(MediaType.APPLICATION_JSON)
         );
@@ -527,7 +546,8 @@ public class DatasetsCmdTest extends BaseCmdTest {
     @EnumSource(OutputType.class)
     void testLabelsApply(OutputType format, MockServerClient mock) {
         mock.when(
-                request().withMethod("GET").withPath("/workspaces/249664655368293/datasets/4D9TP0w2pM0qmwqVHgrgBK/metadata"), exactly(1)
+                request().withMethod("GET").withPath("/datasets/4D9TP0w2pM0qmwqVHgrgBK/metadata")
+                        .withQueryStringParameter("workspaceId", "249664655368293"), exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("datasets/dataset_metadata")).withContentType(MediaType.APPLICATION_JSON)
         );


### PR DESCRIPTION
## Summary

Extends the `datasets` command group with three new subcommands and improves `datasets list` with server-side filtering, pagination, label display, and hidden-dataset visibility control.

---

### `datasets hide` / `datasets show`

Hide or un-hide one or more datasets at once, referencing them by ID, name, or a mix of both.

```sh
# Hide by ID (multiple at once)
tw datasets hide -w <workspace> -i <id1> -i <id2>

# Hide by name
tw datasets hide -w <workspace> -n my-dataset

# Un-hide by name 
tw datasets show -w <workspace> -n my-dataset

# Mixed -i / -n
tw datasets show -w <workspace> -i <id1> -n other-dataset
```

---

### `datasets labels`

Manage labels on a single dataset — set, append, or delete.

```sh
# Replace all labels
tw datasets labels -w <workspace> -i <id> "production,validated"

# Add a label without removing existing ones
tw datasets labels -w <workspace> -i <id> --operations append "nightly"

# Remove a specific label
tw datasets labels -w <workspace> -i <id> --operations delete "nightly"
```

---

### `datasets list` improvements

| New flag | Description |
|---|---|
| `--show-hidden` | Include hidden datasets in results |
| `--filter <expr>` | Server-side search (name and other supported keys) |
| `-l` | Show labels column |
| `--max` / `--page` | Pagination |

```sh
tw datasets list -w <workspace> --show-hidden --filter "my-dataset" -l --max 20
```

The `runs list --filter` description has also been updated to document the full server-side search syntax (`datasetId:<id>`, `status:<status>`, `after:<date>`, etc.).

---

### V2 API migration

All datasets API calls have been migrated from the legacy `/workspaces/{id}/datasets/...` path to the `/datasets/...?workspaceId=...` V2 endpoints. This covers `list`, `add`, `view`, `view versions`, `update`, `url`, `download`, and `delete`. Name-based lookups (`-n`) also pass `visibility=all` so hidden datasets can be resolved by name in all commands (e.g. `show`, `view`, `delete`).

---

<details>
<summary>Regression testing — full command examples</summary>

### Prerequisites

```sh
export TW_ACCESS_TOKEN="<your-token>"
export TW_API_ENDPOINT="https://<your-platform-host>/api"  # omit for cloud
export WORKSPACE="<workspace-id-or-name>"
export PIPELINE="<pipeline-name-or-url>"
export COMPUTE_ENV="<compute-env-name>"  # optional
```

Create a test samplesheet:

```sh
cat > /tmp/test-samplesheet.csv <<'EOF'
sample,fastq_1,fastq_2
SAMPLE1_PE,https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/illumina/amplicon/sample1_R1.fastq.gz,https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/illumina/amplicon/sample1_R2.fastq.gz
SAMPLE2_PE,https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/illumina/amplicon/sample2_R1.fastq.gz,https://raw.githubusercontent.com/nf-core/test-datasets/viralrecon/illumina/amplicon/sample2_R2.fastq.gz
EOF
```

---

### 1. datasets list

```sh
# Baseline
tw datasets list -w "$WORKSPACE"

# Server-side filter
tw datasets list -w "$WORKSPACE" --filter "test"

# JSON output
tw -o json datasets list -w "$WORKSPACE" --filter "test"

# Pagination
tw datasets list -w "$WORKSPACE" --max 5 --page 1

# Labels column
tw datasets list -w "$WORKSPACE" -l
```

---

### 2. Create test datasets

```sh
DS1_ID=$(tw -o json datasets add /tmp/test-samplesheet.csv \
    -w "$WORKSPACE" -n "tw-cli-test-ds1" -d "CLI test dataset 1" --header \
    | jq -r '.datasetId')
echo "DS1_ID=$DS1_ID"

DS2_ID=$(tw -o json datasets add /tmp/test-samplesheet.csv \
    -w "$WORKSPACE" -n "tw-cli-test-ds2" -d "CLI test dataset 2" --header \
    | jq -r '.datasetId')
echo "DS2_ID=$DS2_ID"
```

---

### 3. View and inspect

```sh
# View by ID and by name
tw datasets view -w "$WORKSPACE" -i "$DS1_ID"
tw datasets view -w "$WORKSPACE" -n "tw-cli-test-ds1"

# List all versions
tw datasets view -w "$WORKSPACE" -i "$DS1_ID" versions

# Get URL of latest version
DS_URL=$(tw -o json datasets url -w "$WORKSPACE" -i "$DS1_ID" | jq -r '.datasetUrl')
echo "DS_URL=$DS_URL"

# Get URL of a specific version
tw datasets url -w "$WORKSPACE" -i "$DS1_ID" --dataset-version 1

# Download latest version
tw datasets download -w "$WORKSPACE" -i "$DS1_ID"

# Download a specific version
tw datasets download -w "$WORKSPACE" -i "$DS1_ID" --dataset-version 1
```

---

### 4. Update datasets

```sh
# Rename and update description
tw datasets update -w "$WORKSPACE" -i "$DS1_ID" \
    --new-name "tw-cli-test-ds1-renamed" -d "Updated description"

# Verify
tw datasets view -w "$WORKSPACE" -i "$DS1_ID"

# Upload a new version (rename back at the same time)
tw datasets update -w "$WORKSPACE" -i "$DS1_ID" \
    --new-name "tw-cli-test-ds1" -f /tmp/test-samplesheet.csv --header

# Verify second version was created
tw datasets view -w "$WORKSPACE" -i "$DS1_ID" versions

# Overwrite (delete + recreate) via add --overwrite
tw datasets add /tmp/test-samplesheet.csv \
    -w "$WORKSPACE" -n "tw-cli-test-ds1" -d "Overwritten" --header --overwrite
```

---

### 5. Hide datasets

```sh
# Hide one by ID
tw datasets hide -w "$WORKSPACE" -i "$DS1_ID"

# Hide two at once by ID
tw datasets hide -w "$WORKSPACE" -i "$DS1_ID" -i "$DS2_ID"

# Hide by name
tw datasets hide -w "$WORKSPACE" -n "tw-cli-test-ds1"

# Hide multiple by name
tw datasets hide -w "$WORKSPACE" -n "tw-cli-test-ds1" -n "tw-cli-test-ds2"

# Verify: hidden datasets not visible by default
tw datasets list -w "$WORKSPACE" --filter "tw-cli-test"

# Verify: visible with --show-hidden
tw datasets list -w "$WORKSPACE" --show-hidden --filter "tw-cli-test"
```

---

### 6. Show (un-hide) datasets

```sh
# Show by ID
tw datasets show -w "$WORKSPACE" -i "$DS1_ID"

# Show by name (works even when dataset is hidden)
tw datasets show -w "$WORKSPACE" -n "tw-cli-test-ds2"

# Show multiple — mix -i and -n
tw datasets show -w "$WORKSPACE" -i "$DS1_ID" -n "tw-cli-test-ds2"

# Verify both visible again
tw datasets list -w "$WORKSPACE" --filter "tw-cli-test"
```

---

### 7. Labels

```sh
# Set (replaces all existing labels)
tw datasets labels -w "$WORKSPACE" -i "$DS1_ID" "test,integration"

# Append
tw datasets labels -w "$WORKSPACE" -i "$DS1_ID" --operations append "nightly"

# Delete one label
tw datasets labels -w "$WORKSPACE" -i "$DS1_ID" --operations delete "nightly"

# Verify in list
tw datasets list -w "$WORKSPACE" -l --filter "tw-cli-test"
```

---

### 8. Pipeline runs

```sh
# Launch without a dataset
tw launch "$PIPELINE" -w "$WORKSPACE" -n "tw-cli-no-dataset-run" --stub-run

# Write a params file using the dataset URL from step 3
cat > /tmp/tw-params.json <<EOF
{ "input": "$DS_URL" }
EOF

# Launch with dataset as input
tw launch "$PIPELINE" -w "$WORKSPACE" \
    -n "tw-cli-with-dataset-run" --params-file /tmp/tw-params.json --stub-run

# Launch and wait for completion
tw launch "$PIPELINE" -w "$WORKSPACE" \
    -n "tw-cli-with-dataset-run-wait" --params-file /tmp/tw-params.json \
    --stub-run --wait SUCCEEDED
```

---

### 9. runs list — filter by dataset

```sh
tw runs list -w "$WORKSPACE" --max 10
tw runs list -w "$WORKSPACE" --filter "tw-cli"
tw runs list -w "$WORKSPACE" --filter "datasetId:$DS1_ID"
tw runs list -w "$WORKSPACE" --filter "status:SUCCEEDED"
tw runs list -w "$WORKSPACE" --filter "datasetId:$DS1_ID after:2026-01-01"
```

---

### 10. Cleanup

```sh
tw datasets delete -w "$WORKSPACE" -i "$DS1_ID"
tw datasets delete -w "$WORKSPACE" -i "$DS2_ID"

# List and cancel any remaining test runs
tw runs list -w "$WORKSPACE" --filter "runName:tw-cli"
# tw runs cancel -w "$WORKSPACE" -i <run-id>
```

</details>
