### PR TITLE
feat: add workspace settings commands for studios workspace settings configurability

### DIFF
--- a/conf/reflect-config.json
+++ b/conf/reflect-config.json
@@ -1969,6 +1969,34 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name":"io.seqera.tower.cli.commands.workspaces.settings.SettingsCmd",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"io.seqera.tower.cli.commands.workspaces.settings.studios.StudiosCmd",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"io.seqera.tower.cli.commands.workspaces.settings.studios.ViewCmd",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"io.seqera.tower.cli.commands.workspaces.settings.studios.UpdateCmd",
+  "allDeclaredFields":true,
+  "allDeclaredMethods":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "name":"io.seqera.tower.cli.commands.workspaces.settings.studios.UpdateCmd$NameStrategyConverter",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
   "name":"io.seqera.tower.cli.exceptions.ApiExceptionMessage",
   "allDeclaredFields":true,
   "allDeclaredMethods":true,
@@ -2503,6 +2531,18 @@
 },
 {
   "name":"io.seqera.tower.cli.responses.workspaces.WorkspaceView",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "name":"io.seqera.tower.cli.responses.workspaces.StudiosSettingsView",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "name":"io.seqera.tower.cli.responses.workspaces.StudiosSettingsUpdated",
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true

--- a/src/main/java/io/seqera/tower/cli/commands/WorkspacesCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/WorkspacesCmd.java
@@ -22,6 +22,7 @@ import io.seqera.tower.cli.commands.workspaces.LeaveCmd;
 import io.seqera.tower.cli.commands.workspaces.ListCmd;
 import io.seqera.tower.cli.commands.workspaces.UpdateCmd;
 import io.seqera.tower.cli.commands.workspaces.ViewCmd;
+import io.seqera.tower.cli.commands.workspaces.settings.SettingsCmd;
 import picocli.CommandLine;
 
 @CommandLine.Command(
@@ -34,6 +35,7 @@ import picocli.CommandLine;
                 UpdateCmd.class,
                 ViewCmd.class,
                 LeaveCmd.class,
+                SettingsCmd.class,
         }
 )
 public class WorkspacesCmd extends AbstractRootCmd {

--- a/src/main/java/io/seqera/tower/cli/commands/workspaces/settings/SettingsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/workspaces/settings/SettingsCmd.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.commands.workspaces.settings;
+
+import io.seqera.tower.ApiException;
+import io.seqera.tower.cli.commands.AbstractRootCmd;
+import io.seqera.tower.cli.commands.workspaces.settings.studios.StudiosCmd;
+import io.seqera.tower.cli.exceptions.ShowUsageException;
+import io.seqera.tower.cli.responses.Response;
+import picocli.CommandLine;
+
+import java.io.IOException;
+
+@CommandLine.Command(
+        name = "settings",
+        description = "Manage workspace settings.",
+        subcommands = {
+                StudiosCmd.class,
+        }
+)
+public class SettingsCmd extends AbstractRootCmd {
+
+    @Override
+    protected Response exec() throws ApiException, IOException {
+        throw new ShowUsageException(getSpec(), "Missing Required Subcommand");
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/workspaces/settings/studios/StudiosCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/workspaces/settings/studios/StudiosCmd.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.commands.workspaces.settings.studios;
+
+import io.seqera.tower.ApiException;
+import io.seqera.tower.cli.commands.AbstractRootCmd;
+import io.seqera.tower.cli.exceptions.ShowUsageException;
+import io.seqera.tower.cli.responses.Response;
+import picocli.CommandLine;
+
+import java.io.IOException;
+
+@CommandLine.Command(
+        name = "studios",
+        description = "Manage Studios settings for a workspace.",
+        subcommands = {
+                ViewCmd.class,
+                UpdateCmd.class,
+        }
+)
+public class StudiosCmd extends AbstractRootCmd {
+
+    @Override
+    protected Response exec() throws ApiException, IOException {
+        throw new ShowUsageException(getSpec(), "Missing Required Subcommand");
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/workspaces/settings/studios/UpdateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/workspaces/settings/studios/UpdateCmd.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.commands.workspaces.settings.studios;
+
+import io.seqera.tower.ApiException;
+import io.seqera.tower.cli.commands.workspaces.AbstractWorkspaceCmd;
+import io.seqera.tower.cli.commands.workspaces.WorkspaceRefOptions;
+import io.seqera.tower.cli.exceptions.ShowUsageException;
+import io.seqera.tower.cli.responses.Response;
+import io.seqera.tower.cli.responses.workspaces.StudiosSettingsUpdated;
+import io.seqera.tower.model.DataStudioWorkspaceSettingsRequest;
+import io.seqera.tower.model.DataStudioWorkspaceSettingsRequest.NameStrategyEnum;
+import io.seqera.tower.model.DataStudioWorkspaceSettingsResponse;
+import io.seqera.tower.model.OrgAndWorkspaceDto;
+import io.seqera.tower.model.UpdateWorkspaceRequest;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+import java.io.IOException;
+
+@Command(
+        name = "update",
+        description = "Update the Studios settings of a workspace. Only the provided options are changed; the rest are left untouched."
+)
+public class UpdateCmd extends AbstractWorkspaceCmd {
+
+    @CommandLine.Mixin
+    public WorkspaceRefOptions workspaceRefOptions;
+
+    @Option(names = {"--container-repository"}, description = "Default container repository used to store Studios container images built or augmented with Wave.")
+    public String containerRepository;
+
+    @Option(names = {"--reset-container-repository"}, description = "Clear the default container repository.")
+    public boolean resetContainerRepository;
+
+    @Option(names = {"--name-strategy"}, converter = NameStrategyConverter.class, description = "Wave strategy used to name Studios container images. Valid values: none, tagPrefix, imageSuffix.")
+    public NameStrategyEnum nameStrategy;
+
+    @Option(names = {"--reset-name-strategy"}, description = "Clear the container image naming strategy.")
+    public boolean resetNameStrategy;
+
+    @Option(names = {"--lifespan-hours"}, description = "Maximum lifespan, in hours, of a Studio session before it is automatically stopped. Set to 0 for unlimited lifespan.")
+    public Integer lifespanHours;
+
+    @Option(names = {"--private-by-default"}, negatable = true, description = "Whether new Studios are private by default (use --no-private-by-default to disable).")
+    public Boolean privateStudioByDefault;
+
+    @Override
+    protected Response exec() throws ApiException, IOException {
+
+        boolean updates = containerRepository != null
+                || resetContainerRepository
+                || nameStrategy != null
+                || resetNameStrategy
+                || lifespanHours != null
+                || privateStudioByDefault != null;
+
+        if (!updates) {
+            throw new ShowUsageException(getSpec(), "Required at least one option to update");
+        }
+
+        if (containerRepository != null && resetContainerRepository) {
+            throw new ShowUsageException(getSpec(), "Options '--container-repository' and '--reset-container-repository' are mutually exclusive");
+        }
+
+        if (nameStrategy != null && resetNameStrategy) {
+            throw new ShowUsageException(getSpec(), "Options '--name-strategy' and '--reset-name-strategy' are mutually exclusive");
+        }
+
+        OrgAndWorkspaceDto ws = fetchOrgAndWorkspaceDbDto(workspaceRefOptions);
+
+        // Fetch the current settings and seed the request so unmodified attributes are preserved.
+        DataStudioWorkspaceSettingsResponse current = workspacesApi()
+                .findDataStudiosWorkspaceSettings(ws.getOrgId(), ws.getWorkspaceId(), new UpdateWorkspaceRequest());
+
+        DataStudioWorkspaceSettingsRequest request = new DataStudioWorkspaceSettingsRequest()
+                .containerRepository(current.getContainerRepository())
+                .lifespanHours(current.getLifespanHours())
+                .nameStrategy(current.getNameStrategy() == null ? null : NameStrategyEnum.fromValue(current.getNameStrategy()))
+                .privateStudioByDefault(current.getPrivateStudioByDefault());
+
+        if (containerRepository != null) {
+            request.setContainerRepository(containerRepository);
+        } else if (resetContainerRepository) {
+            request.setContainerRepository(null);
+        }
+
+        if (nameStrategy != null) {
+            request.setNameStrategy(nameStrategy);
+        } else if (resetNameStrategy) {
+            request.setNameStrategy(null);
+        }
+
+        if (lifespanHours != null) {
+            request.setLifespanHours(lifespanHours);
+        }
+
+        if (privateStudioByDefault != null) {
+            request.setPrivateStudioByDefault(privateStudioByDefault);
+        }
+
+        workspacesApi().updateDataStudiosWorkspaceSettings(ws.getOrgId(), ws.getWorkspaceId(), request);
+
+        return new StudiosSettingsUpdated(ws.getWorkspaceName());
+    }
+
+    public static class NameStrategyConverter implements CommandLine.ITypeConverter<NameStrategyEnum> {
+        @Override
+        public NameStrategyEnum convert(String value) {
+            try {
+                return NameStrategyEnum.fromValue(value);
+            } catch (IllegalArgumentException e) {
+                return NameStrategyEnum.valueOf(value.toUpperCase());
+            }
+        }
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/workspaces/settings/studios/ViewCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/workspaces/settings/studios/ViewCmd.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.commands.workspaces.settings.studios;
+
+import io.seqera.tower.ApiException;
+import io.seqera.tower.cli.commands.workspaces.AbstractWorkspaceCmd;
+import io.seqera.tower.cli.commands.workspaces.WorkspaceRefOptions;
+import io.seqera.tower.cli.responses.Response;
+import io.seqera.tower.cli.responses.workspaces.StudiosSettingsView;
+import io.seqera.tower.model.DataStudioWorkspaceSettingsResponse;
+import io.seqera.tower.model.OrgAndWorkspaceDto;
+import io.seqera.tower.model.UpdateWorkspaceRequest;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+import java.io.IOException;
+
+@Command(
+        name = "view",
+        description = "View the Studios settings of a workspace."
+)
+public class ViewCmd extends AbstractWorkspaceCmd {
+
+    @CommandLine.Mixin
+    public WorkspaceRefOptions workspaceRefOptions;
+
+    @Override
+    protected Response exec() throws ApiException, IOException {
+        OrgAndWorkspaceDto ws = fetchOrgAndWorkspaceDbDto(workspaceRefOptions);
+
+        DataStudioWorkspaceSettingsResponse settings = workspacesApi()
+                .findDataStudiosWorkspaceSettings(ws.getOrgId(), ws.getWorkspaceId(), new UpdateWorkspaceRequest());
+
+        return new StudiosSettingsView(ws.getWorkspaceName(), settings);
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/responses/workspaces/StudiosSettingsUpdated.java
+++ b/src/main/java/io/seqera/tower/cli/responses/workspaces/StudiosSettingsUpdated.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.responses.workspaces;
+
+import io.seqera.tower.cli.responses.Response;
+
+public class StudiosSettingsUpdated extends Response {
+
+    public final String workspaceName;
+
+    public StudiosSettingsUpdated(String workspaceName) {
+        this.workspaceName = workspaceName;
+    }
+
+    @Override
+    public String toString() {
+        return ansi(String.format("%n  @|yellow Studios settings updated for workspace '%s'|@%n", workspaceName));
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/responses/workspaces/StudiosSettingsView.java
+++ b/src/main/java/io/seqera/tower/cli/responses/workspaces/StudiosSettingsView.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.responses.workspaces;
+
+import io.seqera.tower.cli.responses.Response;
+import io.seqera.tower.cli.utils.TableList;
+import io.seqera.tower.model.DataStudioWorkspaceSettingsResponse;
+
+import java.io.PrintWriter;
+
+public class StudiosSettingsView extends Response {
+
+    public final String workspaceName;
+    public final DataStudioWorkspaceSettingsResponse settings;
+
+    public StudiosSettingsView(String workspaceName, DataStudioWorkspaceSettingsResponse settings) {
+        this.workspaceName = workspaceName;
+        this.settings = settings;
+    }
+
+    @Override
+    public void toString(PrintWriter out) {
+        out.println(ansi(String.format("%n  @|bold Studios settings for workspace '%s'|@%n", workspaceName)));
+
+        TableList table = new TableList(out, 2);
+        table.setPrefix(" ");
+        table.addRow("Container repository", display(settings.getContainerRepository()));
+        table.addRow("Lifespan (hours)", display(settings.getLifespanHours()));
+        table.addRow("Name strategy", display(settings.getNameStrategy()));
+        table.addRow("Private studio by default", display(settings.getPrivateStudioByDefault()));
+        table.print();
+        out.println("");
+    }
+
+    private static String display(Object value) {
+        return value == null ? "-" : value.toString();
+    }
+}

--- a/src/test/java/io/seqera/tower/cli/workspaces/StudiosSettingsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/workspaces/StudiosSettingsCmdTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.workspaces;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.seqera.tower.cli.BaseCmdTest;
+import io.seqera.tower.cli.commands.enums.OutputType;
+import io.seqera.tower.cli.responses.workspaces.StudiosSettingsUpdated;
+import io.seqera.tower.cli.responses.workspaces.StudiosSettingsView;
+import io.seqera.tower.model.DataStudioWorkspaceSettingsResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.model.MediaType;
+
+import static io.seqera.tower.cli.utils.JsonHelper.parseJson;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockserver.matchers.Times.exactly;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.model.JsonBody.json;
+
+class StudiosSettingsCmdTest extends BaseCmdTest {
+
+    private static final String SETTINGS_PATH = "/orgs/27736513644467/workspaces/75887156211589/settings/studios";
+
+    private void mockWorkspaceResolution(MockServerClient mock) {
+        mock.when(
+                request().withMethod("GET").withPath("/user-info"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/user/1264/workspaces"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workspaces/workspaces_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testView(OutputType format, MockServerClient mock) throws JsonProcessingException {
+        mockWorkspaceResolution(mock);
+
+        mock.when(
+                request().withMethod("GET").withPath(SETTINGS_PATH), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workspaces/settings/studios_settings")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(format, mock, "workspaces", "settings", "studios", "view", "-i", "75887156211589");
+
+        assertOutput(format, out, new StudiosSettingsView("workspace1",
+                parseJson(new String(loadResource("workspaces/settings/studios_settings")), DataStudioWorkspaceSettingsResponse.class)));
+    }
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testUpdateMergesUnchangedAttributes(OutputType format, MockServerClient mock) {
+        mockWorkspaceResolution(mock);
+
+        mock.when(
+                request().withMethod("GET").withPath(SETTINGS_PATH), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workspaces/settings/studios_settings")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        // Only lifespanHours is overridden; the other attributes must be preserved from the current settings.
+        mock.when(
+                request().withMethod("PUT").withPath(SETTINGS_PATH)
+                        .withBody(json("{\"containerRepository\":\"195996028523.dkr.ecr.eu-west-1.amazonaws.com/studios\",\"lifespanHours\":12,\"nameStrategy\":\"tagPrefix\",\"privateStudioByDefault\":false}")),
+                exactly(1)
+        ).respond(
+                response().withStatusCode(204)
+        );
+
+        ExecOut out = exec(format, mock, "workspaces", "settings", "studios", "update", "-i", "75887156211589", "--lifespan-hours", "12");
+
+        assertOutput(format, out, new StudiosSettingsUpdated("workspace1"));
+    }
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testUpdateResetContainerRepository(OutputType format, MockServerClient mock) {
+        mockWorkspaceResolution(mock);
+
+        mock.when(
+                request().withMethod("GET").withPath(SETTINGS_PATH), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workspaces/settings/studios_settings")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        // The reset flag sends an explicit null to clear the container repository.
+        mock.when(
+                request().withMethod("PUT").withPath(SETTINGS_PATH)
+                        .withBody(json("{\"containerRepository\":null}")),
+                exactly(1)
+        ).respond(
+                response().withStatusCode(204)
+        );
+
+        ExecOut out = exec(format, mock, "workspaces", "settings", "studios", "update", "-i", "75887156211589", "--reset-container-repository");
+
+        assertOutput(format, out, new StudiosSettingsUpdated("workspace1"));
+    }
+
+    @Test
+    void testUpdateWithoutOptionsFails(MockServerClient mock) {
+        ExecOut out = exec(mock, "workspaces", "settings", "studios", "update", "-i", "75887156211589");
+
+        assertEquals("", out.stdOut);
+        assertEquals(1, out.exitCode);
+    }
+}

--- a/src/test/resources/runcmd/workspaces/settings/studios_settings.json
+++ b/src/test/resources/runcmd/workspaces/settings/studios_settings.json
@@ -1,0 +1,8 @@
+{
+  "containerRepository": "195996028523.dkr.ecr.eu-west-1.amazonaws.com/studios",
+  "lifespanHours": 8,
+  "nameStrategy": "tagPrefix",
+  "orgId": 27736513644467,
+  "privateStudioByDefault": false,
+  "wspId": 75887156211589
+}


### PR DESCRIPTION
## Summary

Adds a new command tree under `workspaces` for inspecting and configuring a workspace's Studios settings.

```
tw workspaces settings studios view   -i <id> | -n <org/ws>
tw workspaces settings studios update -i <id> | -n <org/ws> [options]
```

Four independent attributes are exposed: 
* `containerRepository`
* `nameStrategy` (`none | tagPrefix | imageSuffix`)
* `lifespanHours`
* `privateStudioByDefault`. 

`update` is a partial / merge-from-current operation — only the options you pass are changed, the rest are preserved.

---

### `workspaces settings studios view`

Show the current Studios settings for a workspace, by ID or by `Org/Workspace` name.

```sh
# By ID (table)
tw workspaces settings studios view -i <workspace-id>

# By name
tw workspaces settings studios view -n my-org/my-workspace

# JSON
tw -o json workspaces settings studios view -i <workspace-id>
```

---

### `workspaces settings studios update`

Update one, several, or all attributes. Untouched attributes are left as-is.

```sh
# Single attribute
tw workspaces settings studios update -i <workspace-id> --lifespan-hours 8

# Multiple attributes at once
tw workspaces settings studios update -i <workspace-id> \
    --container-repository "195996028523.dkr.ecr.eu-west-1.amazonaws.com/studios" \
    --name-strategy tagPrefix \
    --lifespan-hours 8 \
    --private-by-default

# Negatable boolean (disable private-by-default)
tw workspaces settings studios update -i <workspace-id> --no-private-by-default
```

---

### Options

| Flag | Description |
|---|---|
| `--container-repository <repo>` | Default container repository for Studios images |
| `--reset-container-repository` | Clear the container repository (sends explicit `null`) |
| `--name-strategy <none\|tagPrefix\|imageSuffix>` | Image-naming strategy |
| `--reset-name-strategy` | Clear the naming strategy (sends explicit `null`) |
| `--lifespan-hours <int>` | Maximum session lifespan in hours (`0` = unlimited) |
| `--[no-]private-by-default` | Whether new Studios are private by default (tri-state) |

Notes:
- `--reset-*` flags send explicit `null` and are mutually exclusive with their set counterpart.
- `--name-strategy none` is a real value, distinct from `--reset-name-strategy`.
- At least one set/reset option is required; otherwise the command prints a usage error.

---

<details>
<summary>Regression testing — full command examples</summary>

### Prerequisites

The studios settings commands identify the workspace with `-i/--id` (numeric workspace ID) or `-n/--name` (`OrganizationName/WorkspaceName`) — there is no `-w` flag here.

```sh
export TOWER_ACCESS_TOKEN="<your-token>"
export TOWER_API_ENDPOINT="https://<your-platform-host>/api"  # omit for cloud
export WORKSPACE_ID="<numeric-workspace-id>"                  # used with -i
export WORKSPACE_NAME="<OrganizationName/WorkspaceName>"      # used with -n
```

---

### 1. View settings

```sh
# By ID (table)
tw workspaces settings studios view -i "$WORKSPACE_ID"

# By name
tw workspaces settings studios view -n "$WORKSPACE_NAME"

# JSON baseline (capture for later comparison)
tw -o json workspaces settings studios view -i "$WORKSPACE_ID"
```

---

### 2. Update a single attribute

```sh
# Set the session lifespan
tw workspaces settings studios update -i "$WORKSPACE_ID" --lifespan-hours 12

# Verify only that attribute changed
tw workspaces settings studios view -i "$WORKSPACE_ID"

# Set the default container repository
tw workspaces settings studios update -i "$WORKSPACE_ID" \
    --container-repository "195996028523.dkr.ecr.eu-west-1.amazonaws.com/studios"
```

---

### 3. Name strategy (enum)

Accepts `none`, `tagPrefix`, or `imageSuffix` (case-insensitive; the enum constant names `NONE`, `TAG_PREFIX`, `IMAGE_SUFFIX` are also accepted).

```sh
tw workspaces settings studios update -i "$WORKSPACE_ID" --name-strategy tagPrefix
tw workspaces settings studios update -i "$WORKSPACE_ID" --name-strategy imageSuffix
tw workspaces settings studios update -i "$WORKSPACE_ID" --name-strategy none

# Invalid value is rejected
tw workspaces settings studios update -i "$WORKSPACE_ID" --name-strategy bogus
```

---

### 4. Private-by-default (negatable boolean)

```sh
# Enable
tw workspaces settings studios update -i "$WORKSPACE_ID" --private-by-default

# Disable
tw workspaces settings studios update -i "$WORKSPACE_ID" --no-private-by-default
```

---

### 5. Update multiple attributes at once

```sh
tw workspaces settings studios update -i "$WORKSPACE_ID" \
    --container-repository "195996028523.dkr.ecr.eu-west-1.amazonaws.com/studios" \
    --name-strategy tagPrefix \
    --lifespan-hours 8 \
    --private-by-default

# Verify all four
tw workspaces settings studios view -i "$WORKSPACE_ID"
```

---

### 6. Reset (clear) nullable attributes

`--reset-*` flags send an explicit `null` — distinct from `--name-strategy none`, which sets the strategy to the real value `none`.

```sh
# Clear container repository
tw workspaces settings studios update -i "$WORKSPACE_ID" --reset-container-repository

# Clear name strategy
tw workspaces settings studios update -i "$WORKSPACE_ID" --reset-name-strategy

# Verify both now show as empty (`-`)
tw workspaces settings studios view -i "$WORKSPACE_ID"
```

---

### 7. Validation / error cases

```sh
# No options provided — usage error
tw workspaces settings studios update -i "$WORKSPACE_ID"

# Set + reset the same attribute — mutually exclusive error
tw workspaces settings studios update -i "$WORKSPACE_ID" \
    --container-repository "some/repo" --reset-container-repository

tw workspaces settings studios update -i "$WORKSPACE_ID" \
    --name-strategy tagPrefix --reset-name-strategy

# Missing workspace reference — required-arg error
tw workspaces settings studios update --lifespan-hours 8

# Unknown workspace ID — not-found error
tw workspaces settings studios view -i 1
```

---

### 8. By-name equivalents

Every command above also works with `-n "$WORKSPACE_NAME"` instead of `-i "$WORKSPACE_ID"`.

```sh
tw workspaces settings studios update -n "$WORKSPACE_NAME" --lifespan-hours 6
tw -o json workspaces settings studios view -n "$WORKSPACE_NAME"
```

---

### 9. Help text

```sh
tw workspaces settings --help
tw workspaces settings studios --help
tw workspaces settings studios view --help
tw workspaces settings studios update --help
```

</details>
