### PR TITLE
feat: add bootDiskSizeGB support for AzureBatch compute environment

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchForgePlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AzBatchForgePlatform.java
@@ -52,6 +52,9 @@ public class AzBatchForgePlatform extends AbstractPlatform<AzBatchConfig> {
     @Option(names = {"--no-auto-scale"}, description = "Disable pool autoscaling (single pool mode). When disabled, pool maintains fixed VM count and does not scale based on workload.")
     public boolean noAutoScale;
 
+    @Option(names = {"--boot-disk-size"}, description = "Boot disk size in GB for pool nodes. Applies to all pools. In dual pool mode, per-pool values (--head-boot-disk-size, --worker-boot-disk-size) take precedence. If absent, Azure's default is used.")
+    public Integer bootDiskSizeGb;
+
     @ArgGroup(heading = "%nDual pool options (head pool):%n", validate = false)
     public HeadPoolOptions headPoolOpts;
 
@@ -112,12 +115,19 @@ public class AzBatchForgePlatform extends AbstractPlatform<AzBatchConfig> {
         AzBatchForgeConfig forge = new AzBatchForgeConfig()
                 .disposeOnDeletion(!preserveResources);
 
+        if (bootDiskSizeGb != null) {
+            forge.bootDiskSizeGB(bootDiskSizeGb);
+        }
+
         if (dualPool) {
             AzBatchPoolConfig headPool = new AzBatchPoolConfig();
             if (headPoolOpts != null) {
                 headPool.vmType(headPoolOpts.headVmType);
                 headPool.vmCount(headPoolOpts.headVmCount);
                 headPool.autoScale(headPoolOpts.headNoAutoScale != null ? !headPoolOpts.headNoAutoScale : null);
+                if (headPoolOpts.headBootDiskSizeGb != null) {
+                    headPool.bootDiskSizeGB(headPoolOpts.headBootDiskSizeGb);
+                }
             }
 
             AzBatchPoolConfig workerPool = new AzBatchPoolConfig();
@@ -125,6 +135,9 @@ public class AzBatchForgePlatform extends AbstractPlatform<AzBatchConfig> {
                 workerPool.vmType(workerPoolOpts.workerVmType);
                 workerPool.vmCount(workerPoolOpts.workerVmCount);
                 workerPool.autoScale(workerPoolOpts.workerNoAutoScale != null ? !workerPoolOpts.workerNoAutoScale : null);
+                if (workerPoolOpts.workerBootDiskSizeGb != null) {
+                    workerPool.bootDiskSizeGB(workerPoolOpts.workerBootDiskSizeGb);
+                }
             }
 
             forge.headPool(headPool);
@@ -180,6 +193,9 @@ public class AzBatchForgePlatform extends AbstractPlatform<AzBatchConfig> {
         @Option(names = {"--head-no-auto-scale"}, description = "Disable autoscaling for the head pool (dual pool mode).")
         public Boolean headNoAutoScale;
 
+        @Option(names = {"--head-boot-disk-size"}, description = "Boot disk size in GB for the head pool nodes (dual pool mode). Overrides --boot-disk-size for this pool.")
+        public Integer headBootDiskSizeGb;
+
     }
 
     public static class WorkerPoolOptions {
@@ -192,6 +208,9 @@ public class AzBatchForgePlatform extends AbstractPlatform<AzBatchConfig> {
 
         @Option(names = {"--worker-no-auto-scale"}, description = "Disable autoscaling for the worker pool (dual pool mode).")
         public Boolean workerNoAutoScale;
+
+        @Option(names = {"--worker-boot-disk-size"}, description = "Boot disk size in GB for the worker pool nodes (dual pool mode). Overrides --boot-disk-size for this pool.")
+        public Integer workerBootDiskSizeGb;
 
     }
 

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AzBatchForgePlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AzBatchForgePlatformTest.java
@@ -81,4 +81,52 @@ class AzBatchForgePlatformTest extends BaseCmdTest {
         assertEquals(0, out.exitCode);
     }
 
+    @Test
+    void testAddWithBootDiskSize(MockServerClient mock) {
+
+        mock.reset();
+
+        mock.when(
+                request().withMethod("GET").withPath("/credentials").withQueryStringParameter("platformId", "azure-batch"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"credentials\":[{\"id\":\"57Ic6reczFn78H1DTaaXkp\",\"name\":\"azure\",\"description\":null,\"discriminator\":\"azure\",\"baseUrl\":null,\"category\":null,\"deleted\":null,\"lastUsed\":null,\"dateCreated\":\"2021-09-07T13:50:21Z\",\"lastUpdated\":\"2021-09-07T13:50:21Z\"}]}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("POST").withPath("/compute-envs").withBody(JsonBody.json("{\"computeEnv\":{\"name\":\"azure\",\"platform\":\"azure-batch\",\"config\":{\"workDir\":\"az://nextflow-ci/jordeu\",\"region\":\"europe\",\"forge\":{\"vmCount\":10,\"autoScale\":true,\"disposeOnDeletion\":true,\"bootDiskSizeGB\":100}},\"credentialsId\":\"57Ic6reczFn78H1DTaaXkp\"}}")), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(mock, "compute-envs", "add", "azure-batch", "forge", "-n", "azure", "-l", "europe", "--work-dir", "az://nextflow-ci/jordeu", "--vm-count", "10", "--boot-disk-size", "100");
+
+        assertEquals("", out.stdErr);
+        assertEquals(new ComputeEnvAdded("azure-batch", "isnEDBLvHDAIteOEF44ow", "azure", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(0, out.exitCode);
+    }
+
+    @Test
+    void testAddDualPoolWithBootDiskSize(MockServerClient mock) {
+
+        mock.reset();
+
+        mock.when(
+                request().withMethod("GET").withPath("/credentials").withQueryStringParameter("platformId", "azure-batch"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"credentials\":[{\"id\":\"57Ic6reczFn78H1DTaaXkp\",\"name\":\"azure\",\"description\":null,\"discriminator\":\"azure\",\"baseUrl\":null,\"category\":null,\"deleted\":null,\"lastUsed\":null,\"dateCreated\":\"2021-09-07T13:50:21Z\",\"lastUpdated\":\"2021-09-07T13:50:21Z\"}]}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("POST").withPath("/compute-envs").withBody(JsonBody.json("{\"computeEnv\":{\"name\":\"azure\",\"platform\":\"azure-batch\",\"config\":{\"workDir\":\"az://nextflow-ci/jordeu\",\"region\":\"europe\",\"forge\":{\"disposeOnDeletion\":true,\"bootDiskSizeGB\":100,\"headPool\":{\"bootDiskSizeGB\":50},\"workerPool\":{\"bootDiskSizeGB\":200}}},\"credentialsId\":\"57Ic6reczFn78H1DTaaXkp\"}}")), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(mock, "compute-envs", "add", "azure-batch", "forge", "-n", "azure", "-l", "europe", "--work-dir", "az://nextflow-ci/jordeu", "--dual-pool", "--boot-disk-size", "100", "--head-boot-disk-size", "50", "--worker-boot-disk-size", "200");
+
+        assertEquals("", out.stdErr);
+        assertEquals(new ComputeEnvAdded("azure-batch", "isnEDBLvHDAIteOEF44ow", "azure", null, USER_WORKSPACE_NAME).toString(), out.stdOut);
+        assertEquals(0, out.exitCode);
+    }
+
 }


### PR DESCRIPTION
## Summary

Adds support for the `bootDiskSizeGB` parameter for the AzureBatch (forge) compute environment.

- `--boot-disk-size` — forge-level option, applies to all pools → `AzBatchForgeConfig.bootDiskSizeGB`
- `--head-boot-disk-size` — per-pool override for the head pool (dual pool mode) → `AzBatchPoolConfig.bootDiskSizeGB`
- `--worker-boot-disk-size` — per-pool override for the worker pool (dual pool mode) → `AzBatchPoolConfig.bootDiskSizeGB`

Per-pool values take precedence over the forge-level value, matching the SDK's documented semantics.

Closes [COMP-1177](https://seqera.atlassian.net/browse/COMP-1177)

## Notes

- No SDK bump required — `AzBatchForgeConfig` and `AzBatchPoolConfig` already expose `bootDiskSizeGB(Integer)`.
- Manual mode (`AzBatchManualPlatform`) is intentionally untouched — it only references pre-existing pools by name, so there is no forge/pool config to attach a boot disk size to.

## Testing

- `testAddWithBootDiskSize` — asserts `forge.bootDiskSizeGB` in the single-pool request body.
- `testAddDualPoolWithBootDiskSize` — asserts forge-level plus `headPool`/`workerPool` `bootDiskSizeGB` in the dual-pool request body.
- `./gradlew compileJava test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[COMP-1177]: https://seqera.atlassian.net/browse/COMP-1177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ