### PR TITLE
feat: support VPC ID and subnet IDs for aws-cloud compute environment

### DIFF
--- a/VERSION-API
+++ b/VERSION-API
@@ -1,4 +1,4 @@
-1.167.0
+1.175.0
 // Only first line of this file is read
 // This version should be bumped to the minimum version where dependent API changes were introduced
 // But never higher then the current Platform API Version deployed in Cloud Production: https://cloud.seqera.io/api/service-info

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AwsCloudPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/AwsCloudPlatform.java
@@ -78,6 +78,10 @@ public class AwsCloudPlatform extends AbstractPlatform<AwsCloudConfig> {
                 throw new TowerRuntimeException("EBS KMS key requires EBS encryption to be enabled (--ebs-encryption).");
             }
 
+            if (adv.subnetId != null && adv.subnetIds != null) {
+                throw new TowerRuntimeException("Options --subnet-id and --subnet-ids are mutually exclusive; use --subnet-ids.");
+            }
+
             config
                     .instanceType(adv.instanceType)
                     .imageId(adv.imageId)
@@ -87,7 +91,9 @@ public class AwsCloudPlatform extends AbstractPlatform<AwsCloudConfig> {
                     .ebsEncrypted(adv.ebsEncrypted)
                     .ebsKmsKeyId(adv.ebsKmsKeyId)
                     .instanceProfileArn(adv.instanceProfileArn)
+                    .vpcId(adv.vpcId)
                     .subnetId(adv.subnetId)
+                    .subnetIds(adv.subnetIds)
                     .securityGroups(adv.securityGroups);
         }
 
@@ -140,7 +146,14 @@ public class AwsCloudPlatform extends AbstractPlatform<AwsCloudConfig> {
         @Option(names = {"--security-groups"}, description = "Security group IDs for network access control. Comma-separated list defining firewall rules for EC2 instances.", split = ",")
         public List<String> securityGroups;
 
-        @Option(names = {"--subnet-id"}, description = "VPC subnet ID for instance placement. Determines network isolation and internet access configuration.")
+        @Deprecated
+        @Option(names = {"--subnet-id"}, description = "DEPRECATED - Use '--subnet-ids' instead. VPC subnet ID for instance placement. Determines network isolation and internet access configuration.")
         public String subnetId;
+
+        @Option(names = {"--subnet-ids"}, description = "VPC subnet IDs for instance placement. Comma-separated list; the first subnet is used for basic placement while Intelligent Compute may use all of them. Mutually exclusive with --subnet-id.", split = ",")
+        public List<String> subnetIds;
+
+        @Option(names = {"--vpc-id"}, description = "VPC ID used to scope subnet and security-group selection. Determines the network in which EC2 instances are launched.")
+        public String vpcId;
     }
 }

--- a/src/test/java/io/seqera/tower/cli/InfoCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/InfoCmdTest.java
@@ -56,7 +56,7 @@ public class InfoCmdTest extends BaseCmdTest {
         Map<String, String> opts = new HashMap<>();
         opts.put("cliVersion", getCliVersion() );
         opts.put("cliApiVersion", getCliApiVersion());
-        opts.put("towerApiVersion", "1.167.0");
+        opts.put("towerApiVersion", "1.175.0");
         opts.put("towerVersion", "22.3.0-torricelli");
         opts.put("towerApiEndpoint", "http://localhost:"+mock.getPort());
         opts.put("userName", "jordi");
@@ -86,7 +86,7 @@ public class InfoCmdTest extends BaseCmdTest {
         Map<String, String> opts = new HashMap<>();
         opts.put("cliVersion", getCliVersion() );
         opts.put("cliApiVersion", getCliApiVersion());
-        opts.put("towerApiVersion", "1.167.0");
+        opts.put("towerApiVersion", "1.175.0");
         opts.put("towerVersion", "22.3.0-torricelli");
         opts.put("towerApiEndpoint", "http://localhost:"+mock.getPort());
         opts.put("userName", null);

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AwsCloudPlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/AwsCloudPlatformTest.java
@@ -134,7 +134,8 @@ public class AwsCloudPlatformTest extends BaseCmdTest {
                                             "ec2KeyPair": "my-key-pair",
                                             "ebsBootSize": 100,
                                             "instanceProfileArn": "arn:aws:iam::123456789012:instance-profile/my-profile",
-                                            "subnetId": "subnet-12345678",
+                                            "vpcId": "vpc-12345678",
+                                            "subnetIds": ["subnet-12345678", "subnet-87654321"],
                                             "securityGroups": ["sg-12345678", "sg-87654321"],
                                             "allowBuckets": ["s3://bucket1", "s3://bucket2"]
                                         },
@@ -161,7 +162,8 @@ public class AwsCloudPlatformTest extends BaseCmdTest {
                 "--ec2-key-pair", "my-key-pair",
                 "--boot-disk-size", "100",
                 "--instance-profile-arn", "arn:aws:iam::123456789012:instance-profile/my-profile",
-                "--subnet-id", "subnet-12345678",
+                "--vpc-id", "vpc-12345678",
+                "--subnet-ids", "subnet-12345678,subnet-87654321",
                 "--security-groups", "sg-12345678,sg-87654321"
         );
 
@@ -170,6 +172,100 @@ public class AwsCloudPlatformTest extends BaseCmdTest {
         assertEquals("", out.stdErr);
         assertEquals(0, out.exitCode);
         assertEquals(expected.toString(), out.stdOut);
+    }
+
+    @Test
+    void testAddWithDeprecatedSubnetId(MockServerClient mock) throws IOException {
+        mock.reset();
+
+        // given
+        mock.when(
+                request()
+                        .withMethod("GET")
+                        .withPath("/credentials")
+                        .withQueryStringParameter("platformId", "aws-cloud"),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"credentials\":[{\"id\":\"6XfOhoztUq6de3Dw3X9LSb\",\"name\":\"aws\",\"description\":null,\"discriminator\":\"aws\",\"baseUrl\":null,\"category\":null,\"deleted\":null,\"lastUsed\":\"2021-09-08T18:20:46Z\",\"dateCreated\":\"2021-09-08T12:57:04Z\",\"lastUpdated\":\"2021-09-08T12:57:04Z\"}]}")
+        );
+
+        mock.when(
+                request()
+                        .withMethod("POST")
+                        .withPath("/compute-envs")
+                        .withBody(json("""
+                                {
+                                    "computeEnv": {
+                                        "name": "my-aws-cloud-subnet",
+                                        "platform": "aws-cloud",
+                                        "config": {
+                                            "workDir": "s3://my-bucket",
+                                            "region": "us-east-1",
+                                            "fusion2Enabled": true,
+                                            "waveEnabled": true,
+                                            "schedEnabled": false,
+                                            "subnetId": "subnet-12345678"
+                                        },
+                                        "credentialsId": "6XfOhoztUq6de3Dw3X9LSb"
+                                    }
+                                }""")),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}")
+        );
+
+        // when
+        ExecOut out = exec(mock, "compute-envs", "add", "aws-cloud",
+                "-n", "my-aws-cloud-subnet",
+                "--work-dir", "s3://my-bucket",
+                "-r", "us-east-1",
+                "--subnet-id", "subnet-12345678"
+        );
+
+        // then
+        var expected = new ComputeEnvAdded("aws-cloud", "isnEDBLvHDAIteOEF44ow", "my-aws-cloud-subnet", null, USER_WORKSPACE_NAME);
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+        assertEquals(expected.toString(), out.stdOut);
+    }
+
+    @Test
+    void testAddWithBothSubnetOptionsFails(MockServerClient mock) throws IOException {
+        mock.reset();
+
+        // given
+        mock.when(
+                request()
+                        .withMethod("GET")
+                        .withPath("/credentials")
+                        .withQueryStringParameter("platformId", "aws-cloud"),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"credentials\":[{\"id\":\"6XfOhoztUq6de3Dw3X9LSb\",\"name\":\"aws\",\"description\":null,\"discriminator\":\"aws\",\"baseUrl\":null,\"category\":null,\"deleted\":null,\"lastUsed\":\"2021-09-08T18:20:46Z\",\"dateCreated\":\"2021-09-08T12:57:04Z\",\"lastUpdated\":\"2021-09-08T12:57:04Z\"}]}")
+        );
+
+        // when
+        ExecOut out = exec(mock, "compute-envs", "add", "aws-cloud",
+                "-n", "my-aws-cloud-subnet",
+                "--work-dir", "s3://my-bucket",
+                "-r", "us-east-1",
+                "--subnet-id", "subnet-12345678",
+                "--subnet-ids", "subnet-87654321"
+        );
+
+        // then — CLI rejects the ambiguous combination
+        assertEquals("", out.stdOut);
+        assertEquals(1, out.exitCode);
+        assertTrue(out.stdErr.contains("mutually exclusive"));
     }
 
     @Test

--- a/src/test/resources/runcmd/info/service-info.json
+++ b/src/test/resources/runcmd/info/service-info.json
@@ -1,7 +1,7 @@
 {
   "serviceInfo": {
     "version": "22.3.0-torricelli",
-    "apiVersion": "1.167.0",
+    "apiVersion": "1.175.0",
     "commitId": "3f04bfd4",
     "authTypes": [
       "github",


### PR DESCRIPTION
## Summary

Adds `--vpc-id` and `--subnet-ids` advanced options to the `aws-cloud` compute environment platform, wiring them to the `AwsCloudConfig.vpcId` / `AwsCloudConfig.subnetIds` fields.

- **`--vpc-id`** → `vpcId`: VPC that scopes subnet and security-group selection.
- **`--subnet-ids`** → `subnetIds`: comma-separated list of subnets; the modern replacement for the single-value field. The first subnet is used for basic placement while Intelligent Compute may use all of them.
- **`--subnet-id`** is retained for backwards compatibility but marked deprecated (via `@Deprecated` and its help text), matching the SDK, which documents `subnetId` as deprecated in favour of `subnetIds`. This follows the existing `--fusion` deprecation convention in the codebase.
- `--subnet-id` and `--subnet-ids` are **mutually exclusive** — supplying both throws a `TowerRuntimeException`, following the existing option-dependency validation pattern.

Also bumps the minimum required Platform API version to **1.175.0** (`VERSION-API`), which is the version exposing the `vpcId` / `subnetIds` fields.

> ⚠️ Per `VERSION-API`'s own guidance, the minimum should never be higher than the Platform API version deployed in Cloud production. Please confirm 1.175.0 is live before merging, otherwise `tower info` will warn against production.

## Test plan

- Updated `AwsCloudPlatformTest#testAddWithAdvancedOptions` to exercise `--vpc-id` + `--subnet-ids`.
- Added `testAddWithDeprecatedSubnetId` — confirms the legacy `--subnet-id` still serializes to `subnetId`.
- Added `testAddWithBothSubnetOptionsFails` — confirms the mutual-exclusion guard.
- Updated `InfoCmdTest` + `service-info.json` for the API version bump.
- Full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)