### PR TITLE
feat(studios): git repository config, environment variables, SSH toggle, and compute environment change

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/studios/AbstractStudiosCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/studios/AbstractStudiosCmd.java
@@ -146,6 +146,10 @@ public class AbstractStudiosCmd extends AbstractApiCmd {
 
         studioConfiguration.setMountData(getMountDataIds(configOptions, studioConfiguration, wspId));
 
+        if (configOptions.environment != null) {
+            studioConfiguration.setEnvironment(configOptions.environment);
+        }
+
 
         if (condaEnvOverride != null && !condaEnvOverride.isEmpty()) {
             studioConfiguration.setCondaEnvironment(condaEnvOverride);

--- a/src/main/java/io/seqera/tower/cli/commands/studios/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/studios/AddCmd.java
@@ -105,7 +105,7 @@ public class AddCmd extends AbstractStudiosCmd{
 
         // A template is mandatory unless a Git repository is provided, since the remote repository may define it.
         if (templateOptions.getTemplate() == null && remoteConfigOptions.isEmpty()) {
-            throw new TowerException("A studio template is required: provide -t/--template or -ct/--custom-template, or a Git repository via -u/--url");
+            throw new TowerException("A studio template is required: provide -t/--template or -ct/--custom-template, or a Git repository via --repository");
         }
 
         if (standardTemplate != null) {
@@ -135,7 +135,7 @@ public class AddCmd extends AbstractStudiosCmd{
             request.setSpot(spot);
         }
         if (remoteConfigOptions.revision != null && remoteConfigOptions.isEmpty()) {
-            throw new TowerException("--revision requires --url to be set");
+            throw new TowerException("--revision requires --repository to be set");
         }
         if (!remoteConfigOptions.isEmpty()) {
             request.setRemoteConfig(remoteConfigOptions.toRemoteConfiguration());

--- a/src/main/java/io/seqera/tower/cli/commands/studios/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/studios/AddCmd.java
@@ -67,11 +67,20 @@ public class AddCmd extends AbstractStudiosCmd{
     @CommandLine.Mixin
     public StudioConfigurationOptions studioConfigOptions;
 
+    @CommandLine.Mixin
+    public StudioRemoteConfigOptions remoteConfigOptions;
+
     @CommandLine.Option(names = {"-a", "--auto-start"}, description = "Create studio and start it immediately (default: false)", defaultValue = "false")
     public Boolean autoStart;
 
     @CommandLine.Option(names = {"--private"}, description = "Create a private studio that only you can access or manage (default: false)", defaultValue = "false")
     public Boolean isPrivate;
+
+    @CommandLine.Option(names = {"--spot"}, description = "Launch the studio on spot instances (default: provider/compute environment default).")
+    public Boolean spot;
+
+    @CommandLine.Option(names = {"--ssh"}, description = "Enable SSH connectivity to the studio (default: false).")
+    public Boolean ssh;
 
     @CommandLine.Option(names = {"--labels"}, description = "Comma-separated list of labels", split = ",", converter = Label.StudioResourceLabelsConverter.class)
     public List<Label> labels;
@@ -83,7 +92,7 @@ public class AddCmd extends AbstractStudiosCmd{
     protected Response exec() throws ApiException {
         Long wspId = workspaceId(workspace.workspace);
 
-        templateValidation(templateOptions, condaEnv, wspId);
+        templateValidation(templateOptions, remoteConfigOptions, condaEnv, wspId);
         DataStudioCreateRequest request = prepareRequest(wspId);
         DataStudioCreateResponse response = studiosApi().createDataStudio(request, wspId, autoStart);
         DataStudioDto studioDto = response.getStudio();
@@ -91,9 +100,16 @@ public class AddCmd extends AbstractStudiosCmd{
         return new StudiosCreated(studioDto.getSessionId(), wspId, workspaceRef(wspId), baseWorkspaceUrl(wspId), autoStart);
     }
 
-    private void templateValidation(StudioTemplateOptions templateOptions, Path condaEnv, Long wspId) throws ApiException {
-        if (templateOptions.template.standardTemplate != null) {
-            checkIfTemplateIsAvailable(templateOptions.template.standardTemplate, wspId);
+    private void templateValidation(StudioTemplateOptions templateOptions, StudioRemoteConfigOptions remoteConfigOptions, Path condaEnv, Long wspId) throws ApiException {
+        String standardTemplate = templateOptions.template == null ? null : templateOptions.template.standardTemplate;
+
+        // A template is mandatory unless a Git repository is provided, since the remote repository may define it.
+        if (templateOptions.getTemplate() == null && remoteConfigOptions.isEmpty()) {
+            throw new TowerException("A studio template is required: provide -t/--template or -ct/--custom-template, or a Git repository via -u/--url");
+        }
+
+        if (standardTemplate != null) {
+            checkIfTemplateIsAvailable(standardTemplate, wspId);
         } else if (condaEnv != null) {
             throw new StudiosCustomTemplateWithCondaException();
         }
@@ -115,6 +131,15 @@ public class AddCmd extends AbstractStudiosCmd{
         if (description != null && !description.isEmpty()) {request.description(description);}
         request.setLabelIds(getLabelIds(labels, wspId));
         request.setIsPrivate(isPrivate);
+        if (spot != null) {
+            request.setSpot(spot);
+        }
+        if (remoteConfigOptions.revision != null && remoteConfigOptions.isEmpty()) {
+            throw new TowerException("--revision requires --url to be set");
+        }
+        if (!remoteConfigOptions.isEmpty()) {
+            request.setRemoteConfig(remoteConfigOptions.toRemoteConfiguration());
+        }
         request.setDataStudioToolUrl(templateOptions.getTemplate());
         ComputeEnvResponseDto ceResponse = computeEnvByRef(wspId, computeEnv);
         request.setComputeEnvId(ceResponse.getId());
@@ -130,6 +155,9 @@ public class AddCmd extends AbstractStudiosCmd{
 
 
         DataStudioConfiguration newConfig = studioConfigurationFrom(workspaceId(workspace.workspace), studioConfigOptions, condaEnvString);
+        if (ssh != null) {
+            newConfig.setSshEnabled(ssh);
+        }
         request.setConfiguration(setDefaults(newConfig));
         return request;
     }

--- a/src/main/java/io/seqera/tower/cli/commands/studios/StartCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/studios/StartCmd.java
@@ -58,6 +58,12 @@ public class StartCmd extends AbstractStudiosCmd {
     @CommandLine.Option(names = {"--description"}, description = "Optional configuration override for 'description'.")
     public String description;
 
+    @CommandLine.Option(names = {"--spot"}, description = "Optional override to launch the studio on spot instances.")
+    public Boolean spot;
+
+    @CommandLine.Option(names = {"--ssh"}, description = "Optional override to enable SSH connectivity to the studio.")
+    public Boolean ssh;
+
     @Override
     protected Response exec() throws ApiException {
         Long wspId = workspaceId(workspace.workspace);
@@ -97,6 +103,9 @@ public class StartCmd extends AbstractStudiosCmd {
 
     private DataStudioStartRequest getStartRequestWithOverridesApplied(DataStudioDto studioDto) throws ApiException {
         DataStudioConfiguration newConfig = studioConfigurationFrom(studioDto.getWorkspaceId(), studioDto, studioConfigOptions);
+        if (ssh != null) {
+            newConfig.setSshEnabled(ssh);
+        }
         String appliedDescription = description == null
                 ? studioDto.getDescription()
                 : description;
@@ -106,6 +115,9 @@ public class StartCmd extends AbstractStudiosCmd {
         request.setConfiguration(newConfig);
         request.setDescription(appliedDescription);
         request.setLabelIds(getLabelIds(labels, studioDto.getWorkspaceId()));
+        if (spot != null) {
+            request.setSpot(spot);
+        }
 
         return request;
     }

--- a/src/main/java/io/seqera/tower/cli/commands/studios/StudioConfigurationOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/studios/StudioConfigurationOptions.java
@@ -16,6 +16,8 @@
 
 package io.seqera.tower.cli.commands.studios;
 
+import java.util.Map;
+
 import picocli.CommandLine;
 
 public class StudioConfigurationOptions {
@@ -31,6 +33,9 @@ public class StudioConfigurationOptions {
 
     @CommandLine.Option(names = {"--lifespan"}, description = "Optional configuration override for 'lifespan' setting (integer representing hours). Defaults to workspace lifespan setting.")
     public Integer lifespan;
+
+    @CommandLine.Option(names = {"-e", "--env"}, description = "Add environment variables to the studio as key=value pairs. Can be specified multiple times (e.g. -e KEY1=value1 -e KEY2=value2).")
+    public Map<String, String> environment;
 
     @CommandLine.Mixin
     public DataLinkRefOptions dataLinkRefOptions;

--- a/src/main/java/io/seqera/tower/cli/commands/studios/StudioRemoteConfigOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/studios/StudioRemoteConfigOptions.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.commands.studios;
+
+import io.seqera.tower.model.StudioRemoteConfiguration;
+import picocli.CommandLine;
+
+public class StudioRemoteConfigOptions {
+
+    @CommandLine.Option(names = {"-u", "--url"}, description = "Git repository URL to import studio configuration from.")
+    public String url;
+
+    @CommandLine.Option(names = {"--revision"}, description = "Optional branch, tag or commit of the Git repository to check out. Requires --url.")
+    public String revision;
+
+    public boolean isEmpty() {
+        return url == null || url.isEmpty();
+    }
+
+    public StudioRemoteConfiguration toRemoteConfiguration() {
+        if (isEmpty()) {
+            return null;
+        }
+        StudioRemoteConfiguration remoteConfig = new StudioRemoteConfiguration();
+        remoteConfig.setRepository(url);
+        if (revision != null && !revision.isEmpty()) {
+            remoteConfig.setRevision(revision);
+        }
+        return remoteConfig;
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/studios/StudioRemoteConfigOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/studios/StudioRemoteConfigOptions.java
@@ -21,14 +21,14 @@ import picocli.CommandLine;
 
 public class StudioRemoteConfigOptions {
 
-    @CommandLine.Option(names = {"-u", "--url"}, description = "Git repository URL to import studio configuration from.")
-    public String url;
+    @CommandLine.Option(names = {"--repository"}, description = "Git repository URL to import studio configuration from.")
+    public String repository;
 
-    @CommandLine.Option(names = {"--revision"}, description = "Optional branch, tag or commit of the Git repository to check out. Requires --url.")
+    @CommandLine.Option(names = {"--revision"}, description = "Optional branch, tag or commit of the Git repository to check out. Requires --repository.")
     public String revision;
 
     public boolean isEmpty() {
-        return url == null || url.isEmpty();
+        return repository == null || repository.isEmpty();
     }
 
     public StudioRemoteConfiguration toRemoteConfiguration() {
@@ -36,7 +36,7 @@ public class StudioRemoteConfigOptions {
             return null;
         }
         StudioRemoteConfiguration remoteConfig = new StudioRemoteConfiguration();
-        remoteConfig.setRepository(url);
+        remoteConfig.setRepository(repository);
         if (revision != null && !revision.isEmpty()) {
             remoteConfig.setRevision(revision);
         }

--- a/src/main/java/io/seqera/tower/cli/commands/studios/StudioTemplateOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/studios/StudioTemplateOptions.java
@@ -20,7 +20,7 @@ import picocli.CommandLine;
 
 public class StudioTemplateOptions {
 
-    @CommandLine.ArgGroup(multiplicity = "1")
+    @CommandLine.ArgGroup(multiplicity = "0..1")
     public StudioTemplate template;
 
     public static class StudioTemplate {
@@ -32,6 +32,9 @@ public class StudioTemplateOptions {
     }
 
     public String getTemplate() {
+        if (template == null) {
+            return null;
+        }
         return template.standardTemplate != null ? template.standardTemplate : template.customTemplate;
     }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/studios/UpdateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/studios/UpdateCmd.java
@@ -25,9 +25,11 @@ import io.seqera.tower.cli.exceptions.StudioNotFoundException;
 import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.studios.StudioUpdated;
+import io.seqera.tower.model.ComputeEnvResponseDto;
 import io.seqera.tower.model.DataStudioConfiguration;
 import io.seqera.tower.model.DataStudioDto;
 import io.seqera.tower.model.DataStudioUpdateRequest;
+import io.seqera.tower.model.ListComputeEnvsResponseEntry;
 import picocli.CommandLine;
 
 @CommandLine.Command(
@@ -54,19 +56,39 @@ public class UpdateCmd extends AbstractStudiosCmd {
     @CommandLine.Option(names = {"--new-name"}, description = "Optional new name for the studio.")
     public String newName;
 
+    @CommandLine.Option(names = {"--ssh"}, description = "Optional override to enable or disable SSH connectivity to the studio.")
+    public Boolean ssh;
+
+    @CommandLine.Option(names = {"-c", "--compute-env"}, description = "Move the studio to a different (compatible) compute environment. Only allowed while the studio is stopped.")
+    public String computeEnv;
+
     @Override
     protected Response exec() throws ApiException {
         Long wspId = workspaceId(workspace.workspace);
 
+        DataStudioDto studioDto;
         try {
-            DataStudioDto studioDto = fetchStudio(studioRefOptions, wspId);
+            studioDto = fetchStudio(studioRefOptions, wspId);
+        } catch (ApiException e) {
+            if (e.getCode() == 404) {
+                throw new StudioNotFoundException(studioRefOptions.getStudioIdentifier(), workspace.workspace);
+            }
+            if (e.getCode() == 403) {
+                throw new TowerException(String.format("User not entitled to view studio '%s' at %s workspace", studioRefOptions.getStudioIdentifier(), workspace.workspace));
+            }
+            throw e;
+        }
 
-            DataStudioUpdateRequest request = getUpdateRequestWithOverridesApplied(studioDto);
+        DataStudioUpdateRequest request = getUpdateRequestWithOverridesApplied(studioDto);
 
+        try {
             DataStudioDto updatedStudio = studiosApi().updateDataStudio(studioDto.getSessionId(), request, wspId);
 
             return new StudioUpdated(updatedStudio.getSessionId(), studioRefOptions.getStudioIdentifier(), wspId, workspaceRef(wspId));
         } catch (ApiException e) {
+            if (computeEnv != null && e.getCode() == 400 && isIncompatibleComputeEnvError(e)) {
+                throw incompatibleComputeEnvException(studioDto.getSessionId(), wspId);
+            }
             if (e.getCode() == 404) {
                 throw new StudioNotFoundException(studioRefOptions.getStudioIdentifier(), workspace.workspace);
             }
@@ -77,8 +99,35 @@ public class UpdateCmd extends AbstractStudiosCmd {
         }
     }
 
+    private boolean isIncompatibleComputeEnvError(ApiException e) {
+        String body = e.getResponseBody();
+        return body != null && body.contains("is not compatible with the Studio's current compute environment");
+    }
+
+    private TowerException incompatibleComputeEnvException(String sessionId, Long wspId) {
+        StringBuilder message = new StringBuilder(String.format(
+                "Compute environment '%s' is not compatible with studio '%s'.", computeEnv, studioRefOptions.getStudioIdentifier()));
+        try {
+            List<ListComputeEnvsResponseEntry> compatible = studiosApi()
+                    .listDataStudioCompatibleComputeEnvs(sessionId, wspId, null)
+                    .getComputeEnvs();
+            if (compatible == null || compatible.isEmpty()) {
+                message.append(" No compatible compute environments are available in this workspace.");
+            } else {
+                message.append(" Choose one of the following compatible compute environments:");
+                compatible.forEach(ce -> message.append(String.format("%n  - %s (%s)", ce.getName(), ce.getId())));
+            }
+        } catch (ApiException ex) {
+            message.append(" (unable to retrieve the list of compatible compute environments)");
+        }
+        return new TowerException(message.toString());
+    }
+
     private DataStudioUpdateRequest getUpdateRequestWithOverridesApplied(DataStudioDto studioDto) throws ApiException {
         DataStudioConfiguration newConfig = studioConfigurationFrom(studioDto.getWorkspaceId(), studioDto, studioConfigOptions);
+        if (ssh != null) {
+            newConfig.setSshEnabled(ssh);
+        }
         String appliedDescription = description == null
                 ? studioDto.getDescription()
                 : description;
@@ -91,6 +140,11 @@ public class UpdateCmd extends AbstractStudiosCmd {
 
         if (newName != null) {
             request.setName(newName);
+        }
+
+        if (computeEnv != null) {
+            ComputeEnvResponseDto ceResponse = computeEnvByRef(studioDto.getWorkspaceId(), computeEnv);
+            request.setComputeEnvId(ceResponse.getId());
         }
 
         return request;

--- a/src/main/java/io/seqera/tower/cli/responses/studios/StudiosView.java
+++ b/src/main/java/io/seqera/tower/cli/responses/studios/StudiosView.java
@@ -22,6 +22,7 @@ import io.seqera.tower.model.DataLinkDto;
 import io.seqera.tower.model.DataStudioConfiguration;
 import io.seqera.tower.model.DataStudioDto;
 import io.seqera.tower.model.DataStudioStatusInfo;
+import io.seqera.tower.model.StudioSshDetailsDto;
 import io.seqera.tower.model.UserInfo;
 
 import java.io.PrintWriter;
@@ -66,6 +67,23 @@ public class StudiosView extends Response {
         table.addRow("CPU allocated",  config == null ? "-" : String.valueOf(config.getCpu()));
         table.addRow("Memory allocated", config == null ? "-" : String.valueOf(config.getMemory()));
         table.addRow("Build reports", studio.getWaveBuildUrl() == null ? "NA" : studio.getWaveBuildUrl());
+        table.addRow("Private", studio.getIsPrivate() == null ? "NA" : String.valueOf(studio.getIsPrivate()));
+        table.addRow("Lifespan (hours)", studio.getEffectiveLifespanHours() == null ? "Unlimited" : String.valueOf(studio.getEffectiveLifespanHours()));
+        table.addRow("SSH enabled", config == null || config.getSshEnabled() == null ? "false" : String.valueOf(config.getSshEnabled()));
+
+        StudioSshDetailsDto sshDetails = studio.getSshDetails();
+        if (sshDetails != null) {
+            table.addRow("SSH host", sshDetails.getHost());
+            table.addRow("SSH port", sshDetails.getPort() == null ? "NA" : String.valueOf(sshDetails.getPort()));
+            table.addRow("SSH command", sshDetails.getCommand());
+        }
+
+        if (config != null && config.getEnvironment() != null && !config.getEnvironment().isEmpty()) {
+            String envVars = config.getEnvironment().entrySet().stream()
+                    .map(e -> String.format("%s=%s", e.getKey(), e.getValue()))
+                    .collect(java.util.stream.Collectors.joining(", "));
+            table.addRow("Environment variables", envVars);
+        }
 
         table.print();
         if (config != null && config.getCondaEnvironment() != null && !config.getCondaEnvironment().isEmpty()) {

--- a/src/test/java/io/seqera/tower/cli/studios/StudiosCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/studios/StudiosCmdTest.java
@@ -2334,7 +2334,7 @@ public class StudiosCmdTest extends BaseCmdTest {
                 response().withStatusCode(200).withBody(loadResource("studios/studios_created_response")).withContentType(MediaType.APPLICATION_JSON)
         );
 
-        ExecOut out = exec(format, mock, "studios", "add", "-n", "studio-a66d", "-w", "75887156211589", "-t", "cr.seqera.io/public/data-studio-vscode:1.93.1-snapshot", "-c", "demo", "--url", "https://github.com/owner/repo", "--revision", "main");
+        ExecOut out = exec(format, mock, "studios", "add", "-n", "studio-a66d", "-w", "75887156211589", "-t", "cr.seqera.io/public/data-studio-vscode:1.93.1-snapshot", "-c", "demo", "--repository", "https://github.com/owner/repo", "--revision", "main");
 
         assertOutput(format, out, new StudiosCreated("3e8370e7", 75887156211589L, "[organization1 / workspace1]",
                 "http://localhost:" + mock.getPort() + "/orgs/organization1/workspaces/workspace1", false));
@@ -2533,7 +2533,7 @@ public class StudiosCmdTest extends BaseCmdTest {
                 response().withStatusCode(200).withBody(loadResource("studios/studios_created_response")).withContentType(MediaType.APPLICATION_JSON)
         );
 
-        ExecOut out = exec(format, mock, "studios", "add", "-n", "studio-a66d", "-w", "75887156211589", "-c", "demo", "--url", "https://github.com/owner/repo");
+        ExecOut out = exec(format, mock, "studios", "add", "-n", "studio-a66d", "-w", "75887156211589", "-c", "demo", "--repository", "https://github.com/owner/repo");
 
         assertOutput(format, out, new StudiosCreated("3e8370e7", 75887156211589L, "[organization1 / workspace1]",
                 "http://localhost:" + mock.getPort() + "/orgs/organization1/workspaces/workspace1", false));

--- a/src/test/java/io/seqera/tower/cli/studios/StudiosCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/studios/StudiosCmdTest.java
@@ -53,6 +53,7 @@ import org.mockserver.verify.VerificationTimes;
 
 import static io.seqera.tower.cli.utils.JsonHelper.parseJson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockserver.matchers.Times.exactly;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
@@ -2229,6 +2230,332 @@ public class StudiosCmdTest extends BaseCmdTest {
 
         assertOutput(format, out, new StudioUpdated("3e8370e7", "3e8370e7", 75887156211589L,
                 "[organization1 / workspace1]"));
+    }
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testAddWithSpotAndSsh(OutputType format, MockServerClient mock) {
+        mock.when(
+                request().withMethod("GET").withPath("/user-info"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/user/1264/workspaces"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workspaces/workspaces_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/studios/templates")
+                        .withQueryStringParameter("workspaceId", "75887156211589")
+                        .withQueryStringParameter("max", "20"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("studios/studios_templates_response")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/compute-envs")
+                        .withQueryStringParameter("status", "AVAILABLE")
+                        .withQueryStringParameter("workspaceId", "75887156211589"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"computeEnvs\":[{\"id\":\"vYOK4vn7spw7bHHWBDXZ2\",\"name\":\"demo\",\"platform\":\"aws-batch\",\"status\":\"AVAILABLE\",\"message\":null,\"lastUsed\":null,\"primary\":true,\"workspaceName\":null,\"visibility\":null}]}").withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/compute-envs/vYOK4vn7spw7bHHWBDXZ2"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("compute_env_demo")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("POST").withPath("/studios")
+                        .withQueryStringParameter("workspaceId", "75887156211589")
+                        .withBody(json("""
+                           {
+                             "spot": true,
+                             "configuration": {
+                               "sshEnabled": true
+                             }
+                           }
+                           """))
+                , exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("studios/studios_created_response")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(format, mock, "studios", "add", "-n", "studio-a66d", "-w", "75887156211589", "-t", "cr.seqera.io/public/data-studio-vscode:1.93.1-snapshot", "-c", "demo", "--spot", "--ssh");
+
+        assertOutput(format, out, new StudiosCreated("3e8370e7", 75887156211589L, "[organization1 / workspace1]",
+                "http://localhost:" + mock.getPort() + "/orgs/organization1/workspaces/workspace1", false));
+    }
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testAddWithRepository(OutputType format, MockServerClient mock) {
+        mock.when(
+                request().withMethod("GET").withPath("/user-info"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/user/1264/workspaces"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workspaces/workspaces_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/studios/templates")
+                        .withQueryStringParameter("workspaceId", "75887156211589")
+                        .withQueryStringParameter("max", "20"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("studios/studios_templates_response")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/compute-envs")
+                        .withQueryStringParameter("status", "AVAILABLE")
+                        .withQueryStringParameter("workspaceId", "75887156211589"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"computeEnvs\":[{\"id\":\"vYOK4vn7spw7bHHWBDXZ2\",\"name\":\"demo\",\"platform\":\"aws-batch\",\"status\":\"AVAILABLE\",\"message\":null,\"lastUsed\":null,\"primary\":true,\"workspaceName\":null,\"visibility\":null}]}").withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/compute-envs/vYOK4vn7spw7bHHWBDXZ2"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("compute_env_demo")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("POST").withPath("/studios")
+                        .withQueryStringParameter("workspaceId", "75887156211589")
+                        .withBody(json("""
+                           {
+                             "remoteConfig": {
+                               "repository": "https://github.com/owner/repo",
+                               "revision": "main"
+                             }
+                           }
+                           """))
+                , exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("studios/studios_created_response")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(format, mock, "studios", "add", "-n", "studio-a66d", "-w", "75887156211589", "-t", "cr.seqera.io/public/data-studio-vscode:1.93.1-snapshot", "-c", "demo", "--url", "https://github.com/owner/repo", "--revision", "main");
+
+        assertOutput(format, out, new StudiosCreated("3e8370e7", 75887156211589L, "[organization1 / workspace1]",
+                "http://localhost:" + mock.getPort() + "/orgs/organization1/workspaces/workspace1", false));
+    }
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testUpdateWithComputeEnv(OutputType format, MockServerClient mock) {
+        mock.when(
+                request().withMethod("GET").withPath("/user-info"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/user/1264/workspaces"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workspaces/workspaces_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/studios/3e8370e7").withQueryStringParameter("workspaceId", "75887156211589"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("studios/studios_view_response_studio_stopped")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/compute-envs")
+                        .withQueryStringParameter("status", "AVAILABLE")
+                        .withQueryStringParameter("workspaceId", "75887156211589"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"computeEnvs\":[{\"id\":\"vYOK4vn7spw7bHHWBDXZ2\",\"name\":\"demo\",\"platform\":\"aws-batch\",\"status\":\"AVAILABLE\",\"message\":null,\"lastUsed\":null,\"primary\":true,\"workspaceName\":null,\"visibility\":null}]}").withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/compute-envs/vYOK4vn7spw7bHHWBDXZ2"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("compute_env_demo")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("PUT").withPath("/studios/3e8370e7").withQueryStringParameter("workspaceId", "75887156211589").withBody(json("""
+                           {
+                             "computeEnvId": "vYOK4vn7spw7bHHWBDXZ2"
+                           }
+                           """))
+                , exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("studios/studios_update_response")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(format, mock, "studios", "update", "-w", "75887156211589", "-i", "3e8370e7", "--compute-env", "demo");
+
+        assertOutput(format, out, new StudioUpdated("3e8370e7", "3e8370e7", 75887156211589L,
+                "[organization1 / workspace1]"));
+    }
+
+    @Test
+    void testUpdateWithIncompatibleComputeEnvListsCompatibleOnes(MockServerClient mock) {
+        mock.when(
+                request().withMethod("GET").withPath("/user-info"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/user/1264/workspaces"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workspaces/workspaces_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/studios/3e8370e7").withQueryStringParameter("workspaceId", "75887156211589"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("studios/studios_view_response_studio_stopped")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/compute-envs")
+                        .withQueryStringParameter("status", "AVAILABLE")
+                        .withQueryStringParameter("workspaceId", "75887156211589"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"computeEnvs\":[{\"id\":\"vYOK4vn7spw7bHHWBDXZ2\",\"name\":\"demo\",\"platform\":\"aws-batch\",\"status\":\"AVAILABLE\",\"message\":null,\"lastUsed\":null,\"primary\":true,\"workspaceName\":null,\"visibility\":null}]}").withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/compute-envs/vYOK4vn7spw7bHHWBDXZ2"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("compute_env_demo")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        // The update is rejected because the target CE is not compatible.
+        mock.when(
+                request().withMethod("PUT").withPath("/studios/3e8370e7").withQueryStringParameter("workspaceId", "75887156211589"), exactly(1)
+        ).respond(
+                response().withStatusCode(400).withBody("{\"message\":\"Compute environment 'vYOK4vn7spw7bHHWBDXZ2' is not compatible with the Studio's current compute environment\"}").withContentType(MediaType.APPLICATION_JSON)
+        );
+        // The CLI then queries the compatible CEs to suggest valid options.
+        mock.when(
+                request().withMethod("GET").withPath("/studios/3e8370e7/compatible-ce").withQueryStringParameter("workspaceId", "75887156211589"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"computeEnvs\":[{\"id\":\"ce-compatible-123\",\"name\":\"compatible-ce\",\"platform\":\"aws-batch\",\"status\":\"AVAILABLE\"}]}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(mock, "studios", "update", "-w", "75887156211589", "-i", "3e8370e7", "--compute-env", "demo");
+
+        assertEquals(1, out.exitCode);
+        assertTrue(out.stdErr.contains("not compatible"), out.stdErr);
+        assertTrue(out.stdErr.contains("compatible-ce"), out.stdErr);
+        assertTrue(out.stdErr.contains("ce-compatible-123"), out.stdErr);
+    }
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testAddWithEnvironmentVariables(OutputType format, MockServerClient mock) {
+        mock.when(
+                request().withMethod("GET").withPath("/user-info"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/user/1264/workspaces"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workspaces/workspaces_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/studios/templates")
+                        .withQueryStringParameter("workspaceId", "75887156211589")
+                        .withQueryStringParameter("max", "20"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("studios/studios_templates_response")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/compute-envs")
+                        .withQueryStringParameter("status", "AVAILABLE")
+                        .withQueryStringParameter("workspaceId", "75887156211589"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"computeEnvs\":[{\"id\":\"vYOK4vn7spw7bHHWBDXZ2\",\"name\":\"demo\",\"platform\":\"aws-batch\",\"status\":\"AVAILABLE\",\"message\":null,\"lastUsed\":null,\"primary\":true,\"workspaceName\":null,\"visibility\":null}]}").withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/compute-envs/vYOK4vn7spw7bHHWBDXZ2"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("compute_env_demo")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("POST").withPath("/studios")
+                        .withQueryStringParameter("workspaceId", "75887156211589")
+                        .withBody(json("""
+                           {
+                             "configuration": {
+                               "environment": {
+                                 "FOO": "bar",
+                                 "BAZ": "qux"
+                               }
+                             }
+                           }
+                           """))
+                , exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("studios/studios_created_response")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(format, mock, "studios", "add", "-n", "studio-a66d", "-w", "75887156211589", "-t", "cr.seqera.io/public/data-studio-vscode:1.93.1-snapshot", "-c", "demo", "-e", "FOO=bar", "-e", "BAZ=qux");
+
+        assertOutput(format, out, new StudiosCreated("3e8370e7", 75887156211589L, "[organization1 / workspace1]",
+                "http://localhost:" + mock.getPort() + "/orgs/organization1/workspaces/workspace1", false));
+    }
+
+    @ParameterizedTest
+    @EnumSource(OutputType.class)
+    void testAddWithUrlAndNoTemplate(OutputType format, MockServerClient mock) {
+        mock.when(
+                request().withMethod("GET").withPath("/user-info"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/user/1264/workspaces"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workspaces/workspaces_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/compute-envs")
+                        .withQueryStringParameter("status", "AVAILABLE")
+                        .withQueryStringParameter("workspaceId", "75887156211589"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"computeEnvs\":[{\"id\":\"vYOK4vn7spw7bHHWBDXZ2\",\"name\":\"demo\",\"platform\":\"aws-batch\",\"status\":\"AVAILABLE\",\"message\":null,\"lastUsed\":null,\"primary\":true,\"workspaceName\":null,\"visibility\":null}]}").withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/compute-envs/vYOK4vn7spw7bHHWBDXZ2"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("compute_env_demo")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("POST").withPath("/studios")
+                        .withQueryStringParameter("workspaceId", "75887156211589")
+                        .withBody(json("""
+                           {
+                             "remoteConfig": {
+                               "repository": "https://github.com/owner/repo"
+                             }
+                           }
+                           """))
+                , exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("studios/studios_created_response")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(format, mock, "studios", "add", "-n", "studio-a66d", "-w", "75887156211589", "-c", "demo", "--url", "https://github.com/owner/repo");
+
+        assertOutput(format, out, new StudiosCreated("3e8370e7", 75887156211589L, "[organization1 / workspace1]",
+                "http://localhost:" + mock.getPort() + "/orgs/organization1/workspaces/workspace1", false));
+    }
+
+    @Test
+    void testAddWithoutTemplateOrUrlFails(MockServerClient mock) {
+        mock.when(
+                request().withMethod("GET").withPath("/user-info"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
+        );
+        mock.when(
+                request().withMethod("GET").withPath("/user/1264/workspaces"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workspaces/workspaces_list")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(mock, "studios", "add", "-n", "studio-a66d", "-w", "75887156211589", "-c", "demo");
+
+        assertEquals(1, out.exitCode);
+        assertTrue(out.stdErr.contains("A studio template is required"), out.stdErr);
     }
 
 }


### PR DESCRIPTION
###  Configuring studios via Git repository config and studio configuration enhancements

This PR adds support for Git repository studio config as the headline feature, alongside several studio configuration enhancements across the `add`, `start`, and `update` commands.

#### Main change: Git-backed studio configuration

Studios can now be created from a Git repository via `--repository`, with an optional `--revision` (branch, tag, or commit). When a repository is provided, `-t/--template` becomes **optional**, since the remote repository may define the template itself.

```bash
tw studios add -n my-studio -w my-workspace -c my-ce --repository https://github.com/owner/repo --revision main
```

#### Other enhancements

- **Environment variables** — set env vars with repeatable `-e/--env KEY=value` pairs (available on `add`, `start`, and `update`).
  ```bash
  tw studios add -n my-studio -w my-workspace -c my-ce -t <template> -e FOO=bar -e BAZ=qux
  ```

- **Spot instances** — launch on spot via `--spot` (on `add` and `start`). Note: whether spot instances are supported can depend on the chosen underlying compute environment where the studio is launched.
  ```bash
  tw studios add -n my-studio -w my-workspace -c my-ce -t <template> --spot
  ```



- **SSH connectivity** — enable SSH with `--ssh` (on `add`, `start`, and `update`); SSH host/port/command are shown in the studio view.
  ```bash
  tw studios add -n my-studio -w my-workspace -c my-ce -t <template> --ssh
  ```

- **Change compute environment on update** — move a stopped studio to a compatible CE with `-c/--compute-env`. If the target CE is incompatible, the CLI lists the compatible ones.
  ```bash
  tw studios update -w my-workspace -i <session-id> --compute-env another-ce
  ```

- **Richer studio view** — the studio view now also shows Private, Lifespan, SSH details, and environment variables.

<details>
<summary><b>Command examples</b></summary>

```bash
# Set environment variables (repeatable) on any of the commands below
tw studios add -n my-studio -w my-workspace -c my-ce -t <template> \
  -e FOO=bar -e BAZ=qux
```

**Add a template-based studio**
```bash
tw studios add -n my-studio -w my-workspace -c my-ce \
  -t cr.seqera.io/public/data-studio-vscode:1.93.1-snapshot
```

**Add a Git-backed studio (template optional)**
```bash
# With a revision
tw studios add -n my-studio -w my-workspace -c my-ce \
  --repository https://github.com/owner/repo --revision main

# Without a template — the repository may define it
tw studios add -n my-studio -w my-workspace -c my-ce \
  --repository https://github.com/owner/repo
```

**Add on spot instances with SSH enabled**
```bash
tw studios add -n my-studio -w my-workspace -c my-ce -t <template> \
  --spot --ssh
```

**Start a studio with overrides**
```bash
tw studios start -w my-workspace -i <session-id> --spot --ssh
```

**Update SSH connectivity**
```bash
tw studios update -w my-workspace -i <session-id> --ssh
```

**Move a stopped studio to a compatible compute environment**
```bash
tw studios update -w my-workspace -i <session-id> --compute-env another-ce
```

</details>
