### PR TITLE
feat(compute): add compute-envs validate command

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/ComputeEnvsCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/ComputeEnvsCmd.java
@@ -23,6 +23,7 @@ import io.seqera.tower.cli.commands.computeenvs.ImportCmd;
 import io.seqera.tower.cli.commands.computeenvs.ListCmd;
 import io.seqera.tower.cli.commands.computeenvs.PrimaryCmd;
 import io.seqera.tower.cli.commands.computeenvs.UpdateCmd;
+import io.seqera.tower.cli.commands.computeenvs.ValidateCmd;
 import io.seqera.tower.cli.commands.computeenvs.ViewCmd;
 import picocli.CommandLine.Command;
 
@@ -39,6 +40,7 @@ import picocli.CommandLine.Command;
                 ExportCmd.class,
                 ImportCmd.class,
                 PrimaryCmd.class,
+                ValidateCmd.class,
         }
 )
 public class ComputeEnvsCmd extends AbstractRootCmd {

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/ValidateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/ValidateCmd.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.commands.computeenvs;
+
+import io.seqera.tower.ApiException;
+import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
+import io.seqera.tower.cli.responses.Response;
+import io.seqera.tower.cli.responses.computeenvs.ComputeEnvValidated;
+import io.seqera.tower.model.ComputeEnvResponseDto;
+import io.seqera.tower.model.ValidateComputeEnvResponse;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+@Command(
+        name = "validate",
+        description = "Validate a compute environment by re-running its pre-flight checks (credential and work-directory)."
+)
+public class ValidateCmd extends AbstractComputeEnvCmd {
+
+    @CommandLine.Mixin
+    public ComputeEnvRefOptions computeEnvRefOptions;
+
+    @CommandLine.Mixin
+    public WorkspaceOptionalOptions workspace;
+
+    @CommandLine.Option(names = {"--force"}, description = "Skip the pre-flight checks and force an INVALID compute environment (with an AVAILABLE credential) to AVAILABLE. Rejected otherwise.")
+    public boolean force;
+
+    @Override
+    protected Response exec() throws ApiException {
+        Long wspId = workspaceId(workspace.workspace);
+        ComputeEnvResponseDto computeEnv = fetchComputeEnv(computeEnvRefOptions, wspId);
+
+        ValidateComputeEnvResponse response = computeEnvsApi().validateComputeEnv(computeEnv.getId(), wspId, force, null);
+
+        return new ComputeEnvValidated(
+                computeEnv.getId(),
+                computeEnv.getName(),
+                workspaceRef(wspId),
+                response.getStatus(),
+                Boolean.TRUE.equals(response.getTransientError()),
+                response.getMessage()
+        );
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/responses/computeenvs/ComputeEnvValidated.java
+++ b/src/main/java/io/seqera/tower/cli/responses/computeenvs/ComputeEnvValidated.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.responses.computeenvs;
+
+import io.seqera.tower.cli.responses.Response;
+import io.seqera.tower.model.ComputeEnvStatus;
+import picocli.CommandLine;
+
+public class ComputeEnvValidated extends Response {
+
+    public final String id;
+    public final String name;
+    public final String workspaceRef;
+    public final ComputeEnvStatus status;
+    public final boolean transientError;
+    public final String message;
+
+    public ComputeEnvValidated(String id, String name, String workspaceRef, ComputeEnvStatus status, boolean transientError, String message) {
+        this.id = id;
+        this.name = name;
+        this.workspaceRef = workspaceRef;
+        this.status = status;
+        this.transientError = transientError;
+        this.message = message;
+    }
+
+    @Override
+    public String toString() {
+        String color = status == ComputeEnvStatus.AVAILABLE ? "green" : "red";
+        StringBuilder result = new StringBuilder(ansi(String.format(
+                "%n  @|bold Compute environment '%s'|@ at %s workspace validated as @|%s %s|@%n",
+                id, workspaceRef, color, status)));
+
+        if (transientError) {
+            result.append(ansi(String.format(
+                    "  @|yellow The provider could not be reached; the reported status is the last known value.|@%n")));
+        }
+        if (message != null && !message.isEmpty()) {
+            result.append(String.format("  Detail: %s%n", message));
+        }
+        return result.toString();
+    }
+
+    @Override
+    public int getExitCode() {
+        return status == ComputeEnvStatus.INVALID ? CommandLine.ExitCode.SOFTWARE : CommandLine.ExitCode.OK;
+    }
+}

--- a/src/test/java/io/seqera/tower/cli/computeenvs/ComputeEnvsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/ComputeEnvsCmdTest.java
@@ -32,6 +32,7 @@ import io.seqera.tower.cli.responses.computeenvs.ComputeEnvDeleted;
 import io.seqera.tower.cli.responses.computeenvs.ComputeEnvExport;
 import io.seqera.tower.cli.responses.computeenvs.ComputeEnvList;
 import io.seqera.tower.cli.responses.computeenvs.ComputeEnvUpdated;
+import io.seqera.tower.cli.responses.computeenvs.ComputeEnvValidated;
 import io.seqera.tower.cli.responses.computeenvs.ComputeEnvView;
 import io.seqera.tower.cli.responses.computeenvs.ComputeEnvsPrimaryGet;
 import io.seqera.tower.cli.responses.computeenvs.ComputeEnvsPrimarySet;
@@ -760,5 +761,51 @@ class ComputeEnvsCmdTest extends BaseCmdTest {
         ExecOut out = exec(mock, "compute-envs", "delete", "-i", "vYOK4vn7spw7bHHWBDXZ2", "--wait");
 
         assertEquals(1, out.exitCode);
+    }
+
+    @Test
+    void testValidateAvailable(MockServerClient mock) {
+        mock.when(
+                request().withMethod("GET").withPath("/compute-envs/isnEDBLvHDAIteOEF44ow"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"computeEnv\":{\"id\":\"isnEDBLvHDAIteOEF44ow\",\"name\":\"demo\",\"platform\":\"aws-batch\",\"status\":\"INVALID\"}}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("POST").withPath("/compute-envs/isnEDBLvHDAIteOEF44ow/validate"), exactly(1)
+        ).respond(
+                response().withStatusCode(200)
+                        .withBody("{\"status\":\"AVAILABLE\",\"transientError\":false}")
+                        .withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(mock, "compute-envs", "validate", "-i", "isnEDBLvHDAIteOEF44ow");
+
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+        assertEquals(new ComputeEnvValidated("isnEDBLvHDAIteOEF44ow", "demo", USER_WORKSPACE_NAME, ComputeEnvStatus.AVAILABLE, false, null).toString(), out.stdOut);
+    }
+
+    @Test
+    void testValidateInvalid(MockServerClient mock) {
+        mock.when(
+                request().withMethod("GET").withPath("/compute-envs/isnEDBLvHDAIteOEF44ow"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"computeEnv\":{\"id\":\"isnEDBLvHDAIteOEF44ow\",\"name\":\"demo\",\"platform\":\"aws-batch\",\"status\":\"INVALID\"}}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("POST").withPath("/compute-envs/isnEDBLvHDAIteOEF44ow/validate"), exactly(1)
+        ).respond(
+                response().withStatusCode(200)
+                        .withBody("{\"status\":\"INVALID\",\"transientError\":false,\"message\":\"Work directory not accessible\"}")
+                        .withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(mock, "compute-envs", "validate", "-i", "isnEDBLvHDAIteOEF44ow");
+
+        assertEquals("", out.stdErr);
+        assertEquals(1, out.exitCode);
+        assertEquals(new ComputeEnvValidated("isnEDBLvHDAIteOEF44ow", "demo", USER_WORKSPACE_NAME, ComputeEnvStatus.INVALID, false, "Work directory not accessible").toString(), out.stdOut);
     }
 }


### PR DESCRIPTION
## What

Adds a `tower compute-envs validate` subcommand that validates a compute environment against its cloud provider, mirroring the existing `tower credentials validate` command.

## Why

Platform SDK **1.181.0** (consumed in #643) added `ComputeEnvsApi.validateComputeEnv` — `POST /compute-envs/{computeEnvId}/validate` — which re-runs a compute environment's pre-flight checks (associated-credential validation and work-directory accessibility) and persists the outcome to the CE and its credential. It is the CE counterpart of the credentials validate endpoint and is intended to recover a compute environment marked `INVALID` once the underlying problem has been fixed.

The SDK bump surfaced new CE *creation* options but left this endpoint unused. This PR wires it into the CLI.

## How

- `commands/computeenvs/ValidateCmd.java` — resolves the CE by `--id`/`--name` (via the shared `ComputeEnvRefOptions` + `fetchComputeEnv`), calls `validateComputeEnv(id, wspId, force, null)`, and returns a `ComputeEnvValidated` response.
- `responses/computeenvs/ComputeEnvValidated.java` — renders status (green/red), a transient-error hint, and the detail message; exits with `SOFTWARE` when the CE validates as `INVALID`, matching `CredentialsValidated`.
- A `--force` flag maps to the API's force override that promotes an `INVALID` CE (with an `AVAILABLE` credential) to `AVAILABLE`.
- Registered `ValidateCmd` in `ComputeEnvsCmd`.

## How to verify

- `./gradlew test --tests "io.seqera.tower.cli.computeenvs.ComputeEnvsCmdTest"` — passes, including two new tests:
  - `testValidateAvailable` — recovering an `INVALID` CE to `AVAILABLE` (exit 0)
  - `testValidateInvalid` — CE still `INVALID` with a detail message (exit 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)