### PR TITLE
feat: [COMP-2106] support VPC network and subnetworks for google-cloud compute environment

### DIFF
--- a/VERSION-API
+++ b/VERSION-API
@@ -1,4 +1,4 @@
-1.190.0
+1.189.0
 // Only first line of this file is read
 // This version should be bumped to the minimum version where dependent API changes were introduced
 // But never higher then the current Platform API Version deployed in Cloud Production: https://cloud.seqera.io/api/service-info

--- a/VERSION-API
+++ b/VERSION-API
@@ -1,4 +1,4 @@
-1.181.0
+1.190.0
 // Only first line of this file is read
 // This version should be bumped to the minimum version where dependent API changes were introduced
 // But never higher then the current Platform API Version deployed in Cloud Production: https://cloud.seqera.io/api/service-info

--- a/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/GoogleCloudPlatform.java
+++ b/src/main/java/io/seqera/tower/cli/commands/computeenvs/platforms/GoogleCloudPlatform.java
@@ -17,6 +17,7 @@
 package io.seqera.tower.cli.commands.computeenvs.platforms;
 
 import io.seqera.tower.ApiException;
+import io.seqera.tower.cli.exceptions.TowerRuntimeException;
 import io.seqera.tower.model.ComputeEnvComputeConfig.PlatformEnum;
 import io.seqera.tower.model.GoogleCloudConfig;
 import io.seqera.tower.model.SchedConfig;
@@ -25,8 +26,13 @@ import picocli.CommandLine.Option;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.regex.Pattern;
 
 public class GoogleCloudPlatform extends AbstractPlatform<GoogleCloudConfig> {
+
+    private static final Pattern NETWORK_TAG_PATTERN = Pattern.compile("^[a-z][-a-z0-9]*[a-z0-9]$");
+    private static final int MAX_NETWORK_TAGS = 64;
+    private static final int MAX_TAG_LENGTH = 63;
 
     @Option(names = {"--work-dir"}, description = "Nextflow work directory. Path where workflow intermediate files are stored. Must be a Google Cloud Storage bucket path (e.g., gs://your-bucket/work). Credentials must have read-write access.", required = true)
     public String workDir;
@@ -81,12 +87,20 @@ public class GoogleCloudPlatform extends AbstractPlatform<GoogleCloudConfig> {
 
         // Advanced
         if (adv != null) {
+            if (adv.networkTags != null && !adv.networkTags.isEmpty()) {
+                validateNetworkTags(adv.networkTags, adv.network);
+            }
+
             config
                     .arm64Enabled(adv.arm64Enabled)
                     .gpuEnabled(adv.gpuEnabled)
                     .imageId(adv.imageId)
                     .instanceType(adv.instanceType)
-                    .bootDiskSizeGb(adv.bootDiskSizeGb);
+                    .bootDiskSizeGb(adv.bootDiskSizeGb)
+                    .network(adv.network)
+                    .subnetworks(adv.subnetworks)
+                    .networkTags(adv.networkTags)
+                    .usePrivateAddress(adv.usePrivateAddress);
         }
 
         // Common
@@ -97,6 +111,31 @@ public class GoogleCloudPlatform extends AbstractPlatform<GoogleCloudConfig> {
                 .environment(environmentVariables());
 
         return config;
+    }
+
+    private static void validateNetworkTags(List<String> tags, String network) {
+        if (network == null || network.isEmpty()) {
+            throw new TowerRuntimeException("Network tags require VPC configuration: set the '--network' option to use network tags.");
+        }
+
+        if (tags.size() > MAX_NETWORK_TAGS) {
+            throw new TowerRuntimeException(String.format("Too many network tags: maximum is %d, provided %d.", MAX_NETWORK_TAGS, tags.size()));
+        }
+
+        for (String tag : tags) {
+            if (tag == null || tag.isEmpty() || tag.length() > MAX_TAG_LENGTH) {
+                throw new TowerRuntimeException(String.format("Invalid network tag '%s': must be 1-63 characters.", tag));
+            }
+            if (tag.length() == 1) {
+                if (!tag.matches("^[a-z]$")) {
+                    throw new TowerRuntimeException(String.format("Invalid network tag '%s': single-character tags must be a lowercase letter.", tag));
+                }
+            } else {
+                if (!NETWORK_TAG_PATTERN.matcher(tag).matches()) {
+                    throw new TowerRuntimeException(String.format("Invalid network tag '%s': must start with a lowercase letter, end with a letter or number, and contain only lowercase letters, numbers, and hyphens.", tag));
+                }
+            }
+        }
     }
 
     public static class SchedOptions {
@@ -125,5 +164,17 @@ public class GoogleCloudPlatform extends AbstractPlatform<GoogleCloudConfig> {
 
         @Option(names = {"--instance-type"}, description = "Compute Engine machine type (e.g., n1-standard-1, n2-standard-2). If omitted, a default machine type is used.")
         public String instanceType;
+
+        @Option(names = {"--network"}, description = "Google Cloud VPC network name or URI. Required when using subnetworks or network tags. When omitted, the project's 'default' network is used.")
+        public String network;
+
+        @Option(names = {"--subnetworks"}, split = ",", paramLabel = "<subnetwork>", description = "Google Cloud VPC subnetworks for instance placement. Comma-separated list of names or URIs in the same region as the compute environment; the first is used for basic placement while Intelligent Compute may use all of them. Requires --network.")
+        public List<String> subnetworks;
+
+        @Option(names = {"--network-tags"}, split = ",", paramLabel = "<tag>", description = "Comma-separated list of network tags applied to VMs for firewall rule targeting. Tags must be lowercase, use only letters, numbers, and hyphens (1-63 chars). Requires --network.")
+        public List<String> networkTags;
+
+        @Option(names = {"--use-private-address"}, description = "Do not attach a public IP address to VM instances. When enabled, only Google internal services are accessible. Requires Cloud NAT for external access.")
+        public Boolean usePrivateAddress;
     }
 }

--- a/src/test/java/io/seqera/tower/cli/InfoCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/InfoCmdTest.java
@@ -56,7 +56,7 @@ public class InfoCmdTest extends BaseCmdTest {
         Map<String, String> opts = new HashMap<>();
         opts.put("cliVersion", getCliVersion() );
         opts.put("cliApiVersion", getCliApiVersion());
-        opts.put("towerApiVersion", "1.181.0");
+        opts.put("towerApiVersion", "1.190.0");
         opts.put("towerVersion", "22.3.0-torricelli");
         opts.put("towerApiEndpoint", "http://localhost:"+mock.getPort());
         opts.put("userName", "jordi");
@@ -86,7 +86,7 @@ public class InfoCmdTest extends BaseCmdTest {
         Map<String, String> opts = new HashMap<>();
         opts.put("cliVersion", getCliVersion() );
         opts.put("cliApiVersion", getCliApiVersion());
-        opts.put("towerApiVersion", "1.181.0");
+        opts.put("towerApiVersion", "1.190.0");
         opts.put("towerVersion", "22.3.0-torricelli");
         opts.put("towerApiEndpoint", "http://localhost:"+mock.getPort());
         opts.put("userName", null);

--- a/src/test/java/io/seqera/tower/cli/InfoCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/InfoCmdTest.java
@@ -56,7 +56,7 @@ public class InfoCmdTest extends BaseCmdTest {
         Map<String, String> opts = new HashMap<>();
         opts.put("cliVersion", getCliVersion() );
         opts.put("cliApiVersion", getCliApiVersion());
-        opts.put("towerApiVersion", "1.190.0");
+        opts.put("towerApiVersion", "1.189.0");
         opts.put("towerVersion", "22.3.0-torricelli");
         opts.put("towerApiEndpoint", "http://localhost:"+mock.getPort());
         opts.put("userName", "jordi");
@@ -86,7 +86,7 @@ public class InfoCmdTest extends BaseCmdTest {
         Map<String, String> opts = new HashMap<>();
         opts.put("cliVersion", getCliVersion() );
         opts.put("cliApiVersion", getCliApiVersion());
-        opts.put("towerApiVersion", "1.190.0");
+        opts.put("towerApiVersion", "1.189.0");
         opts.put("towerVersion", "22.3.0-torricelli");
         opts.put("towerApiEndpoint", "http://localhost:"+mock.getPort());
         opts.put("userName", null);

--- a/src/test/java/io/seqera/tower/cli/computeenvs/platforms/GoogleCloudPlatformTest.java
+++ b/src/test/java/io/seqera/tower/cli/computeenvs/platforms/GoogleCloudPlatformTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 
 import static io.seqera.tower.cli.commands.AbstractApiCmd.USER_WORKSPACE_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockserver.matchers.Times.exactly;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
@@ -229,5 +230,153 @@ public class GoogleCloudPlatformTest extends BaseCmdTest {
         assertEquals("", out.stdErr);
         assertEquals(0, out.exitCode);
         assertEquals(expected.toString(), out.stdOut);
+    }
+
+    @Test
+    void testAddWithNetworkAndSubnetworks(MockServerClient mock) throws IOException {
+        mock.reset();
+        mockCredentials(mock);
+
+        mock.when(
+                request()
+                        .withMethod("POST")
+                        .withPath("/compute-envs")
+                        .withBody(json("""
+                                {
+                                    "computeEnv": {
+                                        "name": "my-google-cloud-net",
+                                        "platform": "google-cloud",
+                                        "config": {
+                                            "workDir": "gs://my-bucket",
+                                            "region": "us-central1",
+                                            "zone": "us-central1-a",
+                                            "fusion2Enabled": true,
+                                            "waveEnabled": true,
+                                            "network": "my-vpc",
+                                            "subnetworks": ["subnet-a", "subnet-b"],
+                                            "usePrivateAddress": true
+                                        },
+                                        "credentialsId": "6XfOhoztUq6de3Dw3X9LSb"
+                                    }
+                                }""")),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}")
+        );
+
+        ExecOut out = exec(mock, "compute-envs", "add", "google-cloud",
+                "-n", "my-google-cloud-net",
+                "--work-dir", "gs://my-bucket",
+                "-r", "us-central1",
+                "-z", "us-central1-a",
+                "--network", "my-vpc",
+                "--subnetworks", "subnet-a,subnet-b",
+                "--use-private-address"
+        );
+
+        var expected = new ComputeEnvAdded("google-cloud", "isnEDBLvHDAIteOEF44ow", "my-google-cloud-net", null, USER_WORKSPACE_NAME);
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+        assertEquals(expected.toString(), out.stdOut);
+    }
+
+    @Test
+    void testAddWithNetworkTags(MockServerClient mock) throws IOException {
+        mock.reset();
+        mockCredentials(mock);
+
+        mock.when(
+                request()
+                        .withMethod("POST")
+                        .withPath("/compute-envs")
+                        .withBody(json("""
+                                {
+                                    "computeEnv": {
+                                        "name": "my-google-cloud-tags",
+                                        "platform": "google-cloud",
+                                        "config": {
+                                            "workDir": "gs://my-bucket",
+                                            "region": "us-central1",
+                                            "zone": "us-central1-a",
+                                            "fusion2Enabled": true,
+                                            "waveEnabled": true,
+                                            "network": "my-vpc",
+                                            "networkTags": ["allow-ssh", "web-tier"]
+                                        },
+                                        "credentialsId": "6XfOhoztUq6de3Dw3X9LSb"
+                                    }
+                                }""")),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"computeEnvId\":\"isnEDBLvHDAIteOEF44ow\"}")
+        );
+
+        ExecOut out = exec(mock, "compute-envs", "add", "google-cloud",
+                "-n", "my-google-cloud-tags",
+                "--work-dir", "gs://my-bucket",
+                "-r", "us-central1",
+                "-z", "us-central1-a",
+                "--network", "my-vpc",
+                "--network-tags", "allow-ssh,web-tier"
+        );
+
+        var expected = new ComputeEnvAdded("google-cloud", "isnEDBLvHDAIteOEF44ow", "my-google-cloud-tags", null, USER_WORKSPACE_NAME);
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+        assertEquals(expected.toString(), out.stdOut);
+    }
+
+    @Test
+    void testAddNetworkTagsWithoutNetworkFails(MockServerClient mock) {
+        mock.reset();
+
+        ExecOut out = exec(mock, "compute-envs", "add", "google-cloud",
+                "-n", "my-google-cloud-tags",
+                "--work-dir", "gs://my-bucket",
+                "-r", "us-central1",
+                "-z", "us-central1-a",
+                "--network-tags", "allow-ssh"
+        );
+
+        assertTrue(out.stdErr.contains("Network tags require VPC configuration"), "Expected VPC required error, got: " + out.stdErr);
+        assertEquals(1, out.exitCode);
+    }
+
+    @Test
+    void testAddNetworkTagsInvalidFormatFails(MockServerClient mock) {
+        mock.reset();
+
+        ExecOut out = exec(mock, "compute-envs", "add", "google-cloud",
+                "-n", "my-google-cloud-tags",
+                "--work-dir", "gs://my-bucket",
+                "-r", "us-central1",
+                "-z", "us-central1-a",
+                "--network", "my-vpc",
+                "--network-tags", "Allow-SSH"
+        );
+
+        assertTrue(out.stdErr.contains("Invalid network tag 'Allow-SSH'"), "Expected invalid tag error, got: " + out.stdErr);
+        assertEquals(1, out.exitCode);
+    }
+
+    private static void mockCredentials(MockServerClient mock) {
+        mock.when(
+                request()
+                        .withMethod("GET")
+                        .withPath("/credentials")
+                        .withQueryStringParameter("platformId", "google-cloud"),
+                exactly(1)
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"credentials\":[{\"id\":\"6XfOhoztUq6de3Dw3X9LSb\",\"name\":\"google\",\"description\":null,\"discriminator\":\"google\",\"baseUrl\":null,\"category\":null,\"deleted\":null,\"lastUsed\":\"2021-09-08T18:20:46Z\",\"dateCreated\":\"2021-09-08T12:57:04Z\",\"lastUpdated\":\"2021-09-08T12:57:04Z\"}]}")
+        );
     }
 }

--- a/src/test/resources/runcmd/info/service-info.json
+++ b/src/test/resources/runcmd/info/service-info.json
@@ -1,7 +1,7 @@
 {
   "serviceInfo": {
     "version": "22.3.0-torricelli",
-    "apiVersion": "1.181.0",
+    "apiVersion": "1.190.0",
     "commitId": "3f04bfd4",
     "authTypes": [
       "github",

--- a/src/test/resources/runcmd/info/service-info.json
+++ b/src/test/resources/runcmd/info/service-info.json
@@ -1,7 +1,7 @@
 {
   "serviceInfo": {
     "version": "22.3.0-torricelli",
-    "apiVersion": "1.190.0",
+    "apiVersion": "1.189.0",
     "commitId": "3f04bfd4",
     "authTypes": [
       "github",


### PR DESCRIPTION
## Summary
Adds VPC/subnet customization to the `compute-envs add google-cloud` command, which previously had no networking options. Mirrors the existing `aws-cloud` VPC/subnet support (#639).

New advanced options:
- `--network` — VPC network name or URI (defaults to the project's `default` network)
- `--subnetworks` — comma-separated subnetworks; the first is used for basic placement, Intelligent Compute may use all of them
- `--network-tags` — firewall-targeting tags (validated: require `--network`, GCP tag format, max 64)
- `--use-private-address` — launch VMs without an external IP

`subnetworks` is a list (not singular like `google-batch`), matching the `GoogleCloudConfig` SIC model where workers can be spread across a subnet pool.

Also bumps the minimum required Platform API version to `1.190.0` (the version that introduced the `GoogleCloudConfig` network fields, and the current cloud production API version), updating the `info` command tests/fixture to match.

## Test plan

### Unit tests
New tests in `GoogleCloudPlatformTest`:
- `--network` + `--subnetworks` (list) + `--use-private-address` → asserts exact request body
- `--network-tags` → asserts tags in request body
- `--network-tags` without `--network` → fails CLI-side ("Network tags require VPC configuration")
- invalid tag format (`Allow-SSH`) → fails CLI-side

### Manual end-to-end verification
Built the CLI shadow jar and exercised the real `compute-envs add google-cloud` flow against live backends, confirming each field round-trips CLI flag → API → persisted CE config.

| Scenario | Backend | Result |
|----------|---------|--------|
| network + subnetworks + tags + private-address (no SIC) | local (API 1.195.0) | CE created; persisted `network=sic-test-vpc`, `subnetworks=[sic-test-subnet]`, `networkTags=[allow-ssh, web-tier]`, `usePrivateAddress=true` ✓ |
| same, non-SIC | dev (API 1.195.0), personal workspace | same four fields persisted ✓ |
| **SIC enabled** + network flags | dev (API 1.195.0), org workspace | `schedEnabled=true`, `schedConfig={provisioningModel: ondemand, machineTypes: [n2d-standard-2]}` **and** all four network fields persisted ✓ |

Negative validation (tags without network, invalid tag format) confirmed to fail CLI-side against the live backend as well.

The SIC + VPC/subnet combination is the key case for COMP-2106 (VPC/subnet customization for GCP Cloud Intelligent Compute); verified the two work together.

Requires `tower-java-sdk` >= 1.190.0 (already pinned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
