### PR TITLE
chore: Bump VERSION-API to 1.190.0

### DIFF
--- a/VERSION-API
+++ b/VERSION-API
@@ -1,4 +1,4 @@
-1.189.0
+1.190.0
 // Only first line of this file is read
 // This version should be bumped to the minimum version where dependent API changes were introduced
 // But never higher then the current Platform API Version deployed in Cloud Production: https://cloud.seqera.io/api/service-info

--- a/src/test/java/io/seqera/tower/cli/InfoCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/InfoCmdTest.java
@@ -56,7 +56,7 @@ public class InfoCmdTest extends BaseCmdTest {
         Map<String, String> opts = new HashMap<>();
         opts.put("cliVersion", getCliVersion() );
         opts.put("cliApiVersion", getCliApiVersion());
-        opts.put("towerApiVersion", "1.189.0");
+        opts.put("towerApiVersion", "1.190.0");
         opts.put("towerVersion", "22.3.0-torricelli");
         opts.put("towerApiEndpoint", "http://localhost:"+mock.getPort());
         opts.put("userName", "jordi");
@@ -86,7 +86,7 @@ public class InfoCmdTest extends BaseCmdTest {
         Map<String, String> opts = new HashMap<>();
         opts.put("cliVersion", getCliVersion() );
         opts.put("cliApiVersion", getCliApiVersion());
-        opts.put("towerApiVersion", "1.189.0");
+        opts.put("towerApiVersion", "1.190.0");
         opts.put("towerVersion", "22.3.0-torricelli");
         opts.put("towerApiEndpoint", "http://localhost:"+mock.getPort());
         opts.put("userName", null);

--- a/src/test/resources/runcmd/info/service-info.json
+++ b/src/test/resources/runcmd/info/service-info.json
@@ -1,7 +1,7 @@
 {
   "serviceInfo": {
     "version": "22.3.0-torricelli",
-    "apiVersion": "1.189.0",
+    "apiVersion": "1.190.0",
     "commitId": "3f04bfd4",
     "authTypes": [
       "github",


### PR DESCRIPTION
Bump `VERSION-API` to `1.190.0` that supports allow list for studios.