### PR TITLE
fix(runs): make tw runs relaunch resume honestly and stop dropping launch settings

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
@@ -89,9 +89,11 @@ public class RelaunchCmd extends AbstractRunsCmd {
             ce = computeEnvByRef(wspId, opts.computeEnv);
         }
 
-        // Check if it's not possible to resume the workflow
-        if (launch.getResumeCommitId() == null) {
-            noResume = true;
+        // A run can only be resumed from the commit ID it reported: without it there is no
+        // revision to resume from, and silently relaunching from scratch would charge the user
+        // for a full rerun while reporting a resume.
+        if (!noResume && launch.getResumeCommitId() == null) {
+            throw new TowerException(String.format("Pipeline run '%s' cannot be resumed because it did not report a commit ID. Use '--no-resume' to relaunch it from scratch.", id));
         }
 
         WorkflowLaunchRequest workflowLaunchRequest = new WorkflowLaunchRequest()

--- a/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
@@ -77,6 +77,10 @@ public class RelaunchCmd extends AbstractRunsCmd {
             throw new TowerException("Not allowed to change '--work-dir' option when resuming. Use '--no-resume' if you want to relaunch into a different working directory without resuming.");
         }
 
+        if (!noResume && pipeline != null) {
+            throw new TowerException("Not allowed to change '--pipeline' option when resuming. Use '--no-resume' if you want to relaunch a different pipeline without resuming.");
+        }
+
         WorkflowMaxDbDto workflow = workflowById(wspId, id, NO_WORKFLOW_ATTRIBUTES).getWorkflow();
         WorkflowLaunchResponse launch = workflowLaunchResponse(workflow.getId(), wspId);
 

--- a/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
@@ -119,6 +119,12 @@ public class RelaunchCmd extends AbstractRunsCmd {
                 .resume(!noResume)
                 .pullLatest(coalesce(opts.pullLatest, launch.getPullLatest()))
                 .stubRun(coalesce(opts.stubRun, launch.getStubRun()))
+                // Platform reads these from the incoming request only, without falling back to the
+                // source launch, so they have to be carried over explicitly or they are lost.
+                .headJobCpus(launch.getHeadJobCpus())
+                .headJobMemoryMb(launch.getHeadJobMemoryMb())
+                .optimizationId(launch.getOptimizationId())
+                .optimizationTargets(launch.getOptimizationTargets())
                 .dateCreated(OffsetDateTime.now())
                 .runName(name)
                 .launchContainer(launchContainer)

--- a/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
@@ -97,6 +97,9 @@ public class RelaunchCmd extends AbstractRunsCmd {
                 .pipeline(coalesce(pipeline, launch.getPipeline()))
                 .workDir(opts.workDir != null ? opts.workDir : selectWorkDir(!noResume, launch.getResumeDir(), launch.getWorkDir(), workflow.getWorkDir()))
                 .revision(coalesce(opts.revision, (noResume ? launch.getRevision() : launch.getResumeCommitId())))
+                // Platform never inherits the commit ID from the source launch: an unset value means
+                // "unpinned", so only an explicit --commit-id pins the relaunch to a given commit.
+                .commitId(opts.commitId)
                 .configProfiles(coalesce(opts.profile, launch.getConfigProfiles()))
                 .configText(opts.config != null ? FilesHelper.readString(opts.config) : launch.getConfigText())
                 .paramsText(opts.paramsFile != null ? FilesHelper.readString(opts.paramsFile) : launch.getParamsText())

--- a/src/test/java/io/seqera/tower/cli/runs/RunsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/runs/RunsCmdTest.java
@@ -76,6 +76,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockserver.matchers.Times.exactly;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.model.JsonBody.json;
 
 class RunsCmdTest extends BaseCmdTest {
 
@@ -500,7 +501,25 @@ class RunsCmdTest extends BaseCmdTest {
     @EnumSource(OutputType.class)
     void testRelaunch(OutputType format, MockServerClient mock) {
         mock.when(
-                request().withMethod("POST").withPath("/workflow/launch"), exactly(1)
+                request().withMethod("POST").withPath("/workflow/launch")
+                        .withBody(json("""
+                            {
+                                "launch":{
+                                    "id":"5SCyEXKrCqFoGzOXGpesr5",
+                                    "sessionId":"ecaad2dd-83bb-4e0d-9418-d84f177e1e74",
+                                    "computeEnvId":"2lu3NFms1qRvwTVnrs1yhg",
+                                    "pipeline":"https://github.com/nf-core/rnaseq",
+                                    "workDir":"s3://fusionfs/scratch/5qRNYT6iAJfRbJ",
+                                    "revision":"89bf536ce4faa98b4d50a8ec0a0343780bc62e0a",
+                                    "resume":true,
+                                    "headJobCpus":8,
+                                    "headJobMemoryMb":16384,
+                                    "optimizationId":"rOYdwTnmTaRCJjUq",
+                                    "optimizationTargets":"cpus, memory"
+                                }
+                            }"""
+                        )),
+                exactly(1)
         ).respond(
                 response().withStatusCode(200).withBody(loadResource("workflow_launch")).withContentType(MediaType.APPLICATION_JSON)
         );
@@ -526,6 +545,85 @@ class RunsCmdTest extends BaseCmdTest {
 
         ExecOut out = exec(format, mock, "runs", "relaunch", "-i", "5mDfiUtqyptDib");
         assertOutput(format, out, new RunSubmited("35aLiS0bIM5efd", null, String.format("%s/user/jordi/watch/35aLiS0bIM5efd", url(mock)), "user"));
+    }
+
+    @Test
+    void testRelaunchWithCommitId(MockServerClient mock) {
+        mock.when(
+                request().withMethod("POST").withPath("/workflow/launch")
+                        .withBody(json("""
+                            {
+                                "launch":{
+                                    "resume":true,
+                                    "commitId":"1c0e11e42bdba1f5aef4dc0d9a4a4bb1e8be9d75"
+                                }
+                            }"""
+                        )),
+                exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workflow_launch")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/workflow/5mDfiUtqyptDib"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workflow_view")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/workflow/5mDfiUtqyptDib/launch"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("runs/workflow_launch")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/user-info"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(mock, "runs", "relaunch", "-i", "5mDfiUtqyptDib", "--commit-id", "1c0e11e42bdba1f5aef4dc0d9a4a4bb1e8be9d75");
+
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+    }
+
+    @Test
+    void testRelaunchWithoutResumableCommitId(MockServerClient mock) {
+        mock.when(
+                request().withMethod("GET").withPath("/workflow/5mDfiUtqyptDib"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workflow_view")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        // A run that never reported a commit ID has no revision to resume from
+        mock.when(
+                request().withMethod("GET").withPath("/workflow/5mDfiUtqyptDib/launch"), exactly(1)
+        ).respond(
+                response().withStatusCode(200)
+                        .withBody("{\"launch\":{\"id\":\"5SCyEXKrCqFoGzOXGpesr5\",\"pipeline\":\"https://github.com/nf-core/rnaseq\",\"workDir\":\"s3://fusionfs\",\"resumeDir\":\"s3://fusionfs/scratch/5qRNYT6iAJfRbJ\",\"resumeCommitId\":null}}")
+                        .withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(mock, "runs", "relaunch", "-i", "5mDfiUtqyptDib");
+
+        assertEquals(errorMessage(out.app, new TowerException("Pipeline run '5mDfiUtqyptDib' cannot be resumed because it did not report a commit ID. Use '--no-resume' to relaunch it from scratch.")), out.stdErr);
+        assertEquals("", out.stdOut);
+        assertEquals(1, out.exitCode);
+    }
+
+    @Test
+    void testRelaunchRejectsUnwritableFieldsWhenResuming(MockServerClient mock) {
+        // Platform makes both fields read-only on a resumed launch, so fail before submitting
+        ExecOut pipelineOut = exec(mock, "runs", "relaunch", "-i", "5mDfiUtqyptDib", "--pipeline", "https://github.com/nf-core/rnaseq");
+
+        assertEquals(errorMessage(pipelineOut.app, new TowerException("Not allowed to change '--pipeline' option when resuming. Use '--no-resume' if you want to relaunch a different pipeline without resuming.")), pipelineOut.stdErr);
+        assertEquals(1, pipelineOut.exitCode);
+
+        ExecOut workDirOut = exec(mock, "runs", "relaunch", "-i", "5mDfiUtqyptDib", "--work-dir", "s3://other-bucket");
+
+        assertEquals(errorMessage(workDirOut.app, new TowerException("Not allowed to change '--work-dir' option when resuming. Use '--no-resume' if you want to relaunch into a different working directory without resuming.")), workDirOut.stdErr);
+        assertEquals(1, workDirOut.exitCode);
     }
 
     @Test

--- a/src/test/resources/runcmd/runs/workflow_launch.json
+++ b/src/test/resources/runcmd/runs/workflow_launch.json
@@ -111,6 +111,10 @@
     "stubRun": false,
     "resumeDir": "s3://fusionfs/scratch/5qRNYT6iAJfRbJ",
     "resumeCommitId": "89bf536ce4faa98b4d50a8ec0a0343780bc62e0a",
+    "headJobCpus": 8,
+    "headJobMemoryMb": 16384,
+    "optimizationId": "rOYdwTnmTaRCJjUq",
+    "optimizationTargets": "cpus, memory",
     "dateCreated": "2022-08-01T15:58:08Z"
   }
 }


### PR DESCRIPTION
## TL;DR

Resume already works from the CLI — `tw runs relaunch -i <runId>` resumes **by default** and has since v0.6 (#245). Issue #138 (`tw launch` flag for `-resume`) was closed with exactly that answer.

This PR does not add resume. It fixes five ways the existing command lies to you or quietly drops your configuration.

## How resume actually works today

Traced end to end against `master` here and platform `ff60aea7ca`:

1. `RelaunchCmd:141` → `GET /workflow/{id}/launch`
2. platform `WorkflowLaunchServiceImpl:456-462` returns `resumeDir` = `workflow.workDir`, `resumeCommitId` = `workflow.commitId`, `sessionId` = `workflow.sessionId`
3. CLI posts `/workflow/launch` with `id` = `workflow.launchId`, `resume=true`, `sessionId`, `workDir=resumeDir`, `revision=resumeCommitId`
4. `WorkflowLaunchRequest.isResumedLaunch():284` = `id && resume && launchedEntity instanceof Workflow`. Every run owns its own `Launch` record (`createLaunchForWorkflow`), so `workflow.launchId` resolves to the Workflow rather than the source Pipeline — that is what makes the request classify as a resume
5. `createResumedLaunch:686` → `checkOverwrittenFields:803` requires `pipeline`, `workDir` and `sessionId` (plus `computeEnvId`, unless the CE change is compatible) to match the source launch
6. `newLaunchRequest:297` — `sessionId = launch.resume ? launch.sessionId : random`
7. `AbstractComputePlatformProvider:434-435` sets `NXF_WORK` and `NXF_UUID`, then `:397` appends `-resume <sessionId>`
8. `nf-launcher.txt:23,54-55` restores `.nextflow/cache/$NXF_UUID`, rsync'd from `$TOWER_RESUME_DIR` when set — only HPC/agent CEs set it (`AgentConnector:239-249`), from `resumeLaunchId`, which platform derives itself (`LaunchServiceImpl:383`)

So the mechanism is sound and needs nothing from us. What it needs is for the CLI to stop misreporting and stop dropping fields.

## Problems fixed

### 1. `--commit-id` was accepted and ignored

`runs relaunch` mixes in `LaunchOptions`, which defines `--commit-id`, but the command never read `opts.commitId`. The flag parsed, validated, and did nothing. Platform reads `commitId` from the incoming request only (`constructLaunchRequest:776`, `// If null has been unpinned during launch`), so forwarding the value is the whole fix.

Not specifying it still sends `null`, i.e. unpinned — the same thing the web UI submits. Auto-inheriting the source launch's `commitId` would have silently overridden `--revision`, since platform's `getCommitIdOrRevision()` prefers the commit.

### 2. `--pipeline` + resume always failed server-side

Platform marks `pipeline` read-only for resumed launches (`alwaysReadOnlyFields = ['pipeline', 'workDir', 'sessionId']`, `:710`). Since the command resumes by default, `--pipeline` could only ever produce `Field 'pipeline' is not writable: unset or use previous value` from the API. Now it fails immediately with a message that names the option and points at `--no-resume`, mirroring the `--work-dir` guard that was already there.

### 3. Resume was silently downgraded to a full rerun ⚠️ behaviour change

```java
// before
if (launch.getResumeCommitId() == null) {
    noResume = true;
}
```

A run that never reported a commit ID cannot be resumed. The command flipped itself to `--no-resume`, submitted `resume=false` against a different work dir, printed the normal success output, and said nothing. You paid for a full rerun believing the cache had been reused.

Now it raises a `TowerException` naming the run and the escape hatch. **This turns a previously-succeeding invocation into a non-zero exit** — a bare `tw runs relaunch -i <id>` on such a run now fails instead of quietly re-running everything. Chosen over a stderr warning because failing fast beats a fallback that hides the issue, but happy to switch it to a warning if that is too disruptive for existing scripts.

### 4. Head job resources and optimization were dropped on every relaunch

`constructLaunchRequest:764-772` assigns `outputDir`, `headJobCpus`, `headJobMemoryMb`, `optimizationId` and `optimizationTargets` straight from the incoming request, with no fallback to the source launch — unlike the ~20 fields above them, which do fall back. Anything the CLI omitted was therefore lost: a run with a tuned head job or an applied optimization came back on compute environment defaults.

`tw launch` already forwards all of these (`LaunchCmd:157-161`). Relaunch now does too. All four are already exposed by `WorkflowLaunchResponse` in the pinned SDK, so no version bump is involved.

### 5. `outputDir` — NOT fixed here, needs an SDK bump

Same root cause as #4, but `tower-java-sdk` 1.114.0 has no `outputDir` on `WorkflowLaunchRequest` *or* `WorkflowLaunchResponse` (checked with `javap` against the built shadow jar), so the CLI cannot send or read it at all. Runs using `-output-dir` / workflow outputs syntax lose their output directory on relaunch.

Fixing it means bumping the SDK and `VERSION-API`, which must not exceed the API version deployed in cloud production. Deliberately left for a separate PR — flagging it here so it is not lost.

### 6. The relaunch test asserted nothing about the request

`testRelaunch` mocked `POST /workflow/launch` and never inspected the body, so every regression above passed CI silently. It now asserts the resume payload the command must produce, and three new tests cover the fixed behaviours: `--commit-id` forwarded, an unresumable run failing, and `--pipeline`/`--work-dir` rejected while resuming. The relaunch fixture gains the four carry-over fields so #4 is actually exercised.

## Also noted, not changed

`relaunch` has no `--wait` and no `-l/--labels`, both of which exist on `tw launch`. Labels are inherited server-side from the source workflow (`setLabelIdsInLaunchRequest`), so only `--wait` is a genuine gap.

## Verification status

⚠️ **Not compiled or tested locally.** `./gradlew compileJava` fails with `401 Unauthorized` against `maven.pkg.github.com/seqeralabs/tower-java-sdk`; the token available in my environment has `gist, read:org, repo` but not `read:packages`. Every SDK method used here was verified to exist by disassembling the pinned `tower-java-sdk-1.114.0` classes out of `build/libs/tw.jar`:

```
WorkflowLaunchRequest.commitId(String), .headJobCpus(Integer), .headJobMemoryMb(Integer),
  .optimizationId(String), .optimizationTargets(String)
WorkflowLaunchResponse.getHeadJobCpus(), .getHeadJobMemoryMb(),
  .getOptimizationId(), .getOptimizationTargets(), .getResumeCommitId()
```

CI runs `./gradlew cleanTest test` (`build.yml:40`) with package access, so the checks on this PR are the real verification. Locally:

```bash
gh auth refresh -s read:packages
GITHUB_USERNAME=<user> GITHUB_TOKEN=$(gh auth token) ./gradlew test --tests '*RunsCmdTest*'
```

Draft until CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
