### PR TITLE
fix(launch): align CLI launch requests with the API model [COMP-2318]

### DIFF
--- a/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
@@ -20,6 +20,7 @@ import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.enums.OutputType;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
 import io.seqera.tower.cli.commands.labels.Label;
+import io.seqera.tower.cli.commands.pipelines.LaunchOptions;
 import io.seqera.tower.cli.commands.pipelines.versions.VersionRefOptions;
 import io.seqera.tower.cli.exceptions.InvalidResponseException;
 import io.seqera.tower.cli.responses.Response;
@@ -100,6 +101,12 @@ public class LaunchCmd extends AbstractRootCmd {
     @Option(names = {"--syntax-parser"}, description = "Nextflow language syntax parser version: 'v1' (legacy) or 'v2'. Overrides the value stored in the pipeline.")
     SyntaxParserEnum syntaxParser;
 
+    @Option(names = {"--nextflow-version"}, description = "Nextflow version to run the workflow with. Must exist in the Platform version catalog and meet the minimum required by the compute environment. Overrides the value stored in the pipeline.")
+    String nextflowVersion;
+
+    @Option(names = {"--output-dir"}, description = "Per-run output directory, passed to Nextflow as '-output-dir'. Requires Nextflow 24.10.0 or later and the workflow outputs syntax. Overrides the value stored in the pipeline.")
+    String outputDir;
+
     @ArgGroup(heading = "%nAdvanced options:%n", validate = false)
     AdvancedOptions adv;
 
@@ -144,11 +151,7 @@ public class LaunchCmd extends AbstractRootCmd {
     private WorkflowLaunchRequest updateLaunchRequest(WorkflowLaunchRequest base) throws IOException {
         boolean disableOptimization = coalesce(adv().disableOptimization, false);
 
-        // Only set when requested: the setter cannot express 'undefined', so an unconditional call
-        // would replace the pipeline's stored value with an explicit null, which Platform reads as v1.
-        if (syntaxParser != null) {
-            base.syntaxParser(syntaxParser);
-        }
+        applyNullableOptions(base);
 
         return base
                 .runName(name)
@@ -176,6 +179,23 @@ public class LaunchCmd extends AbstractRootCmd {
                 .sessionId(null)
                 .resume(null)
                 .dateCreated(null);
+    }
+
+    /**
+     * Same reasoning as {@link LaunchOptions#applyNullableOptions}: these setters wrap their argument in
+     * {@code JsonNullable.of()}, so applying them unconditionally would overwrite the pipeline's stored
+     * value with an explicit null. This command declares its own options rather than the shared mixin.
+     */
+    private void applyNullableOptions(WorkflowLaunchRequest base) {
+        if (syntaxParser != null) {
+            base.syntaxParser(syntaxParser);
+        }
+        if (nextflowVersion != null) {
+            base.nextflowVersion(nextflowVersion);
+        }
+        if (outputDir != null) {
+            base.outputDir(outputDir);
+        }
     }
 
     protected Response runTowerPipeline(Long wspId) throws ApiException, IOException {

--- a/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
@@ -31,6 +31,7 @@ import io.seqera.tower.model.PipelineDbDto;
 import io.seqera.tower.model.SubmitWorkflowLaunchRequest;
 import io.seqera.tower.model.SubmitWorkflowLaunchResponse;
 import io.seqera.tower.model.WorkflowLaunchRequest;
+import io.seqera.tower.model.WorkflowLaunchRequest.SyntaxParserEnum;
 import io.seqera.tower.model.WorkflowStatus;
 import jakarta.annotation.Nullable;
 import picocli.CommandLine;
@@ -96,6 +97,9 @@ public class LaunchCmd extends AbstractRootCmd {
     @Option(names = {"--launch-container"}, description = "Container image to use for the Nextflow launcher.")
     String launchContainer;
 
+    @Option(names = {"--syntax-parser"}, description = "Nextflow language syntax parser version: 'v1' (legacy) or 'v2'. Overrides the value stored in the pipeline.")
+    SyntaxParserEnum syntaxParser;
+
     @ArgGroup(heading = "%nAdvanced options:%n", validate = false)
     AdvancedOptions adv;
 
@@ -139,6 +143,12 @@ public class LaunchCmd extends AbstractRootCmd {
      */
     private WorkflowLaunchRequest updateLaunchRequest(WorkflowLaunchRequest base) throws IOException {
         boolean disableOptimization = coalesce(adv().disableOptimization, false);
+
+        // Only set when requested: the setter cannot express 'undefined', so an unconditional call
+        // would replace the pipeline's stored value with an explicit null, which Platform reads as v1.
+        if (syntaxParser != null) {
+            base.syntaxParser(syntaxParser);
+        }
 
         return base
                 .runName(name)

--- a/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
@@ -20,7 +20,7 @@ import io.seqera.tower.ApiException;
 import io.seqera.tower.cli.commands.enums.OutputType;
 import io.seqera.tower.cli.commands.global.WorkspaceOptionalOptions;
 import io.seqera.tower.cli.commands.labels.Label;
-import io.seqera.tower.cli.commands.pipelines.LaunchOptions;
+import io.seqera.tower.cli.commands.pipelines.NullableLaunchOptions;
 import io.seqera.tower.cli.commands.pipelines.versions.VersionRefOptions;
 import io.seqera.tower.cli.exceptions.InvalidResponseException;
 import io.seqera.tower.cli.responses.Response;
@@ -32,12 +32,12 @@ import io.seqera.tower.model.PipelineDbDto;
 import io.seqera.tower.model.SubmitWorkflowLaunchRequest;
 import io.seqera.tower.model.SubmitWorkflowLaunchResponse;
 import io.seqera.tower.model.WorkflowLaunchRequest;
-import io.seqera.tower.model.WorkflowLaunchRequest.SyntaxParserEnum;
 import io.seqera.tower.model.WorkflowStatus;
 import jakarta.annotation.Nullable;
 import picocli.CommandLine;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
@@ -98,14 +98,8 @@ public class LaunchCmd extends AbstractRootCmd {
     @Option(names = {"--launch-container"}, description = "Container image to use for the Nextflow launcher.")
     String launchContainer;
 
-    @Option(names = {"--syntax-parser"}, description = "Nextflow language syntax parser version: 'v1' (legacy) or 'v2'. Overrides the value stored in the pipeline.")
-    SyntaxParserEnum syntaxParser;
-
-    @Option(names = {"--nextflow-version"}, description = "Nextflow version to run the workflow with. Must exist in the Platform version catalog and meet the minimum required by the compute environment. Overrides the value stored in the pipeline.")
-    String nextflowVersion;
-
-    @Option(names = {"--output-dir"}, description = "Per-run output directory, passed to Nextflow as '-output-dir'. Requires Nextflow 24.10.0 or later and the workflow outputs syntax. Overrides the value stored in the pipeline.")
-    String outputDir;
+    @Mixin
+    NullableLaunchOptions nullableOptions;
 
     @ArgGroup(heading = "%nAdvanced options:%n", validate = false)
     AdvancedOptions adv;
@@ -151,7 +145,7 @@ public class LaunchCmd extends AbstractRootCmd {
     private WorkflowLaunchRequest updateLaunchRequest(WorkflowLaunchRequest base) throws IOException {
         boolean disableOptimization = coalesce(adv().disableOptimization, false);
 
-        applyNullableOptions(base);
+        nullableOptions.applyNullableOptions(base);
 
         return base
                 .runName(name)
@@ -179,23 +173,6 @@ public class LaunchCmd extends AbstractRootCmd {
                 .sessionId(null)
                 .resume(null)
                 .dateCreated(null);
-    }
-
-    /**
-     * Same reasoning as {@link LaunchOptions#applyNullableOptions}: these setters wrap their argument in
-     * {@code JsonNullable.of()}, so applying them unconditionally would overwrite the pipeline's stored
-     * value with an explicit null. This command declares its own options rather than the shared mixin.
-     */
-    private void applyNullableOptions(WorkflowLaunchRequest base) {
-        if (syntaxParser != null) {
-            base.syntaxParser(syntaxParser);
-        }
-        if (nextflowVersion != null) {
-            base.nextflowVersion(nextflowVersion);
-        }
-        if (outputDir != null) {
-            base.outputDir(outputDir);
-        }
     }
 
     protected Response runTowerPipeline(Long wspId) throws ApiException, IOException {

--- a/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/LaunchCmd.java
@@ -132,12 +132,16 @@ public class LaunchCmd extends AbstractRootCmd {
         ), wspId, null);
     }
 
+    /**
+     * Applies the command line overrides on top of a launch configuration, mutating it in place so that every
+     * field the CLI does not know about still reaches the API. Rebuilding the request here used to drop the
+     * fields this method did not name, among them syntaxParser (COMP-2318).
+     */
     private WorkflowLaunchRequest updateLaunchRequest(WorkflowLaunchRequest base) throws IOException {
-        return new WorkflowLaunchRequest()
-                .id(base.getId())
-                .computeEnvId(base.getComputeEnvId())
-                .runName(coalesce(name, base.getRunName()))
-                .pipeline(base.getPipeline())
+        boolean disableOptimization = coalesce(adv().disableOptimization, false);
+
+        return base
+                .runName(name)
                 .workDir(coalesce(workDir, base.getWorkDir()))
                 .revision(coalesce(revision, base.getRevision()))
                 .commitId(coalesce(commitId, base.getCommitId()))
@@ -145,7 +149,6 @@ public class LaunchCmd extends AbstractRootCmd {
                 .userSecrets(coalesce(removeEmptyValues(adv().userSecrets), base.getUserSecrets()))
                 .workspaceSecrets(coalesce(removeEmptyValues(adv().workspaceSecrets), base.getWorkspaceSecrets()))
                 .configText(coalesce(readStringOrStdin(adv().config), base.getConfigText()))
-                .towerConfig(base.getTowerConfig())
                 .paramsText(coalesce(readStringOrStdin(paramsFile), base.getParamsText()))
                 .preRunScript(coalesce(readStringOrStdin(adv().preRunScript), base.getPreRunScript()))
                 .postRunScript(coalesce(readStringOrStdin(adv().postRunScript), base.getPostRunScript()))
@@ -154,12 +157,15 @@ public class LaunchCmd extends AbstractRootCmd {
                 .schemaName(coalesce(adv().schemaName, base.getSchemaName()))
                 .pullLatest(coalesce(adv().pullLatest, base.getPullLatest()))
                 .stubRun(coalesce(adv().stubRun, base.getStubRun()))
-                .optimizationId(coalesce(adv().disableOptimization, false) ? null : base.getOptimizationId())
-                .optimizationTargets(coalesce(adv().disableOptimization, false) ? null : base.getOptimizationTargets())
-                .labelIds(base.getLabelIds())
+                .optimizationId(disableOptimization ? null : base.getOptimizationId())
+                .optimizationTargets(disableOptimization ? null : base.getOptimizationTargets())
                 .headJobCpus(coalesce(adv().headJobCpus, base.getHeadJobCpus()))
                 .headJobMemoryMb(coalesce(adv().headJobMemoryMb, base.getHeadJobMemoryMb()))
-                .launchContainer(launchContainer);
+                .launchContainer(coalesce(launchContainer, base.getLaunchContainer()))
+                // A stored launch record describes an earlier run: a new run starts a fresh session, never resumes.
+                .sessionId(null)
+                .resume(null)
+                .dateCreated(null);
     }
 
     protected Response runTowerPipeline(Long wspId) throws ApiException, IOException {

--- a/src/main/java/io/seqera/tower/cli/commands/actions/UpdateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/actions/UpdateCmd.java
@@ -24,6 +24,7 @@ import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.actions.ActionUpdate;
 import io.seqera.tower.cli.utils.FilesHelper;
+import io.seqera.tower.cli.utils.ModelHelper;
 import io.seqera.tower.model.ActionResponseDto;
 import io.seqera.tower.model.UpdateActionRequest;
 import io.seqera.tower.model.WorkflowLaunchRequest;
@@ -31,6 +32,7 @@ import picocli.CommandLine;
 
 import java.io.IOException;
 import java.util.Objects;
+import static io.seqera.tower.cli.utils.ModelHelper.coalesce;
 
 @CommandLine.Command(
         name = "update",
@@ -77,23 +79,31 @@ public class UpdateCmd extends AbstractActionsCmd {
         String postRunScriptValue = opts.postRunScript != null ? FilesHelper.readString(opts.postRunScript) : action.getLaunch().getPostRunScript();
 
 
-        WorkflowLaunchRequest workflowLaunchRequest = new WorkflowLaunchRequest();
-        workflowLaunchRequest.computeEnvId(ceId)
+        // Start from the stored configuration so fields without a flag survive the update untouched
+        // instead of being reset to null, among them syntaxParser (COMP-2318).
+        WorkflowLaunchRequest workflowLaunchRequest = ModelHelper.createLaunchRequest(action.getLaunch())
+                .computeEnvId(ceId)
                 .id(action.getLaunch().getId())
                 .pipeline(action.getLaunch().getPipeline())
-                .revision(opts.revision)
+                .revision(coalesce(opts.revision, action.getLaunch().getRevision()))
                 .workDir(workDirValue)
-                .configProfiles(opts.profile)
-                .paramsText(FilesHelper.readString(opts.paramsFile))
+                .configProfiles(coalesce(opts.profile, action.getLaunch().getConfigProfiles()))
+                .paramsText(coalesce(FilesHelper.readString(opts.paramsFile), action.getLaunch().getParamsText()))
 
                 // Advanced options
-                .configText(FilesHelper.readString(opts.config))
+                .configText(coalesce(FilesHelper.readString(opts.config), action.getLaunch().getConfigText()))
                 .preRunScript(preRunScriptValue)
                 .postRunScript(postRunScriptValue)
-                .pullLatest(opts.pullLatest)
-                .stubRun(opts.stubRun)
-                .mainScript(opts.mainScript)
-                .entryName(opts.entryName);
+                .pullLatest(coalesce(opts.pullLatest, action.getLaunch().getPullLatest()))
+                .stubRun(coalesce(opts.stubRun, action.getLaunch().getStubRun()))
+                .mainScript(coalesce(opts.mainScript, action.getLaunch().getMainScript()))
+                .entryName(coalesce(opts.entryName, action.getLaunch().getEntryName()));
+
+        // Only set when requested: the setter cannot express 'undefined', so an unconditional call
+        // would replace an unset value with an explicit null, which Platform reads as the legacy parser.
+        if (opts.syntaxParser != null) {
+            workflowLaunchRequest.syntaxParser(opts.syntaxParser);
+        }
 
         UpdateActionRequest request = new UpdateActionRequest();
         request.setName(newName != null ? newName : actionName);

--- a/src/main/java/io/seqera/tower/cli/commands/actions/UpdateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/actions/UpdateCmd.java
@@ -99,11 +99,7 @@ public class UpdateCmd extends AbstractActionsCmd {
                 .mainScript(coalesce(opts.mainScript, action.getLaunch().getMainScript()))
                 .entryName(coalesce(opts.entryName, action.getLaunch().getEntryName()));
 
-        // Only set when requested: the setter cannot express 'undefined', so an unconditional call
-        // would replace an unset value with an explicit null, which Platform reads as the legacy parser.
-        if (opts.syntaxParser != null) {
-            workflowLaunchRequest.syntaxParser(opts.syntaxParser);
-        }
+        opts.applyNullableOptions(workflowLaunchRequest);
 
         UpdateActionRequest request = new UpdateActionRequest();
         request.setName(newName != null ? newName : actionName);

--- a/src/main/java/io/seqera/tower/cli/commands/actions/add/AbstractAddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/actions/add/AbstractAddCmd.java
@@ -88,11 +88,7 @@ public abstract class AbstractAddCmd extends AbstractActionsCmd {
                 .mainScript(opts.mainScript)
                 .entryName(opts.entryName);
 
-        // Only set when requested: the setter cannot express 'undefined', and sending an explicit
-        // null makes Platform fall back to the legacy parser (COMP-2318).
-        if (opts.syntaxParser != null) {
-            workflowLaunchRequest.syntaxParser(opts.syntaxParser);
-        }
+        opts.applyNullableOptions(workflowLaunchRequest);
 
         CreateActionRequest request = new CreateActionRequest();
         request.setName(actionName);

--- a/src/main/java/io/seqera/tower/cli/commands/actions/add/AbstractAddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/actions/add/AbstractAddCmd.java
@@ -88,6 +88,12 @@ public abstract class AbstractAddCmd extends AbstractActionsCmd {
                 .mainScript(opts.mainScript)
                 .entryName(opts.entryName);
 
+        // Only set when requested: the setter cannot express 'undefined', and sending an explicit
+        // null makes Platform fall back to the legacy parser (COMP-2318).
+        if (opts.syntaxParser != null) {
+            workflowLaunchRequest.syntaxParser(opts.syntaxParser);
+        }
+
         CreateActionRequest request = new CreateActionRequest();
         request.setName(actionName);
         request.setSource(getSource());

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/AddCmd.java
@@ -119,11 +119,7 @@ public class AddCmd extends AbstractPipelinesCmd {
                 .userSecrets(removeEmptyValues(opts.userSecrets))
                 .workspaceSecrets(removeEmptyValues(opts.workspaceSecrets));
 
-        // Only set when requested: the setter cannot express 'undefined', and sending an explicit
-        // null makes Platform fall back to the legacy parser (COMP-2318).
-        if (opts.syntaxParser != null) {
-            launch.syntaxParser(opts.syntaxParser);
-        }
+        opts.applyNullableOptions(launch);
 
         CreatePipelineResponse response;
         try {

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/AddCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/AddCmd.java
@@ -97,6 +97,34 @@ public class AddCmd extends AbstractPipelinesCmd {
         String preRunScriptValue = opts.preRunScript == null && ce != null ? ce.getConfig().getPreRunScript() : FilesHelper.readString(opts.preRunScript);
         String postRunScriptValue = opts.postRunScript == null && ce != null ? ce.getConfig().getPostRunScript() : FilesHelper.readString(opts.postRunScript);
 
+        WorkflowLaunchRequest launch = new WorkflowLaunchRequest()
+                .computeEnvId(ce != null ? ce.getId() : null)
+                .pipeline(pipeline)
+                .revision(opts.revision)
+                .commitId(opts.commitId)
+                .workDir(workDirValue)
+                .configProfiles(opts.profile)
+                .paramsText(FilesHelper.readString(opts.paramsFile))
+
+                // Advanced options
+                .configText(FilesHelper.readString(opts.config))
+                .preRunScript(preRunScriptValue)
+                .postRunScript(postRunScriptValue)
+                .pullLatest(opts.pullLatest)
+                .stubRun(opts.stubRun)
+                .mainScript(opts.mainScript)
+                .entryName(opts.entryName)
+                .schemaName(opts.schemaName)
+                .pipelineSchemaId(pipelineSchemaId)
+                .userSecrets(removeEmptyValues(opts.userSecrets))
+                .workspaceSecrets(removeEmptyValues(opts.workspaceSecrets));
+
+        // Only set when requested: the setter cannot express 'undefined', and sending an explicit
+        // null makes Platform fall back to the legacy parser (COMP-2318).
+        if (opts.syntaxParser != null) {
+            launch.syntaxParser(opts.syntaxParser);
+        }
+
         CreatePipelineResponse response;
         try {
             response = pipelinesApi().createPipeline(
@@ -104,28 +132,7 @@ public class AddCmd extends AbstractPipelinesCmd {
                             .name(name)
                             .description(description)
                             .version(versionName != null ? new CreatePipelineVersionRequest().name(versionName) : null)
-                            .launch(new WorkflowLaunchRequest()
-                                    .computeEnvId(ce != null ? ce.getId() : null)
-                                    .pipeline(pipeline)
-                                    .revision(opts.revision)
-                                    .commitId(opts.commitId)
-                                    .workDir(workDirValue)
-                                    .configProfiles(opts.profile)
-                                    .paramsText(FilesHelper.readString(opts.paramsFile))
-
-                                    // Advanced options
-                                    .configText(FilesHelper.readString(opts.config))
-                                    .preRunScript(preRunScriptValue)
-                                    .postRunScript(postRunScriptValue)
-                                    .pullLatest(opts.pullLatest)
-                                    .stubRun(opts.stubRun)
-                                    .mainScript(opts.mainScript)
-                                    .entryName(opts.entryName)
-                                    .schemaName(opts.schemaName)
-                                    .pipelineSchemaId(pipelineSchemaId)
-                                    .userSecrets(removeEmptyValues(opts.userSecrets))
-                                    .workspaceSecrets(removeEmptyValues(opts.workspaceSecrets))
-                            )
+                            .launch(launch)
                     , wspId
             );
         } catch (ApiException e) {

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/LaunchOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/LaunchOptions.java
@@ -16,6 +16,7 @@
 
 package io.seqera.tower.cli.commands.pipelines;
 
+import io.seqera.tower.model.WorkflowLaunchRequest.SyntaxParserEnum;
 import picocli.CommandLine.Option;
 
 import java.nio.file.Path;
@@ -70,4 +71,7 @@ public class LaunchOptions {
 
     @Option(names = {"--workspace-secrets"}, split = ",", description = "Array of workspace secrets to make available to the pipeline.")
     public List<String> workspaceSecrets;
+
+    @Option(names = {"--syntax-parser"}, description = "Nextflow language syntax parser version: 'v1' (legacy) or 'v2'.")
+    public SyntaxParserEnum syntaxParser;
 }

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/LaunchOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/LaunchOptions.java
@@ -16,14 +16,12 @@
 
 package io.seqera.tower.cli.commands.pipelines;
 
-import io.seqera.tower.model.WorkflowLaunchRequest;
-import io.seqera.tower.model.WorkflowLaunchRequest.SyntaxParserEnum;
 import picocli.CommandLine.Option;
 
 import java.nio.file.Path;
 import java.util.List;
 
-public class LaunchOptions {
+public class LaunchOptions extends NullableLaunchOptions {
 
     @Option(names = {"-c", "--compute-env"}, description = "Compute environment identifier where the pipeline will run. Defaults to workspace primary compute environment if omitted. Provide the name or identifier.")
     public String computeEnv;
@@ -72,31 +70,4 @@ public class LaunchOptions {
 
     @Option(names = {"--workspace-secrets"}, split = ",", description = "Array of workspace secrets to make available to the pipeline.")
     public List<String> workspaceSecrets;
-
-    @Option(names = {"--syntax-parser"}, description = "Nextflow language syntax parser version: 'v1' (legacy) or 'v2'.")
-    public SyntaxParserEnum syntaxParser;
-
-    @Option(names = {"--nextflow-version"}, description = "Nextflow version to run the workflow with. Must exist in the Platform version catalog and meet the minimum required by the compute environment.")
-    public String nextflowVersion;
-
-    @Option(names = {"--output-dir"}, description = "Per-run output directory, passed to Nextflow as '-output-dir'. Requires Nextflow 24.10.0 or later and the workflow outputs syntax.")
-    public String outputDir;
-
-    /**
-     * Applies the options whose model fields are {@code JsonNullable}, which is why they cannot join the
-     * coalesce chains: their setters wrap the argument in {@code JsonNullable.of()}, so calling one with a
-     * null would send an explicit null instead of leaving the field undefined. For syntaxParser that is not
-     * neutral - Platform reads an explicit null as the legacy parser (COMP-2318).
-     */
-    public void applyNullableOptions(WorkflowLaunchRequest request) {
-        if (syntaxParser != null) {
-            request.syntaxParser(syntaxParser);
-        }
-        if (nextflowVersion != null) {
-            request.nextflowVersion(nextflowVersion);
-        }
-        if (outputDir != null) {
-            request.outputDir(outputDir);
-        }
-    }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/LaunchOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/LaunchOptions.java
@@ -16,6 +16,7 @@
 
 package io.seqera.tower.cli.commands.pipelines;
 
+import io.seqera.tower.model.WorkflowLaunchRequest;
 import io.seqera.tower.model.WorkflowLaunchRequest.SyntaxParserEnum;
 import picocli.CommandLine.Option;
 
@@ -74,4 +75,28 @@ public class LaunchOptions {
 
     @Option(names = {"--syntax-parser"}, description = "Nextflow language syntax parser version: 'v1' (legacy) or 'v2'.")
     public SyntaxParserEnum syntaxParser;
+
+    @Option(names = {"--nextflow-version"}, description = "Nextflow version to run the workflow with. Must exist in the Platform version catalog and meet the minimum required by the compute environment.")
+    public String nextflowVersion;
+
+    @Option(names = {"--output-dir"}, description = "Per-run output directory, passed to Nextflow as '-output-dir'. Requires Nextflow 24.10.0 or later and the workflow outputs syntax.")
+    public String outputDir;
+
+    /**
+     * Applies the options whose model fields are {@code JsonNullable}, which is why they cannot join the
+     * coalesce chains: their setters wrap the argument in {@code JsonNullable.of()}, so calling one with a
+     * null would send an explicit null instead of leaving the field undefined. For syntaxParser that is not
+     * neutral - Platform reads an explicit null as the legacy parser (COMP-2318).
+     */
+    public void applyNullableOptions(WorkflowLaunchRequest request) {
+        if (syntaxParser != null) {
+            request.syntaxParser(syntaxParser);
+        }
+        if (nextflowVersion != null) {
+            request.nextflowVersion(nextflowVersion);
+        }
+        if (outputDir != null) {
+            request.outputDir(outputDir);
+        }
+    }
 }

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/NullableLaunchOptions.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/NullableLaunchOptions.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.commands.pipelines;
+
+import io.seqera.tower.model.WorkflowLaunchRequest;
+import io.seqera.tower.model.WorkflowLaunchRequest.SyntaxParserEnum;
+import picocli.CommandLine.Option;
+
+/**
+ * Launch options backed by a {@code JsonNullable} field of {@link WorkflowLaunchRequest}.
+ * <p>
+ * They are grouped here because they cannot be set the way the other options are. Their setters wrap the
+ * argument in {@code JsonNullable.of()}, so passing a null sends an explicit null rather than leaving the
+ * field undefined, and Platform reads an explicit null {@code syntaxParser} as the legacy parser
+ * (COMP-2318). {@code coalesce} cannot paper over this: by the time it runs, "the user passed nothing" and
+ * "the user passed null" are the same value. So each option is applied only when it was actually given,
+ * by {@link #applyNullableOptions}.
+ * <p>
+ * {@link LaunchOptions} extends this class so the commands mixing it in inherit these options; commands
+ * declaring their own option set mix this class in directly. Adding an option here without handling it in
+ * {@link #applyNullableOptions} would make it silently do nothing, so a test enforces that every option
+ * declared here is applied.
+ */
+public class NullableLaunchOptions {
+
+    @Option(names = {"--syntax-parser"}, description = "Nextflow language syntax parser version: 'v1' (legacy) or 'v2'. Takes precedence over the value stored in the launch configuration.")
+    public SyntaxParserEnum syntaxParser;
+
+    @Option(names = {"--nextflow-version"}, description = "Nextflow version to run the workflow with. Must exist in the Platform version catalog and meet the minimum required by the compute environment. Takes precedence over the value stored in the launch configuration.")
+    public String nextflowVersion;
+
+    @Option(names = {"--output-dir"}, description = "Per-run output directory, passed to Nextflow as '-output-dir'. Requires Nextflow 24.10.0 or later and the workflow outputs syntax. Takes precedence over the value stored in the launch configuration.")
+    public String outputDir;
+
+    public void applyNullableOptions(WorkflowLaunchRequest request) {
+        if (syntaxParser != null) {
+            request.syntaxParser(syntaxParser);
+        }
+        if (nextflowVersion != null) {
+            request.nextflowVersion(nextflowVersion);
+        }
+        if (outputDir != null) {
+            request.outputDir(outputDir);
+        }
+    }
+}

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/UpdateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/UpdateCmd.java
@@ -23,6 +23,7 @@ import io.seqera.tower.cli.exceptions.InvalidResponseException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.pipelines.PipelinesUpdated;
 import io.seqera.tower.cli.utils.FilesHelper;
+import io.seqera.tower.cli.utils.ModelHelper;
 import io.seqera.tower.cli.utils.VersionNameHelper;
 import io.seqera.tower.model.LaunchDbDto;
 import io.seqera.tower.model.PipelineDbDto;
@@ -199,29 +200,39 @@ public class UpdateCmd extends AbstractPipelinesCmd {
      * fields without having to re-specify everything.
      */
     private UpdatePipelineRequest buildUpdateRequest(PipelineDbDto pipe, LaunchDbDto launch, String ceId) throws IOException {
+        // Start from the stored configuration so fields without a flag survive the update untouched
+        // instead of being reset to null, among them syntaxParser (COMP-2318).
+        WorkflowLaunchRequest launchRequest = ModelHelper.createLaunchRequest(launch)
+                .computeEnvId(ceId)
+                .pipeline(coalesce(pipeline, launch.getPipeline()))
+                .revision(coalesce(opts.revision, launch.getRevision()))
+                // A pinned commit only applies to the revision it was given with, so it is not inherited
+                .commitId(opts.commitId)
+                .workDir(coalesce(opts.workDir, launch.getWorkDir()))
+                .configProfiles(coalesce(opts.profile, launch.getConfigProfiles()))
+                .paramsText(coalesce(FilesHelper.readString(opts.paramsFile), launch.getParamsText()))
+                .configText(coalesce(FilesHelper.readString(opts.config), launch.getConfigText()))
+                .preRunScript(coalesce(FilesHelper.readString(opts.preRunScript), launch.getPreRunScript()))
+                .postRunScript(coalesce(FilesHelper.readString(opts.postRunScript), launch.getPostRunScript()))
+                .pullLatest(coalesce(opts.pullLatest, launch.getPullLatest()))
+                .stubRun(coalesce(opts.stubRun, launch.getStubRun()))
+                .mainScript(coalesce(opts.mainScript, launch.getMainScript()))
+                .entryName(coalesce(opts.entryName, launch.getEntryName()))
+                .schemaName(coalesce(opts.schemaName, launch.getSchemaName()))
+                .pipelineSchemaId(coalesce(pipelineSchemaId, launch.getPipelineSchemaId()))
+                .userSecrets(coalesce(removeEmptyValues(opts.userSecrets), launch.getUserSecrets()))
+                .workspaceSecrets(coalesce(removeEmptyValues(opts.workspaceSecrets), launch.getWorkspaceSecrets()));
+
+        // Only set when requested: the setter cannot express 'undefined', so an unconditional call
+        // would replace an unset value with an explicit null, which Platform reads as the legacy parser.
+        if (opts.syntaxParser != null) {
+            launchRequest.syntaxParser(opts.syntaxParser);
+        }
+
         return new UpdatePipelineRequest()
                 .name(coalesce(newName, pipe.getName()))
                 .description(coalesce(description, pipe.getDescription()))
-                .launch(new WorkflowLaunchRequest()
-                        .computeEnvId(ceId)
-                        .pipeline(coalesce(pipeline, launch.getPipeline()))
-                        .revision(coalesce(opts.revision, launch.getRevision()))
-                        .commitId(opts.commitId)
-                        .workDir(coalesce(opts.workDir, launch.getWorkDir()))
-                        .configProfiles(coalesce(opts.profile, launch.getConfigProfiles()))
-                        .paramsText(coalesce(FilesHelper.readString(opts.paramsFile), launch.getParamsText()))
-                        .configText(coalesce(FilesHelper.readString(opts.config), launch.getConfigText()))
-                        .preRunScript(coalesce(FilesHelper.readString(opts.preRunScript), launch.getPreRunScript()))
-                        .postRunScript(coalesce(FilesHelper.readString(opts.postRunScript), launch.getPostRunScript()))
-                        .pullLatest(coalesce(opts.pullLatest, launch.getPullLatest()))
-                        .stubRun(coalesce(opts.stubRun, launch.getStubRun()))
-                        .mainScript(coalesce(opts.mainScript, launch.getMainScript()))
-                        .entryName(coalesce(opts.entryName, launch.getEntryName()))
-                        .schemaName(coalesce(opts.schemaName, launch.getSchemaName()))
-                        .pipelineSchemaId(coalesce(pipelineSchemaId, launch.getPipelineSchemaId()))
-                        .userSecrets(coalesce(removeEmptyValues(opts.userSecrets), launch.getUserSecrets()))
-                        .workspaceSecrets(coalesce(removeEmptyValues(opts.workspaceSecrets), launch.getWorkspaceSecrets()))
-                );
+                .launch(launchRequest);
     }
 
     // --- Post-update version handling ---

--- a/src/main/java/io/seqera/tower/cli/commands/pipelines/UpdateCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/pipelines/UpdateCmd.java
@@ -223,11 +223,7 @@ public class UpdateCmd extends AbstractPipelinesCmd {
                 .userSecrets(coalesce(removeEmptyValues(opts.userSecrets), launch.getUserSecrets()))
                 .workspaceSecrets(coalesce(removeEmptyValues(opts.workspaceSecrets), launch.getWorkspaceSecrets()));
 
-        // Only set when requested: the setter cannot express 'undefined', so an unconditional call
-        // would replace an unset value with an explicit null, which Platform reads as the legacy parser.
-        if (opts.syntaxParser != null) {
-            launchRequest.syntaxParser(opts.syntaxParser);
-        }
+        opts.applyNullableOptions(launchRequest);
 
         return new UpdatePipelineRequest()
                 .name(coalesce(newName, pipe.getName()))

--- a/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
@@ -120,11 +120,7 @@ public class RelaunchCmd extends AbstractRunsCmd {
                 .commitId(null)
                 ;
 
-        // Only set when requested: the setter cannot express 'undefined', so an unconditional call
-        // would replace the original run's value with an explicit null, which Platform reads as v1.
-        if (opts.syntaxParser != null) {
-            workflowLaunchRequest.syntaxParser(opts.syntaxParser);
-        }
+        opts.applyNullableOptions(workflowLaunchRequest);
 
         if (!noResume) {
             workflowLaunchRequest.sessionId(workflow.getSessionId());

--- a/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
@@ -24,6 +24,7 @@ import io.seqera.tower.cli.exceptions.TowerException;
 import io.seqera.tower.cli.responses.Response;
 import io.seqera.tower.cli.responses.runs.RunSubmited;
 import io.seqera.tower.cli.utils.FilesHelper;
+import io.seqera.tower.cli.utils.ModelHelper;
 import io.seqera.tower.model.ComputeEnvResponseDto;
 import io.seqera.tower.model.DescribeWorkflowLaunchResponse;
 import io.seqera.tower.model.SubmitWorkflowLaunchRequest;
@@ -90,9 +91,10 @@ public class RelaunchCmd extends AbstractRunsCmd {
             noResume = true;
         }
 
-        WorkflowLaunchRequest workflowLaunchRequest = new WorkflowLaunchRequest()
+        // Start from the original run configuration so that fields this command does not name are inherited
+        // instead of silently dropped, among them syntaxParser (COMP-2318).
+        WorkflowLaunchRequest workflowLaunchRequest = ModelHelper.createLaunchRequest(launch)
                 .id(workflow.getLaunchId())
-                .sessionId(launch.getSessionId())
                 .computeEnvId(ce != null ? ce.getId() : launch.getComputeEnv().getId())
                 .pipeline(coalesce(pipeline, launch.getPipeline()))
                 .workDir(opts.workDir != null ? opts.workDir : selectWorkDir(!noResume, launch.getResumeDir(), launch.getWorkDir(), workflow.getWorkDir()))
@@ -113,6 +115,9 @@ public class RelaunchCmd extends AbstractRunsCmd {
                 .dateCreated(OffsetDateTime.now())
                 .runName(name)
                 .launchContainer(launchContainer)
+                // 'revision' above already carries the commit to run, so an inherited commitId would pin the
+                // relaunch to the original commit and ignore both the resume commit and '--revision'.
+                .commitId(null)
                 ;
 
         if (!noResume) {

--- a/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
+++ b/src/main/java/io/seqera/tower/cli/commands/runs/RelaunchCmd.java
@@ -120,6 +120,12 @@ public class RelaunchCmd extends AbstractRunsCmd {
                 .commitId(null)
                 ;
 
+        // Only set when requested: the setter cannot express 'undefined', so an unconditional call
+        // would replace the original run's value with an explicit null, which Platform reads as v1.
+        if (opts.syntaxParser != null) {
+            workflowLaunchRequest.syntaxParser(opts.syntaxParser);
+        }
+
         if (!noResume) {
             workflowLaunchRequest.sessionId(workflow.getSessionId());
         }

--- a/src/main/java/io/seqera/tower/cli/utils/ModelHelper.java
+++ b/src/main/java/io/seqera/tower/cli/utils/ModelHelper.java
@@ -16,46 +16,53 @@
 
 package io.seqera.tower.cli.utils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.seqera.tower.JSON;
+import io.seqera.tower.model.ComputeEnvComputeConfig;
 import io.seqera.tower.model.LaunchDbDto;
 import io.seqera.tower.model.WorkflowLaunchRequest;
+import io.seqera.tower.model.WorkflowLaunchResponse;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class ModelHelper {
 
+    /**
+     * The SDK mapper ignores unknown properties and understands {@code JsonNullable}, so it can copy a launch
+     * configuration field by field without a hand-maintained field list. See {@link #copyLaunchFields}.
+     */
+    private static final ObjectMapper LAUNCH_MAPPER = new JSON().getContext(WorkflowLaunchRequest.class);
+
     private ModelHelper() {
     }
 
     public static WorkflowLaunchRequest createLaunchRequest(LaunchDbDto launch) {
-        return new WorkflowLaunchRequest()
-                .id(launch.getId())
-                .computeEnvId(launch.getComputeEnv() != null ? launch.getComputeEnv().getId() : null)
-                .pipeline(launch.getPipeline())
-                .workDir(launch.getWorkDir())
-                .revision(launch.getRevision())
-                .commitId(launch.getCommitId())
-                .sessionId(launch.getSessionId())
-                .configProfiles(launch.getConfigProfiles())
-                .userSecrets(launch.getUserSecrets())
-                .workspaceSecrets(launch.getWorkspaceSecrets())
-                .configText(launch.getConfigText())
-                .towerConfig(launch.getTowerConfig())
-                .paramsText(launch.getParamsText())
-                .preRunScript(launch.getPreRunScript())
-                .postRunScript(launch.getPostRunScript())
-                .mainScript(launch.getMainScript())
-                .entryName(launch.getEntryName())
-                .schemaName(launch.getSchemaName())
-                .pipelineSchemaId(launch.getPipelineSchemaId())
-                .resume(launch.getResume())
-                .pullLatest(launch.getPullLatest())
-                .stubRun(launch.getStubRun())
-                .optimizationId(launch.getOptimizationId())
-                .optimizationTargets(launch.getOptimizationTargets())
-                .headJobCpus(launch.getHeadJobCpus())
-                .headJobMemoryMb(launch.getHeadJobMemoryMb())
-                .dateCreated(launch.getDateCreated());
+        return copyLaunchFields(launch)
+                .computeEnvId(computeEnvId(launch.getComputeEnv()));
+    }
+
+    public static WorkflowLaunchRequest createLaunchRequest(WorkflowLaunchResponse launch) {
+        return copyLaunchFields(launch)
+                .computeEnvId(computeEnvId(launch.getComputeEnv()));
+    }
+
+    /**
+     * Copies every launch field the source and {@link WorkflowLaunchRequest} have in common by serializing the
+     * source and reading it back as a request. Fields the request does not declare are dropped, and fields the
+     * API gains in a future SDK release are carried over with no change here.
+     * <p>
+     * Going through JSON is what makes this safe for the nullable fields ({@code syntaxParser},
+     * {@code nextflowVersion}, {@code outputDir}): an undefined value stays undefined instead of becoming an
+     * explicit {@code null}, which the fluent setters cannot express because they wrap their argument in
+     * {@code JsonNullable.of()} unconditionally.
+     */
+    private static WorkflowLaunchRequest copyLaunchFields(Object launch) {
+        return LAUNCH_MAPPER.convertValue(launch, WorkflowLaunchRequest.class);
+    }
+
+    private static String computeEnvId(ComputeEnvComputeConfig computeEnv) {
+        return computeEnv != null ? computeEnv.getId() : null;
     }
 
     public static <T> T coalesce(T value, T defaultValue) {

--- a/src/test/java/io/seqera/tower/cli/LaunchCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/LaunchCmdTest.java
@@ -142,7 +142,7 @@ class LaunchCmdTest extends BaseCmdTest {
     }
 
     @Test
-    void testSubmitLaunchpadPipelineOverridingSyntaxParser(MockServerClient mock) {
+    void testSubmitLaunchpadPipelineOverridingNullableOptions(MockServerClient mock) {
 
         // Create server expectation
         mock.when(
@@ -163,7 +163,9 @@ class LaunchCmdTest extends BaseCmdTest {
                             {
                                 "launch":{
                                     "pipeline":"https://github.com/nf-core/sarek",
-                                    "syntaxParser":"v1"
+                                    "syntaxParser":"v1",
+                                    "nextflowVersion":"25.10.1",
+                                    "outputDir":"/new-outputs"
                                 }
                             }"""
                         )),
@@ -179,7 +181,8 @@ class LaunchCmdTest extends BaseCmdTest {
         );
 
         // Run the command
-        ExecOut out = exec(mock, "launch", "sarek", "--syntax-parser", "v1");
+        ExecOut out = exec(mock, "launch", "sarek", "--syntax-parser", "v1",
+                "--nextflow-version", "25.10.1", "--output-dir", "/new-outputs");
 
         // Assert results
         assertEquals("", out.stdErr);

--- a/src/test/java/io/seqera/tower/cli/LaunchCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/LaunchCmdTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.model.MediaType;
+import org.mockserver.verify.VerificationTimes;
 
 import java.io.IOException;
 
@@ -39,6 +40,7 @@ import static org.mockserver.matchers.Times.exactly;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 import static org.mockserver.model.JsonBody.json;
+import static org.mockserver.model.StringBody.subString;
 
 
 class LaunchCmdTest extends BaseCmdTest {
@@ -78,6 +80,65 @@ class LaunchCmdTest extends BaseCmdTest {
         // Assert results
         assertEquals(errorMessage(out.app, new InvalidResponseException("Pipeline 'hello' not found on this workspace.")), out.stdErr);
         assertEquals(1, out.exitCode);
+    }
+
+    @Test
+    void testSubmitLaunchpadPipelineKeepsStoredLaunchConfiguration(MockServerClient mock) {
+
+        // Create server expectation
+        mock.when(
+                request().withMethod("GET").withPath("/pipelines"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("pipelines_sarek")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/pipelines/250911634275687/launch"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("pipeline_launch_describe_v2")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("POST").withPath("/workflow/launch")
+                        .withBody(json("""
+                            {
+                                "launch":{
+                                    "id":"5nmCvXcarkvv8tELMF4KyY",
+                                    "computeEnvId":"4X7YrYJp9B1d1DUpfur7DS",
+                                    "pipeline":"https://github.com/nf-core/sarek",
+                                    "workDir":"/efs",
+                                    "pipelineSchemaId":42,
+                                    "pullLatest":false,
+                                    "stubRun":false,
+                                    "launchContainer":"quay.io/seqeralabs/nf-launcher:j17-24.10.0",
+                                    "nextflowVersion":"26.04.6",
+                                    "outputDir":"/outputs",
+                                    "syntaxParser":"v2"
+                                }
+                            }"""
+                        )),
+                exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workflow_launch")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/user-info"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        // Run the command
+        ExecOut out = exec(mock, "launch", "sarek");
+
+        // Assert results: the request matcher above is the assertion, the run only submits if it matched
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+        // A new run must not inherit the stored session or resume state
+        mock.verify(request().withMethod("POST").withPath("/workflow/launch")
+                .withBody(subString("\"sessionId\"")), VerificationTimes.exactly(0));
+        mock.verify(request().withMethod("POST").withPath("/workflow/launch")
+                .withBody(subString("\"resume\"")), VerificationTimes.exactly(0));
     }
 
     @ParameterizedTest

--- a/src/test/java/io/seqera/tower/cli/LaunchCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/LaunchCmdTest.java
@@ -141,6 +141,51 @@ class LaunchCmdTest extends BaseCmdTest {
                 .withBody(subString("\"resume\"")), VerificationTimes.exactly(0));
     }
 
+    @Test
+    void testSubmitLaunchpadPipelineOverridingSyntaxParser(MockServerClient mock) {
+
+        // Create server expectation
+        mock.when(
+                request().withMethod("GET").withPath("/pipelines"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("pipelines_sarek")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/pipelines/250911634275687/launch"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("pipeline_launch_describe_v2")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("POST").withPath("/workflow/launch")
+                        .withBody(json("""
+                            {
+                                "launch":{
+                                    "pipeline":"https://github.com/nf-core/sarek",
+                                    "syntaxParser":"v1"
+                                }
+                            }"""
+                        )),
+                exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workflow_launch")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/user-info"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        // Run the command
+        ExecOut out = exec(mock, "launch", "sarek", "--syntax-parser", "v1");
+
+        // Assert results
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+    }
+
     @ParameterizedTest
     @EnumSource(OutputType.class)
     void testSubmitLaunchpadPipeline(OutputType format, MockServerClient mock) {

--- a/src/test/java/io/seqera/tower/cli/pipelines/PipelinesCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/pipelines/PipelinesCmdTest.java
@@ -1185,6 +1185,46 @@ class PipelinesCmdTest extends BaseCmdTest {
     }
 
     @Test
+    void testAddWithNextflowVersionAndOutputDir(MockServerClient mock) {
+
+        mock.reset();
+
+        mock.when(
+                request().withMethod("GET").withPath("/compute-envs"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"computeEnvs\":[{\"id\":\"vYOK4vn7spw7bHHWBDXZ2\",\"name\":\"demo\",\"platform\":\"aws-batch\",\"status\":\"AVAILABLE\",\"primary\":true}]}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/compute-envs/vYOK4vn7spw7bHHWBDXZ2"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"computeEnv\":{\"id\":\"vYOK4vn7spw7bHHWBDXZ2\",\"name\":\"demo\",\"platform\":\"aws-batch\",\"status\":\"AVAILABLE\",\"config\":{\"workDir\":\"s3://nextflow-ci/jordeu\",\"discriminator\":\"aws-batch\"}}}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("POST").withPath("/pipelines")
+                        .withBody(json("""
+                            {
+                                "launch":{
+                                    "pipeline":"https://github.com/pditommaso/nf-sleep",
+                                    "nextflowVersion":"26.04.6",
+                                    "outputDir":"s3://nextflow-ci/outputs"
+                                }
+                            }"""
+                        )), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"pipeline\":{\"pipelineId\":217997727159863,\"name\":\"sleep_one_minute\"}}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(mock, "pipelines", "add", "-n", "sleep_one_minute",
+                "--nextflow-version", "26.04.6", "--output-dir", "s3://nextflow-ci/outputs",
+                "https://github.com/pditommaso/nf-sleep");
+
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+    }
+
+    @Test
     void testAddWithInvalidSyntaxParser(MockServerClient mock) {
 
         mock.reset();

--- a/src/test/java/io/seqera/tower/cli/pipelines/PipelinesCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/pipelines/PipelinesCmdTest.java
@@ -1146,6 +1146,42 @@ class PipelinesCmdTest extends BaseCmdTest {
     }
 
     @Test
+    void testExportKeepsSyntaxParser(MockServerClient mock) {
+
+        mock.reset();
+
+        mock.when(
+                request().withMethod("GET").withPath("/pipelines").withQueryStringParameter("search", "\"sleep\""), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("pipelines_sleep")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/pipelines/183522618315672"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"pipeline\":{\"pipelineId\":183522618315672,\"name\":\"sleep_one_minute\",\"repository\":\"https://github.com/pditommaso/nf-sleep\"}}")
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/pipelines/183522618315672/launch"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"launch\":{\"id\":\"5nmCvXcarkvv8tELMF4KyY\",\"pipeline\":\"https://github.com/pditommaso/nf-sleep\",\"workDir\":\"s3://nextflow-ci/jordeu\",\"nextflowVersion\":\"26.04.6\",\"outputDir\":\"/outputs\",\"syntaxParser\":\"v2\",\"launchContainer\":\"quay.io/seqeralabs/nf-launcher:j17-24.10.0\"}}")
+        );
+
+        ExecOut out = exec(mock, "pipelines", "export", "-n", "sleep");
+
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+        // An export that drops these fields downgrades the pipeline when it is imported back (COMP-2318)
+        assertTrue(out.stdOut.contains("\"syntaxParser\" : \"v2\""), out.stdOut);
+        assertTrue(out.stdOut.contains("\"nextflowVersion\" : \"26.04.6\""), out.stdOut);
+        assertTrue(out.stdOut.contains("\"outputDir\" : \"/outputs\""), out.stdOut);
+        assertTrue(out.stdOut.contains("\"launchContainer\" : \"quay.io/seqeralabs/nf-launcher:j17-24.10.0\""), out.stdOut);
+    }
+
+    @Test
     void testImport(MockServerClient mock) throws IOException {
 
         mock.reset();

--- a/src/test/java/io/seqera/tower/cli/pipelines/PipelinesCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/pipelines/PipelinesCmdTest.java
@@ -1146,6 +1146,167 @@ class PipelinesCmdTest extends BaseCmdTest {
     }
 
     @Test
+    void testAddWithSyntaxParser(MockServerClient mock) {
+
+        mock.reset();
+
+        mock.when(
+                request().withMethod("GET").withPath("/compute-envs"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"computeEnvs\":[{\"id\":\"vYOK4vn7spw7bHHWBDXZ2\",\"name\":\"demo\",\"platform\":\"aws-batch\",\"status\":\"AVAILABLE\",\"primary\":true}]}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/compute-envs/vYOK4vn7spw7bHHWBDXZ2"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"computeEnv\":{\"id\":\"vYOK4vn7spw7bHHWBDXZ2\",\"name\":\"demo\",\"platform\":\"aws-batch\",\"status\":\"AVAILABLE\",\"config\":{\"workDir\":\"s3://nextflow-ci/jordeu\",\"discriminator\":\"aws-batch\"}}}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("POST").withPath("/pipelines")
+                        .withBody(json("""
+                            {
+                                "name":"sleep_one_minute",
+                                "launch":{
+                                    "computeEnvId":"vYOK4vn7spw7bHHWBDXZ2",
+                                    "pipeline":"https://github.com/pditommaso/nf-sleep",
+                                    "syntaxParser":"v2"
+                                }
+                            }"""
+                        )), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"pipeline\":{\"pipelineId\":217997727159863,\"name\":\"sleep_one_minute\"}}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(mock, "pipelines", "add", "-n", "sleep_one_minute", "--syntax-parser", "v2", "https://github.com/pditommaso/nf-sleep");
+
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+    }
+
+    @Test
+    void testAddWithInvalidSyntaxParser(MockServerClient mock) {
+
+        mock.reset();
+
+        ExecOut out = exec(mock, "pipelines", "add", "-n", "sleep_one_minute", "--syntax-parser", "v3", "https://github.com/pditommaso/nf-sleep");
+
+        assertTrue(out.stdErr.contains("Invalid value for option '--syntax-parser'"), out.stdErr);
+        assertTrue(out.stdErr.contains("v1"), out.stdErr);
+        assertTrue(out.stdErr.contains("v2"), out.stdErr);
+        assertEquals(2, out.exitCode);
+    }
+
+    @Test
+    void testUpdateKeepsStoredSyntaxParser(MockServerClient mock) {
+
+        mock.reset();
+
+        mock.when(
+                request().withMethod("GET").withPath("/pipelines").withQueryStringParameter("search", "\"sleep_one_minute\""), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"pipelines\":[{\"pipelineId\":217997727159863,\"name\":\"sleep_one_minute\",\"repository\":\"https://github.com/pditommaso/nf-sleep\"}],\"totalSize\":1}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/pipelines/217997727159863"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("""
+                        {
+                            "pipeline": {
+                                "pipelineId": 217997727159863,
+                                "name": "sleep_one_minute",
+                                "repository": "https://github.com/pditommaso/nf-sleep",
+                                "version": {"id": "default-ver", "name": "sleep_one_minute-1", "isDefault": true}
+                            }
+                        }""").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/pipelines/217997727159863/launch")
+                        .withQueryStringParameter("versionId", "default-ver"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"launch\":{\"id\":\"5nmCvXcarkvv8tELMF4KyY\",\"computeEnvId\":null,\"computeEnv\":{\"id\":\"vYOK4vn7spw7bHHWBDXZ2\",\"name\":\"demo\",\"platform\":\"aws-batch\",\"status\":\"AVAILABLE\"},\"pipeline\":\"https://github.com/pditommaso/nf-sleep\",\"workDir\":\"s3://nextflow-ci/jordeu\",\"revision\":\"main\",\"syntaxParser\":\"v2\",\"nextflowVersion\":\"26.04.6\"}}")
+        );
+
+        mock.when(
+                request().withMethod("POST").withPath("/pipelines/217997727159863/versions/default-ver")
+                        .withBody(json("""
+                            {
+                                "launch":{
+                                    "computeEnvId":"vYOK4vn7spw7bHHWBDXZ2",
+                                    "pipeline":"https://github.com/pditommaso/nf-sleep",
+                                    "revision":"main",
+                                    "syntaxParser":"v2",
+                                    "nextflowVersion":"26.04.6"
+                                }
+                            }""")), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("""
+                        {"pipeline":{"pipelineId":217997727159863,"name":"sleep_one_minute","version":{"id":"default-ver","name":"sleep_one_minute-1","isDefault":true}}}""").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(mock, "pipelines", "update", "-n", "sleep_one_minute", "-d", "Sleep one minute");
+
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+    }
+
+    @Test
+    void testUpdateOverridesSyntaxParser(MockServerClient mock) {
+
+        mock.reset();
+
+        mock.when(
+                request().withMethod("GET").withPath("/pipelines").withQueryStringParameter("search", "\"sleep_one_minute\""), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("{\"pipelines\":[{\"pipelineId\":217997727159863,\"name\":\"sleep_one_minute\",\"repository\":\"https://github.com/pditommaso/nf-sleep\"}],\"totalSize\":1}").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/pipelines/217997727159863"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("""
+                        {
+                            "pipeline": {
+                                "pipelineId": 217997727159863,
+                                "name": "sleep_one_minute",
+                                "repository": "https://github.com/pditommaso/nf-sleep",
+                                "version": {"id": "default-ver", "name": "sleep_one_minute-1", "isDefault": true}
+                            }
+                        }""").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/pipelines/217997727159863/launch")
+                        .withQueryStringParameter("versionId", "default-ver"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withContentType(MediaType.APPLICATION_JSON)
+                        .withBody("{\"launch\":{\"id\":\"5nmCvXcarkvv8tELMF4KyY\",\"computeEnvId\":null,\"computeEnv\":{\"id\":\"vYOK4vn7spw7bHHWBDXZ2\",\"name\":\"demo\",\"platform\":\"aws-batch\",\"status\":\"AVAILABLE\"},\"pipeline\":\"https://github.com/pditommaso/nf-sleep\",\"workDir\":\"s3://nextflow-ci/jordeu\",\"revision\":\"main\",\"syntaxParser\":\"v2\",\"nextflowVersion\":\"26.04.6\"}}")
+        );
+
+        mock.when(
+                request().withMethod("POST").withPath("/pipelines/217997727159863/versions/default-ver")
+                        .withBody(json("""
+                            {
+                                "launch":{
+                                    "pipeline":"https://github.com/pditommaso/nf-sleep",
+                                    "syntaxParser":"v1"
+                                }
+                            }""")), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody("""
+                        {"pipeline":{"pipelineId":217997727159863,"name":"sleep_one_minute","version":{"id":"default-ver","name":"sleep_one_minute-1","isDefault":true}}}""").withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(mock, "pipelines", "update", "-n", "sleep_one_minute", "--syntax-parser", "v1");
+
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+    }
+
+    @Test
     void testExportKeepsSyntaxParser(MockServerClient mock) {
 
         mock.reset();

--- a/src/test/java/io/seqera/tower/cli/runs/RunsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/runs/RunsCmdTest.java
@@ -583,6 +583,42 @@ class RunsCmdTest extends BaseCmdTest {
     }
 
     @Test
+    void testRelaunchOverridingSyntaxParser(MockServerClient mock) {
+        mock.reset();
+
+        mock.when(
+                request().withMethod("POST").withPath("/workflow/launch"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workflow_launch")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/workflow/5mDfiUtqyptDib"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workflow_view")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/workflow/5mDfiUtqyptDib/launch"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("runs/workflow_launch_v2")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/user-info"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(mock, "runs", "relaunch", "-i", "5mDfiUtqyptDib", "--syntax-parser", "v1");
+
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+        mock.verify(request().withMethod("POST").withPath("/workflow/launch")
+                .withBody(json("{\"launch\":{\"syntaxParser\":\"v1\"}}")), VerificationTimes.exactly(1));
+    }
+
+    @Test
     void testInvalidAuth(MockServerClient mock) {
         mock.when(
                 request().withMethod("DELETE").withPath("/workflow/5dAZoXrcmZXRO4"), exactly(1)

--- a/src/test/java/io/seqera/tower/cli/runs/RunsCmdTest.java
+++ b/src/test/java/io/seqera/tower/cli/runs/RunsCmdTest.java
@@ -57,6 +57,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.model.MediaType;
+import org.mockserver.verify.VerificationTimes;
 
 import java.io.File;
 import java.io.IOException;
@@ -76,6 +77,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockserver.matchers.Times.exactly;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
+import static org.mockserver.model.JsonBody.json;
+import static org.mockserver.model.StringBody.subString;
 
 class RunsCmdTest extends BaseCmdTest {
 
@@ -526,6 +529,57 @@ class RunsCmdTest extends BaseCmdTest {
 
         ExecOut out = exec(format, mock, "runs", "relaunch", "-i", "5mDfiUtqyptDib");
         assertOutput(format, out, new RunSubmited("35aLiS0bIM5efd", null, String.format("%s/user/jordi/watch/35aLiS0bIM5efd", url(mock)), "user"));
+    }
+
+    @Test
+    void testRelaunchKeepsOriginalLaunchConfiguration(MockServerClient mock) {
+        mock.reset();
+
+        mock.when(
+                request().withMethod("POST").withPath("/workflow/launch"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workflow_launch")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/workflow/5mDfiUtqyptDib"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("workflow_view")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/workflow/5mDfiUtqyptDib/launch"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("runs/workflow_launch_v2")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        mock.when(
+                request().withMethod("GET").withPath("/user-info"), exactly(1)
+        ).respond(
+                response().withStatusCode(200).withBody(loadResource("user")).withContentType(MediaType.APPLICATION_JSON)
+        );
+
+        ExecOut out = exec(mock, "runs", "relaunch", "-i", "5mDfiUtqyptDib");
+
+        assertEquals("", out.stdErr);
+        assertEquals(0, out.exitCode);
+        mock.verify(request().withMethod("POST").withPath("/workflow/launch")
+                .withBody(json("""
+                    {
+                        "launch":{
+                            "id":"5SCyEXKrCqFoGzOXGpesr5",
+                            "computeEnvId":"2lu3NFms1qRvwTVnrs1yhg",
+                            "pipeline":"https://github.com/nf-core/rnaseq",
+                            "pipelineSchemaId":42,
+                            "resume":true,
+                            "nextflowVersion":"26.04.6",
+                            "outputDir":"/outputs",
+                            "syntaxParser":"v2"
+                        }
+                    }""")), VerificationTimes.exactly(1));
+        // 'revision' carries the commit to run, so the original commitId must not be inherited
+        mock.verify(request().withMethod("POST").withPath("/workflow/launch")
+                .withBody(subString("\"commitId\"")), VerificationTimes.exactly(0));
     }
 
     @Test

--- a/src/test/java/io/seqera/tower/cli/utils/ModelHelperTest.java
+++ b/src/test/java/io/seqera/tower/cli/utils/ModelHelperTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.seqera.tower.JSON;
+import io.seqera.tower.model.ComputeEnvComputeConfig;
+import io.seqera.tower.model.LaunchDbDto;
+import io.seqera.tower.model.WorkflowLaunchRequest;
+import io.seqera.tower.model.WorkflowLaunchResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ModelHelperTest {
+
+    @Test
+    void createLaunchRequestCopiesEveryLaunchField() throws JsonProcessingException {
+        LaunchDbDto launch = new LaunchDbDto()
+                .id("5nmCvXcarkvv8tELMF4KyY")
+                .computeEnv(computeEnv("4X7YrYJp9B1d1DUpfur7DS"))
+                .pipeline("https://github.com/nf-core/sarek")
+                .workDir("/efs")
+                .revision("dev")
+                .commitId("f5b3a9c")
+                .sessionId("d77a5ac4-1a25-45d6-bab0-358605abc332")
+                .configProfiles(List.of("test", "docker"))
+                .configText("process.cpus = 2")
+                .towerConfig("tower {}")
+                .paramsText("outdir: /results")
+                .preRunScript("echo pre")
+                .postRunScript("echo post")
+                .mainScript("main.nf")
+                .entryName("NFCORE_SAREK")
+                .schemaName("nextflow_schema.json")
+                .pipelineSchemaId(42L)
+                .userSecrets(List.of("USER_SECRET"))
+                .workspaceSecrets(List.of("WORKSPACE_SECRET"))
+                .resume(true)
+                .pullLatest(true)
+                .stubRun(true)
+                .optimizationId("rOYdwTnmTaRCJjUq")
+                .optimizationTargets("cpus, memory")
+                .headJobCpus(4)
+                .headJobMemoryMb(8192)
+                .launchContainer("quay.io/seqeralabs/nf-launcher:j17-24.10.0")
+                .nextflowVersion("26.04.6")
+                .outputDir("/outputs")
+                .syntaxParser(LaunchDbDto.SyntaxParserEnum.V2);
+
+        WorkflowLaunchRequest request = ModelHelper.createLaunchRequest(launch);
+
+        assertEquals("5nmCvXcarkvv8tELMF4KyY", request.getId());
+        assertEquals("4X7YrYJp9B1d1DUpfur7DS", request.getComputeEnvId());
+        assertEquals("https://github.com/nf-core/sarek", request.getPipeline());
+        assertEquals("/efs", request.getWorkDir());
+        assertEquals("dev", request.getRevision());
+        assertEquals("f5b3a9c", request.getCommitId());
+        assertEquals("d77a5ac4-1a25-45d6-bab0-358605abc332", request.getSessionId());
+        assertEquals(List.of("test", "docker"), request.getConfigProfiles());
+        assertEquals("process.cpus = 2", request.getConfigText());
+        assertEquals("tower {}", request.getTowerConfig());
+        assertEquals("outdir: /results", request.getParamsText());
+        assertEquals("echo pre", request.getPreRunScript());
+        assertEquals("echo post", request.getPostRunScript());
+        assertEquals("main.nf", request.getMainScript());
+        assertEquals("NFCORE_SAREK", request.getEntryName());
+        assertEquals("nextflow_schema.json", request.getSchemaName());
+        assertEquals(42L, request.getPipelineSchemaId());
+        assertEquals(List.of("USER_SECRET"), request.getUserSecrets());
+        assertEquals(List.of("WORKSPACE_SECRET"), request.getWorkspaceSecrets());
+        assertTrue(request.getResume());
+        assertTrue(request.getPullLatest());
+        assertTrue(request.getStubRun());
+        assertEquals("rOYdwTnmTaRCJjUq", request.getOptimizationId());
+        assertEquals("cpus, memory", request.getOptimizationTargets());
+        assertEquals(4, request.getHeadJobCpus());
+        assertEquals(8192, request.getHeadJobMemoryMb());
+        assertEquals("quay.io/seqeralabs/nf-launcher:j17-24.10.0", request.getLaunchContainer());
+        assertEquals("26.04.6", request.getNextflowVersion());
+        assertEquals("/outputs", request.getOutputDir());
+        assertEquals(WorkflowLaunchRequest.SyntaxParserEnum.V2, request.getSyntaxParser());
+    }
+
+    @Test
+    void createLaunchRequestFromWorkflowLaunchResponseCopiesSyntaxParser() throws JsonProcessingException {
+        WorkflowLaunchResponse launch = new WorkflowLaunchResponse()
+                .computeEnv(computeEnv("2lu3NFms1qRvwTVnrs1yhg"))
+                .pipeline("https://github.com/nf-core/rnaseq")
+                .nextflowVersion("26.04.6")
+                .syntaxParser(WorkflowLaunchResponse.SyntaxParserEnum.V2);
+
+        WorkflowLaunchRequest request = ModelHelper.createLaunchRequest(launch);
+
+        assertEquals("2lu3NFms1qRvwTVnrs1yhg", request.getComputeEnvId());
+        assertEquals("https://github.com/nf-core/rnaseq", request.getPipeline());
+        assertEquals("26.04.6", request.getNextflowVersion());
+        assertEquals(WorkflowLaunchRequest.SyntaxParserEnum.V2, request.getSyntaxParser());
+    }
+
+    @Test
+    void createLaunchRequestKeepsUndefinedNullableFieldsOutOfThePayload() throws JsonProcessingException {
+        LaunchDbDto launch = new LaunchDbDto().pipeline("https://github.com/nf-core/sarek");
+
+        String json = serialize(ModelHelper.createLaunchRequest(launch));
+
+        assertFalse(json.contains("syntaxParser"), json);
+        assertFalse(json.contains("nextflowVersion"), json);
+        assertFalse(json.contains("outputDir"), json);
+    }
+
+    @Test
+    void createLaunchRequestPreservesExplicitlyNullNullableFields() throws JsonProcessingException {
+        LaunchDbDto launch = new LaunchDbDto()
+                .pipeline("https://github.com/nf-core/sarek")
+                .syntaxParser(null)
+                .outputDir(null);
+
+        WorkflowLaunchRequest request = ModelHelper.createLaunchRequest(launch);
+
+        assertNull(request.getSyntaxParser());
+        assertNull(request.getOutputDir());
+        String json = serialize(request);
+        assertTrue(json.contains("\"syntaxParser\" : null"), json);
+        assertTrue(json.contains("\"outputDir\" : null"), json);
+    }
+
+    @Test
+    void createLaunchRequestWithoutComputeEnvHasNoComputeEnvId() {
+        WorkflowLaunchRequest request = ModelHelper.createLaunchRequest(new LaunchDbDto().pipeline("https://github.com/nf-core/sarek"));
+
+        assertNull(request.getComputeEnvId());
+    }
+
+    // ComputeEnvComputeConfig exposes no setter for 'id', so the fixture is built from JSON.
+    private static ComputeEnvComputeConfig computeEnv(String id) throws JsonProcessingException {
+        return new JSON().getContext(ComputeEnvComputeConfig.class)
+                .readValue(String.format("{\"id\":\"%s\"}", id), ComputeEnvComputeConfig.class);
+    }
+
+    private static String serialize(WorkflowLaunchRequest request) throws JsonProcessingException {
+        return new JSON().getContext(WorkflowLaunchRequest.class)
+                .writerWithDefaultPrettyPrinter()
+                .writeValueAsString(request);
+    }
+}

--- a/src/test/java/io/seqera/tower/cli/utils/NullableLaunchOptionsTest.java
+++ b/src/test/java/io/seqera/tower/cli/utils/NullableLaunchOptionsTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021-2026, Seqera.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.cli.utils;
+
+import io.seqera.tower.cli.commands.pipelines.LaunchOptions;
+import io.seqera.tower.cli.commands.pipelines.NullableLaunchOptions;
+import io.seqera.tower.model.WorkflowLaunchRequest;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine.Option;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Guards the one piece of NullableLaunchOptions that has to be kept in step by hand: an option declared
+ * there but missing from applyNullableOptions would parse fine and then do nothing at all.
+ */
+class NullableLaunchOptionsTest {
+
+    private static final String JSON_NULLABLE = "org.openapitools.jackson.nullable.JsonNullable";
+
+    @Test
+    void everyDeclaredOptionIsApplied() throws ReflectiveOperationException {
+        Set<String> unapplied = new LinkedHashSet<>();
+
+        for (Field option : optionFields()) {
+            NullableLaunchOptions opts = new NullableLaunchOptions();
+            option.set(opts, sampleValueFor(option));
+
+            WorkflowLaunchRequest request = new WorkflowLaunchRequest();
+            opts.applyNullableOptions(request);
+
+            if (readOption(request, option.getName()) == null) {
+                unapplied.add(option.getName());
+            }
+        }
+
+        assertTrue(unapplied.isEmpty(), String.format(
+                "%s declares options that applyNullableOptions never copies to the launch request, so they "
+                        + "would be silently ignored: %s", NullableLaunchOptions.class.getSimpleName(), unapplied));
+    }
+
+    @Test
+    void everyDeclaredOptionMapsToANullableRequestField() {
+        Set<String> nullableRequestFields = Arrays.stream(WorkflowLaunchRequest.class.getDeclaredFields())
+                .filter(f -> JSON_NULLABLE.equals(f.getType().getName()))
+                .map(Field::getName)
+                .collect(Collectors.toSet());
+
+        Set<String> unknown = optionFields().stream()
+                .map(Field::getName)
+                .filter(name -> !nullableRequestFields.contains(name))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        assertTrue(unknown.isEmpty(), String.format(
+                "These options are not backed by a JsonNullable field of WorkflowLaunchRequest, so they do "
+                        + "not belong here: %s", unknown));
+    }
+
+    @Test
+    void launchOptionsInheritsThem() {
+        assertNotNull(optionFields());
+        assertTrue(NullableLaunchOptions.class.isAssignableFrom(LaunchOptions.class),
+                "LaunchOptions must extend NullableLaunchOptions so the commands mixing it in expose these options");
+    }
+
+    private static Set<Field> optionFields() {
+        return Arrays.stream(NullableLaunchOptions.class.getDeclaredFields())
+                .filter(f -> f.isAnnotationPresent(Option.class))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private static Object sampleValueFor(Field option) {
+        Class<?> type = option.getType();
+        if (type == String.class) {
+            return "sample";
+        }
+        if (type.isEnum()) {
+            return type.getEnumConstants()[0];
+        }
+        throw new IllegalStateException(String.format(
+                "No sample value for option '%s' of type %s: extend this test alongside the new option",
+                option.getName(), type.getName()));
+    }
+
+    /**
+     * Reads the plain getter, which unwraps the JsonNullable, so this test needs no direct dependency on it.
+     */
+    private static Object readOption(WorkflowLaunchRequest request, String fieldName) throws ReflectiveOperationException {
+        String getter = "get" + Character.toUpperCase(fieldName.charAt(0)) + fieldName.substring(1);
+        return WorkflowLaunchRequest.class.getMethod(getter).invoke(request);
+    }
+}

--- a/src/test/resources/runcmd/pipeline_launch_describe_v2.json
+++ b/src/test/resources/runcmd/pipeline_launch_describe_v2.json
@@ -1,0 +1,33 @@
+{
+  "launch": {
+    "id": "5nmCvXcarkvv8tELMF4KyY",
+    "computeEnv": {
+      "id": "4X7YrYJp9B1d1DUpfur7DS",
+      "name": "aws jordeu",
+      "platform": "aws-batch",
+      "status": "AVAILABLE"
+    },
+    "pipeline": "https://github.com/nf-core/sarek",
+    "workDir": "/efs",
+    "revision": null,
+    "sessionId": "d77a5ac4-1a25-45d6-bab0-358605abc332",
+    "configProfiles": null,
+    "configText": null,
+    "paramsText": null,
+    "preRunScript": null,
+    "postRunScript": null,
+    "mainScript": null,
+    "entryName": null,
+    "schemaName": null,
+    "pipelineSchemaId": 42,
+    "resume": false,
+    "pullLatest": false,
+    "stubRun": false,
+    "launchContainer": "quay.io/seqeralabs/nf-launcher:j17-24.10.0",
+    "nextflowVersion": "26.04.6",
+    "outputDir": "/outputs",
+    "syntaxParser": "v2",
+    "dateCreated": "2021-06-21T18:06:01Z",
+    "lastUpdated": "2021-07-14T12:55:29Z"
+  }
+}

--- a/src/test/resources/runcmd/runs/workflow_launch_v2.json
+++ b/src/test/resources/runcmd/runs/workflow_launch_v2.json
@@ -1,0 +1,35 @@
+{
+  "launch": {
+    "id": "3r9NghqwymK6xymExVnmdB",
+    "computeEnv": {
+      "id": "2lu3NFms1qRvwTVnrs1yhg",
+      "name": "aws_batch",
+      "platform": "aws-batch",
+      "status": "AVAILABLE"
+    },
+    "pipeline": "https://github.com/nf-core/rnaseq",
+    "workDir": "s3://fusionfs",
+    "revision": null,
+    "commitId": "89bf536ce4faa98b4d50a8ec0a0343780bc62e0a",
+    "sessionId": "d77a5ac4-1a25-45d6-bab0-358605abc332",
+    "configProfiles": null,
+    "configText": null,
+    "towerConfig": null,
+    "paramsText": null,
+    "preRunScript": null,
+    "postRunScript": null,
+    "mainScript": null,
+    "entryName": null,
+    "schemaName": null,
+    "pipelineSchemaId": 42,
+    "resume": false,
+    "pullLatest": false,
+    "stubRun": false,
+    "nextflowVersion": "26.04.6",
+    "outputDir": "/outputs",
+    "syntaxParser": "v2",
+    "resumeDir": "s3://fusionfs/scratch/5qRNYT6iAJfRbJ",
+    "resumeCommitId": "89bf536ce4faa98b4d50a8ec0a0343780bc62e0a",
+    "dateCreated": "2022-08-01T15:58:08Z"
+  }
+}


### PR DESCRIPTION
Fixes [COMP-2318](https://seqera.atlassian.net/browse/COMP-2318) (support ticket FD-7868).

Three commits: the silent-drop bug, then `--syntax-parser`, then `--nextflow-version` and `--output-dir`. The ticket filed the options as separate follow-ups, but the customer's actual workflow — registering pipelines across several workspaces with `tw pipelines add` — cannot select v2 without them, and the other two fields had the same gap.

## The bug

`WorkflowLaunchRequest` objects were built from **five** independent hand-maintained field lists, all drifted from the generated SDK model and all omitting `syntaxParser`. Platform coerces an omitted `syntaxParser` to `v1` (companion bug PLAT-6585), so dropping the field is equivalent to explicitly requesting the legacy parser: a pipeline set to v2 in the web UI ran under v1 from the CLI, with no warning anywhere.

The ticket named two mappers. There were five:

| Mapper | Used by | Was |
| --- | --- | --- |
| `ModelHelper.createLaunchRequest` | `tw launch`, `pipelines export`, `pipelines view`, `actions view` | 27 of 31 fields |
| `LaunchCmd.updateLaunchRequest` | `tw launch` (both forms) | **not in the ticket** — rebuilt the request right after `ModelHelper` had built it |
| `RelaunchCmd.exec` | `tw runs relaunch` | own list |
| `pipelines UpdateCmd.buildUpdateRequest` | `tw pipelines update` | **not in the ticket** — any single-field update reset everything omitted |
| `actions UpdateCmd.exec` | `tw actions update` | **not in the ticket** — same |

The `LaunchCmd` one mattered most: `runTowerPipeline` pipes `createLaunchRequest`'s output straight through `updateLaunchRequest`, so fixing `ModelHelper` alone would have left `tw launch` broken. The two update commands mean a v2 pipeline was also downgraded by an unrelated `tw pipelines update`.

## The fix

**`ModelHelper.createLaunchRequest`** copies the configuration by serializing the source model and reading it back as a request, instead of naming fields. Every field the models share is carried over, and fields the API gains in a future SDK release need no change here — which is the point, since these lists had already drifted independently five times over.

Going through JSON is also what makes the nullable fields correct. `syntaxParser`, `nextflowVersion` and `outputDir` are `JsonNullable`, and the fluent setters wrap their argument unconditionally:

\`\`\`java
public WorkflowLaunchRequest syntaxParser(SyntaxParserEnum syntaxParser) {
  this.syntaxParser = JsonNullable.<SyntaxParserEnum>of(syntaxParser);   // null becomes an explicit null
\`\`\`

So the obvious one-line fix (`.syntaxParser(launch.getSyntaxParser())`) would have started sending `"syntaxParser": null` for every pipeline that never set it — which Platform coerces to `v1` just the same, i.e. the same bug wearing a different hat. The round-trip keeps *undefined* undefined; `ModelHelperTest` pins that in both directions. The same trap is why the new options are applied only when passed, via `LaunchOptions.applyNullableOptions`, which documents the reason once instead of in six commands.

**The four command-level mappers** now start from the stored configuration and apply only the overrides the user asked for, so each names just the fields its own flags can change.

## The options

`--syntax-parser v1|v2`, `--nextflow-version` and `--output-dir`, on `tw pipelines add|update`, `tw actions add|update`, `tw launch` and `tw runs relaunch` — in `LaunchOptions` for the six sharing that mixin, plus `LaunchCmd`, which declares its own. Verified in the built jar: all three appear in all six commands' help.

All three are writable in the API spec (`seqera-api.yml`) — no `readOnly`, which the spec does use 39 times elsewhere, and `CreatePipelineRequest`, `UpdatePipelineRequest`, `CreateActionRequest`, `UpdateActionRequest` and `SubmitWorkflowLaunchRequest` all `$ref` the same `WorkflowLaunchRequest`. Per the spec, `nextflowVersion` must exist in the version catalog and meet the compute environment's minimum, and `outputDir` needs Nextflow ≥ 24.10 with the workflow outputs syntax; both are validated server-side, so a bad value surfaces as an API error.

No type converter for the enum: `Tower.buildCommandLine` already calls `setCaseInsensitiveEnumValuesAllowed(true)`, so `v2` resolves to `SyntaxParserEnum.V2` and picocli rejects anything else while listing the accepted values (`testAddWithInvalidSyntaxParser` pins that). I wrote a converter first and deleted it — worth knowing the setting is there before adding one.

## Fields recovered beyond the options

`launchContainer`, `pipelineSchemaId`, and on the update paths everything the partial lists omitted. (`lineage`, the fourth name in the ticket, does not exist in any SDK 1.200.0 launch model — nothing to fix.)

## Behaviour changes a reviewer should weigh

All deliberate; say the word and I will narrow any of them.

- **`tw pipelines update` and `tw actions update` no longer clear stored fields.** In `actions update` that stops `--revision`, `--profile`, `--params-file`, `--config`, `--pull-latest`, `--stub-run`, `--main-script` and `--entry-name` from resetting their stored values when omitted. This is the largest change in the PR and it is a pre-existing bug of the same family, found while adding the options to those commands.
- **`tw launch` keeps `--launch-container` unset instead of clearing the stored value**, which it wiped whenever the flag was absent.
- **`tw runs relaunch` now inherits optimization settings and head job resources** from the original run. This follows from "relaunch the same configuration", but `relaunch` has no `--disable-optimization` to opt out the way `launch` does. Easy to drop if you would rather leave relaunch alone.
- **`tw runs relaunch` explicitly clears `commitId`.** `revision` already carries the commit to run (the resume commit when resuming), so an inherited `commitId` would pin the relaunch to the original commit and silently defeat both resume and `--revision`. Matches today's payload.
- **`tw pipelines export` output gains keys** — that is the fix: re-importing an exported v2 pipeline no longer downgrades it. `pipelines view` and `actions view` serialize the same request and now show these fields too.
- **`tw launch` still clears `sessionId`, `resume` and `dateCreated`** — a new run starts a fresh session and never resumes — so its payload is otherwise unchanged.

## How to verify

\`\`\`
./gradlew test
\`\`\`

698 tests, 0 failures. Note the build needs GitHub Packages credentials for `tower-java-sdk:1.200.0` (`github.packages.user` / `github.packages.token`, or `GITHUB_USERNAME` / `GITHUB_TOKEN`).

Eleven new tests. The ten command-level ones were run against `master`'s `src/main` with this branch's tests in place, and **all ten fail there** (three unrelated tests also fail in that configuration, because a command rejecting an unknown option leaves its mocks unconsumed for the next test; they pass on the branch):

- `ModelHelperTest` — full field copy, the `WorkflowLaunchResponse` overload, and undefined vs explicit-null nullable behaviour.
- `LaunchCmdTest` — the real `POST /workflow/launch` body carries the stored `syntaxParser: v2`, `sessionId`/`resume` stay absent, and all three options override.
- `RunsCmdTest` — same for relaunch, plus no inherited `commitId`, plus the override.
- `PipelinesCmdTest` — `add` with each option, an invalid enum value rejected, `update` preserving a stored v2 with no flag, `update --syntax-parser v1` overriding, and the exported JSON.

That last one matters: the pre-existing `testExport` builds its expected output by calling `ModelHelper` itself, so it could never have caught this class of bug, which is part of why the drift went unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[COMP-2318]: https://seqera.atlassian.net/browse/COMP-2318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ